### PR TITLE
Execute registered workloads and retain validation contracts

### DIFF
--- a/code/ch10/warpgroup_specialization_demo.py
+++ b/code/ch10/warpgroup_specialization_demo.py
@@ -44,3 +44,21 @@ class WarpgroupSpecializationDemo(Tcgen05MatmulBenchmarkBase):
 def get_benchmark() -> BaseBenchmark:
     return WarpgroupSpecializationDemo()
 
+
+def main() -> None:
+    """Run the chapter demo through the shared standalone benchmark helper."""
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA required for ch10 warpgroup specialization demo")
+
+    from core.harness.benchmark_harness import benchmark_main
+
+    benchmark_main(
+        get_benchmark,
+        iterations=20,
+        warmup=5,
+        name="ch10_warpgroup_specialization_demo",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/code/ch13/dtensor_mesh_tool.py
+++ b/code/ch13/dtensor_mesh_tool.py
@@ -102,3 +102,22 @@ class DTensorMeshBenchmark(VerificationPayloadMixin, BaseBenchmark):
 
 def get_benchmark() -> BaseBenchmark:
     return DTensorMeshBenchmark()
+
+
+def main() -> None:
+    """Run the chapter tool through the shared standalone benchmark helper."""
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA required for ch13 DTensor mesh tool")
+
+    from core.harness.benchmark_harness import benchmark_main
+
+    benchmark_main(
+        get_benchmark,
+        iterations=10,
+        warmup=5,
+        name="ch13_dtensor_mesh_tool",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/code/ch13/fp8_perchannel_bench.py
+++ b/code/ch13/fp8_perchannel_bench.py
@@ -233,3 +233,22 @@ class OptimizedFP8PerChannelBenchmark(VerificationPayloadMixin, BaseBenchmark):
 def get_benchmark() -> BaseBenchmark:
     """Factory function for benchmark discovery."""
     return OptimizedFP8PerChannelBenchmark()
+
+
+def main() -> None:
+    """Run the chapter tool through the shared standalone benchmark helper."""
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA required for ch13 FP8 per-channel tool")
+
+    from core.harness.benchmark_harness import benchmark_main
+
+    benchmark_main(
+        get_benchmark,
+        iterations=50,
+        warmup=10,
+        name="ch13_fp8_perchannel_tool",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/code/ch13/fp8_perchannel_demo.py
+++ b/code/ch13/fp8_perchannel_demo.py
@@ -586,3 +586,22 @@ class FP8PerChannelDemoBenchmark(VerificationPayloadMixin, BaseBenchmark):
 def get_benchmark() -> BaseBenchmark:
     """Factory function for benchmark discovery."""
     return FP8PerChannelDemoBenchmark()
+
+
+def main() -> None:
+    """Run the chapter demo through the shared standalone benchmark helper."""
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA required for ch13 FP8 per-channel demo")
+
+    from core.harness.benchmark_harness import benchmark_main
+
+    benchmark_main(
+        get_benchmark,
+        iterations=50,
+        warmup=10,
+        name="ch13_fp8_perchannel_demo",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/code/ch15/kv_cache_management_math.py
+++ b/code/ch15/kv_cache_management_math.py
@@ -273,3 +273,22 @@ class KVCacheManagementMathBenchmark(VerificationPayloadMixin, BaseBenchmark):
 
 def get_benchmark() -> BaseBenchmark:
     return KVCacheManagementMathBenchmark()
+
+
+def main() -> None:
+    """Run the chapter tool through the shared standalone benchmark helper."""
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA required for ch15 KV-cache math tool")
+
+    from core.harness.benchmark_harness import benchmark_main
+
+    benchmark_main(
+        get_benchmark,
+        iterations=10,
+        warmup=5,
+        name="ch15_kv_cache_management_math",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/code/ch18/nvfp4_trtllm_tool.py
+++ b/code/ch18/nvfp4_trtllm_tool.py
@@ -132,3 +132,22 @@ class NVFP4TRTLLMBenchmark(VerificationPayloadMixin, BaseBenchmark):
 
 def get_benchmark() -> BaseBenchmark:
     return NVFP4TRTLLMBenchmark()
+
+
+def main() -> None:
+    """Run the chapter tool through the shared standalone benchmark helper."""
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA required for ch18 NVFP4/TRT-LLM tool")
+
+    from core.harness.benchmark_harness import benchmark_main
+
+    benchmark_main(
+        get_benchmark,
+        iterations=10,
+        warmup=5,
+        name="ch18_nvfp4_trtllm_tool",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/code/ch19/fp8_calibration_free_tool.py
+++ b/code/ch19/fp8_calibration_free_tool.py
@@ -398,3 +398,22 @@ class _FP8CalibrationFreeBenchmark(VerificationPayloadMixin, BaseBenchmark):
 
 def get_benchmark() -> BaseBenchmark:
     return _FP8CalibrationFreeBenchmark()
+
+
+def main() -> None:
+    """Run the chapter tool through the shared standalone benchmark helper."""
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA required for ch19 calibration-free FP8 tool")
+
+    from core.harness.benchmark_harness import benchmark_main
+
+    benchmark_main(
+        get_benchmark,
+        iterations=10,
+        warmup=5,
+        name="ch19_fp8_calibration_free_tool",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/code/ch20/kernel_verification_tool.py
+++ b/code/ch20/kernel_verification_tool.py
@@ -353,3 +353,22 @@ class BaselineKernelVerificationBenchmark(VerificationPayloadMixin, BaseBenchmar
 def get_benchmark() -> BaseBenchmark:
     """Factory function for harness discovery."""
     return BaselineKernelVerificationBenchmark()
+
+
+def main() -> None:
+    """Run the chapter tool through the shared standalone benchmark helper."""
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA required for ch20 kernel verification tool")
+
+    from core.harness.benchmark_harness import benchmark_main
+
+    benchmark_main(
+        get_benchmark,
+        iterations=10,
+        warmup=5,
+        name="ch20_kernel_verification_tool",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/code/ch20/proofwright_verify_tool.py
+++ b/code/ch20/proofwright_verify_tool.py
@@ -571,3 +571,22 @@ class OptimizedProofwrightBenchmark(VerificationPayloadMixin, BaseBenchmark):
 def get_benchmark() -> BaseBenchmark:
     """Factory function for harness discovery."""
     return OptimizedProofwrightBenchmark()
+
+
+def main() -> None:
+    """Run the chapter tool through the shared standalone benchmark helper."""
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA required for ch20 ProofWright verification tool")
+
+    from core.harness.benchmark_harness import benchmark_main
+
+    benchmark_main(
+        get_benchmark,
+        iterations=10,
+        warmup=5,
+        name="ch20_proofwright_verify_tool",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/code/core/benchmark/contract.py
+++ b/code/core/benchmark/contract.py
@@ -24,6 +24,19 @@ _BASE_BENCHMARK_QUALNAME = "core.harness.benchmark_harness.BaseBenchmark"
 _VERIFICATION_PAYLOAD_MIXIN_QUALNAME = "core.benchmark.verification_mixin.VerificationPayloadMixin"
 
 
+@lru_cache(maxsize=1)
+def _registered_standalone_paths() -> frozenset[Path]:
+    """Read core registry metadata without importing any workload modules."""
+    from core.demos.demos_commands import DEMOS
+    from core.tools.tools_commands import TOOLS
+
+    return frozenset(
+        spec.script_path.resolve()
+        for registry in (DEMOS, TOOLS)
+        for spec in registry.values()
+    )
+
+
 @dataclass(frozen=True)
 class _ImportRef:
     module_name: Optional[str]
@@ -819,7 +832,12 @@ def check_benchmark_file_ast(file_path: Path) -> Tuple[bool, List[str], List[str
 
         if not has_get_benchmark and not benchmark_class_refs:
             errors.append("No get_benchmark() function or benchmark class found")
-        elif any(_is_main_guard(node) for node in tree.body) or _invokes_main_guard_helper(tree):
+        elif (
+            any(_is_main_guard(node) for node in tree.body) or _invokes_main_guard_helper(tree)
+        ) and (
+            file_path.name.startswith(("baseline_", "optimized_"))
+            or file_path.resolve() not in _registered_standalone_paths()
+        ):
             errors.append(
                 "Benchmark modules must not define __main__ blocks; run them via compare.py or cli.aisp bench run"
             )

--- a/code/core/benchmark/distributed_work_contract.py
+++ b/code/core/benchmark/distributed_work_contract.py
@@ -1,0 +1,426 @@
+"""Observed completion receipts for distributed measured work.
+
+The topology fields in :mod:`core.benchmark.verification` establish declared
+baseline/optimized parity.  They do not prove which collective algorithm a
+runtime selected.  This module covers a narrower runtime fact: every declared
+rank observed its registered asynchronous collectives and final barrier finish
+before that rank closed its timed region.
+
+Runtime algorithm selection (for example NCCL ring versus tree) still requires
+profiler-backed evidence.  A valid receipt from this module must not be treated
+as that proof.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from core.benchmark.verification import DistributedTopology
+
+BARRIER_BEFORE_TIMED_CLOSE = "barrier_before_timed_close"
+WAIT_FOR_ASYNC_BEFORE_TIMED_CLOSE = "wait_for_async_before_timed_close"
+DECLARED_ALGORITHM_EVIDENCE = "declared_only"
+
+
+@dataclass(frozen=True)
+class DistributedRankWorkReceipt:
+    """Per-rank ordering evidence for one measured distributed region."""
+
+    rank: int
+    world_size: int
+    backend: str
+    collective_type: str
+    declared_collective_algorithm: str
+    gradient_bucket_bytes: int
+    barrier_policy: str
+    async_completion_policy: str
+    timed_region_start_ns: int
+    collective_launch_ns: tuple[int, ...]
+    collective_completion_ns: tuple[int, ...]
+    barrier_entry_ns: int | None
+    barrier_completion_ns: int | None
+    timed_region_close_ns: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize a receipt without filling missing evidence."""
+
+        return {
+            "rank": self.rank,
+            "world_size": self.world_size,
+            "backend": self.backend,
+            "collective_type": self.collective_type,
+            "declared_collective_algorithm": self.declared_collective_algorithm,
+            "gradient_bucket_bytes": self.gradient_bucket_bytes,
+            "barrier_policy": self.barrier_policy,
+            "async_completion_policy": self.async_completion_policy,
+            "timed_region_start_ns": self.timed_region_start_ns,
+            "collective_launch_ns": list(self.collective_launch_ns),
+            "collective_completion_ns": list(self.collective_completion_ns),
+            "barrier_entry_ns": self.barrier_entry_ns,
+            "barrier_completion_ns": self.barrier_completion_ns,
+            "timed_region_close_ns": self.timed_region_close_ns,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DistributedRankWorkReceipt:
+        """Deserialize a receipt, rejecting absent evidence fields."""
+
+        required = {
+            "rank",
+            "world_size",
+            "backend",
+            "collective_type",
+            "declared_collective_algorithm",
+            "gradient_bucket_bytes",
+            "barrier_policy",
+            "async_completion_policy",
+            "timed_region_start_ns",
+            "collective_launch_ns",
+            "collective_completion_ns",
+            "barrier_entry_ns",
+            "barrier_completion_ns",
+            "timed_region_close_ns",
+        }
+        missing = sorted(required - set(data))
+        if missing:
+            raise ValueError(
+                "Distributed rank receipt missing required fields: " + ", ".join(missing)
+            )
+        launches = data["collective_launch_ns"]
+        completions = data["collective_completion_ns"]
+        if not isinstance(launches, list | tuple):
+            raise TypeError("collective_launch_ns must be a list or tuple")
+        if not isinstance(completions, list | tuple):
+            raise TypeError("collective_completion_ns must be a list or tuple")
+        return cls(
+            rank=data["rank"],
+            world_size=data["world_size"],
+            backend=data["backend"],
+            collective_type=data["collective_type"],
+            declared_collective_algorithm=data["declared_collective_algorithm"],
+            gradient_bucket_bytes=data["gradient_bucket_bytes"],
+            barrier_policy=data["barrier_policy"],
+            async_completion_policy=data["async_completion_policy"],
+            timed_region_start_ns=data["timed_region_start_ns"],
+            collective_launch_ns=tuple(launches),
+            collective_completion_ns=tuple(completions),
+            barrier_entry_ns=data["barrier_entry_ns"],
+            barrier_completion_ns=data["barrier_completion_ns"],
+            timed_region_close_ns=data["timed_region_close_ns"],
+        )
+
+
+@dataclass(frozen=True)
+class DistributedWorkValidation:
+    """Validation result with an explicit algorithm-evidence boundary."""
+
+    passed: bool
+    errors: tuple[str, ...]
+    backend: str | None
+    collective_algorithm_evidence: str = DECLARED_ALGORITHM_EVIDENCE
+
+    def raise_for_failure(self) -> None:
+        """Raise one bounded diagnostic when any receipt is invalid."""
+
+        if not self.passed:
+            raise RuntimeError("DISTRIBUTED WORK RECEIPT INVALID: " + " | ".join(self.errors))
+
+
+def _is_timestamp(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _declared_contract_errors(topology: DistributedTopology) -> list[str]:
+    errors: list[str] = []
+    if topology.world_size <= 1:
+        errors.append("world_size must be greater than one")
+    if len(topology.ranks) != topology.world_size:
+        errors.append(
+            f"ranks must contain world_size entries: {len(topology.ranks)} vs {topology.world_size}"
+        )
+    if len(set(topology.ranks)) != len(topology.ranks):
+        errors.append("ranks must be unique")
+    if not isinstance(topology.collective_type, str) or not topology.collective_type.strip():
+        errors.append("collective_type is required")
+    if (
+        not isinstance(topology.collective_algorithm, str)
+        or not topology.collective_algorithm.strip()
+    ):
+        errors.append("collective_algorithm is required")
+    if (
+        isinstance(topology.gradient_bucket_bytes, bool)
+        or not isinstance(topology.gradient_bucket_bytes, int)
+        or topology.gradient_bucket_bytes <= 0
+    ):
+        errors.append("gradient_bucket_bytes must be a positive integer")
+    if topology.barrier_policy != BARRIER_BEFORE_TIMED_CLOSE:
+        errors.append(f"barrier_policy must be {BARRIER_BEFORE_TIMED_CLOSE!r}")
+    if topology.async_completion_policy != WAIT_FOR_ASYNC_BEFORE_TIMED_CLOSE:
+        errors.append(f"async_completion_policy must be {WAIT_FOR_ASYNC_BEFORE_TIMED_CLOSE!r}")
+    return errors
+
+
+def validate_distributed_work_receipts(
+    topology: DistributedTopology,
+    receipts: Sequence[DistributedRankWorkReceipt],
+    *,
+    expected_backend: str | None = None,
+) -> DistributedWorkValidation:
+    """Validate rank coverage and local event ordering for a measured region.
+
+    Monotonic timestamps are compared only within a rank.  They are not assumed
+    to be synchronized across hosts.
+    """
+
+    errors = _declared_contract_errors(topology)
+    by_rank: dict[int, DistributedRankWorkReceipt] = {}
+    for receipt in receipts:
+        if not isinstance(receipt, DistributedRankWorkReceipt):
+            errors.append("receipt entries must be DistributedRankWorkReceipt instances")
+            continue
+        if receipt.rank in by_rank:
+            errors.append(f"duplicate receipt for rank {receipt.rank}")
+            continue
+        by_rank[receipt.rank] = receipt
+
+    expected_ranks = set(topology.ranks)
+    observed_ranks = set(by_rank)
+    missing = sorted(expected_ranks - observed_ranks)
+    extra = sorted(observed_ranks - expected_ranks)
+    if missing:
+        errors.append(f"missing receipts from ranks {missing}")
+    if extra:
+        errors.append(f"unexpected receipts from ranks {extra}")
+
+    observed_backends = {
+        receipt.backend
+        for receipt in by_rank.values()
+        if isinstance(receipt.backend, str) and receipt.backend.strip()
+    }
+    backend: str | None = None
+    if len(observed_backends) == 1:
+        backend = next(iter(observed_backends))
+    elif observed_backends:
+        errors.append(f"backend mismatch across ranks: {sorted(observed_backends)}")
+    if expected_backend is not None and observed_backends != {expected_backend}:
+        errors.append(
+            f"expected backend {expected_backend!r}, observed {sorted(observed_backends)}"
+        )
+
+    for rank in sorted(expected_ranks & observed_ranks):
+        receipt = by_rank[rank]
+        prefix = f"rank {rank}: "
+        if not isinstance(receipt.backend, str) or not receipt.backend.strip():
+            errors.append(f"{prefix}backend must be a non-empty string")
+        metadata_pairs = (
+            ("world_size", receipt.world_size, topology.world_size),
+            ("collective_type", receipt.collective_type, topology.collective_type),
+            (
+                "declared_collective_algorithm",
+                receipt.declared_collective_algorithm,
+                topology.collective_algorithm,
+            ),
+            (
+                "gradient_bucket_bytes",
+                receipt.gradient_bucket_bytes,
+                topology.gradient_bucket_bytes,
+            ),
+            ("barrier_policy", receipt.barrier_policy, topology.barrier_policy),
+            (
+                "async_completion_policy",
+                receipt.async_completion_policy,
+                topology.async_completion_policy,
+            ),
+        )
+        for field_name, observed, declared in metadata_pairs:
+            if observed != declared:
+                errors.append(f"{prefix}{field_name} mismatch: {observed!r} vs {declared!r}")
+
+        timestamps = (
+            ("timed_region_start_ns", receipt.timed_region_start_ns),
+            ("timed_region_close_ns", receipt.timed_region_close_ns),
+            ("barrier_entry_ns", receipt.barrier_entry_ns),
+            ("barrier_completion_ns", receipt.barrier_completion_ns),
+        )
+        for field_name, value in timestamps:
+            if not _is_timestamp(value):
+                errors.append(f"{prefix}{field_name} must be a non-negative integer")
+
+        if not receipt.collective_launch_ns:
+            errors.append(f"{prefix}no asynchronous collective launch was recorded")
+        if len(receipt.collective_completion_ns) != len(receipt.collective_launch_ns):
+            errors.append(
+                f"{prefix}asynchronous collectives incomplete: "
+                f"{len(receipt.collective_completion_ns)} of "
+                f"{len(receipt.collective_launch_ns)} completed"
+            )
+        for field_name, values in (
+            ("collective_launch_ns", receipt.collective_launch_ns),
+            ("collective_completion_ns", receipt.collective_completion_ns),
+        ):
+            if any(not _is_timestamp(value) for value in values):
+                errors.append(f"{prefix}{field_name} entries must be non-negative integers")
+
+        if all(
+            _is_timestamp(value)
+            for value in (
+                receipt.timed_region_start_ns,
+                receipt.timed_region_close_ns,
+                receipt.barrier_entry_ns,
+                receipt.barrier_completion_ns,
+            )
+        ):
+            start = receipt.timed_region_start_ns
+            close = receipt.timed_region_close_ns
+            barrier_entry = receipt.barrier_entry_ns
+            barrier_complete = receipt.barrier_completion_ns
+            if start > close:
+                errors.append(f"{prefix}timed region closes before it starts")
+            if not (start <= barrier_entry <= barrier_complete <= close):
+                errors.append(f"{prefix}barrier must enter and complete before timed-region close")
+            for index, (launch, complete) in enumerate(
+                zip(
+                    receipt.collective_launch_ns,
+                    receipt.collective_completion_ns,
+                    strict=False,
+                )
+            ):
+                if (
+                    _is_timestamp(launch)
+                    and _is_timestamp(complete)
+                    and not (start <= launch <= complete <= barrier_entry)
+                ):
+                    errors.append(
+                        f"{prefix}collective {index} was not observed complete "
+                        "before the final barrier"
+                    )
+
+    return DistributedWorkValidation(
+        passed=not errors,
+        errors=tuple(errors),
+        backend=backend,
+    )
+
+
+class DistributedWorkRecorder:
+    """Record actual ``Work.wait`` and barrier returns inside a timed region."""
+
+    def __init__(
+        self,
+        topology: DistributedTopology,
+        *,
+        rank: int,
+        backend: str,
+    ) -> None:
+        contract_errors = _declared_contract_errors(topology)
+        if contract_errors:
+            raise ValueError(
+                "Invalid declared distributed work contract: " + " | ".join(contract_errors)
+            )
+        if rank not in topology.ranks:
+            raise ValueError(f"rank {rank} is not declared in topology ranks {topology.ranks}")
+        if not isinstance(backend, str) or not backend.strip():
+            raise ValueError("backend must be a non-empty string")
+
+        self._topology = topology
+        self._rank = rank
+        self._backend = backend
+        self._timed_region_start_ns: int | None = None
+        self._timed_region_close_ns: int | None = None
+        self._work_handles: list[Any] = []
+        self._collective_launch_ns: list[int] = []
+        self._collective_completion_ns: list[int] = []
+        self._barrier_entry_ns: int | None = None
+        self._barrier_completion_ns: int | None = None
+
+    def begin_timed_region(self) -> None:
+        if self._timed_region_start_ns is not None:
+            raise RuntimeError("timed region has already started")
+        self._timed_region_start_ns = time.monotonic_ns()
+
+    def record_async_collective(self, work: Any) -> None:
+        if self._timed_region_start_ns is None:
+            raise RuntimeError("begin_timed_region() must be called first")
+        if self._timed_region_close_ns is not None:
+            raise RuntimeError("cannot record a collective after timed-region close")
+        if self._barrier_entry_ns is not None:
+            raise RuntimeError("cannot record a collective after the final barrier")
+        if not callable(getattr(work, "wait", None)):
+            raise TypeError("async collective work must expose a callable wait()")
+        self._work_handles.append(work)
+        self._collective_launch_ns.append(time.monotonic_ns())
+
+    def wait_for_async_collectives(self) -> None:
+        if not self._work_handles:
+            raise RuntimeError("no asynchronous collective work was recorded")
+        for work in self._work_handles[len(self._collective_completion_ns) :]:
+            work.wait()
+            self._collective_completion_ns.append(time.monotonic_ns())
+
+    def run_final_barrier(self, barrier: Callable[[], Any]) -> None:
+        if self._timed_region_start_ns is None:
+            raise RuntimeError("begin_timed_region() must be called first")
+        if self._timed_region_close_ns is not None:
+            raise RuntimeError("cannot run final barrier after timed-region close")
+        if not self._work_handles:
+            raise RuntimeError("no asynchronous collective work was recorded")
+        if not callable(barrier):
+            raise TypeError("barrier must be callable")
+        if len(self._collective_completion_ns) != len(self._work_handles):
+            raise RuntimeError(
+                "all registered asynchronous collectives must complete before the final barrier"
+            )
+        if self._barrier_entry_ns is not None:
+            raise RuntimeError("final barrier has already run")
+        self._barrier_entry_ns = time.monotonic_ns()
+        barrier_result = barrier()
+        if callable(getattr(barrier_result, "wait", None)):
+            raise RuntimeError(
+                "final barrier returned asynchronous work; pass a synchronous barrier callable"
+            )
+        self._barrier_completion_ns = time.monotonic_ns()
+
+    def close_timed_region(self) -> DistributedRankWorkReceipt:
+        if self._timed_region_start_ns is None:
+            raise RuntimeError("begin_timed_region() must be called first")
+        if self._timed_region_close_ns is not None:
+            raise RuntimeError("timed region has already closed")
+        if not self._work_handles:
+            raise RuntimeError("no asynchronous collective work was recorded")
+        if len(self._collective_completion_ns) != len(self._work_handles):
+            raise RuntimeError(
+                "cannot close timed region before all asynchronous collectives complete"
+            )
+        if self._barrier_completion_ns is None:
+            raise RuntimeError("cannot close timed region before the final barrier completes")
+        self._timed_region_close_ns = time.monotonic_ns()
+        return DistributedRankWorkReceipt(
+            rank=self._rank,
+            world_size=self._topology.world_size,
+            backend=self._backend,
+            collective_type=self._topology.collective_type or "",
+            declared_collective_algorithm=self._topology.collective_algorithm or "",
+            gradient_bucket_bytes=self._topology.gradient_bucket_bytes or 0,
+            barrier_policy=self._topology.barrier_policy or "",
+            async_completion_policy=self._topology.async_completion_policy or "",
+            timed_region_start_ns=self._timed_region_start_ns,
+            collective_launch_ns=tuple(self._collective_launch_ns),
+            collective_completion_ns=tuple(self._collective_completion_ns),
+            barrier_entry_ns=self._barrier_entry_ns,
+            barrier_completion_ns=self._barrier_completion_ns,
+            timed_region_close_ns=self._timed_region_close_ns,
+        )
+
+
+__all__ = [
+    "BARRIER_BEFORE_TIMED_CLOSE",
+    "DECLARED_ALGORITHM_EVIDENCE",
+    "DistributedRankWorkReceipt",
+    "DistributedWorkRecorder",
+    "DistributedWorkValidation",
+    "WAIT_FOR_ASYNC_BEFORE_TIMED_CLOSE",
+    "validate_distributed_work_receipts",
+]

--- a/code/core/benchmark/evaluation_provenance.py
+++ b/code/core/benchmark/evaluation_provenance.py
@@ -1,0 +1,660 @@
+"""Explicit provenance contract for workloads that make evaluation claims.
+
+Kernel and systems microbenchmarks do not opt in to this contract. Evaluation
+workloads provide auditable sample identifiers, split policy, evaluator settings,
+feature lineage, and protected source files through :class:`EvaluationContract`.
+The serialized provenance retains digests and counts rather than raw sample IDs.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import stat
+from typing import Any, Literal, Mapping, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+SCHEMA_VERSION = "1.0"
+_SHA256_HEX_LENGTH = 64
+_SPLIT_ORDER = ("train", "test", "holdout")
+
+
+class DatasetDeclaration(BaseModel):
+    """Identity declared by an evaluation workload for its dataset."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str
+    version: str
+    content_sha256: str
+
+
+class TemporalSplitBoundary(BaseModel):
+    """Half-open time interval assigned to one named data split."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    split: str
+    start: datetime
+    end: datetime
+
+
+class EvaluatorDeclaration(BaseModel):
+    """Evaluator identity and thresholds fixed before evaluation starts."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str
+    version: str
+    thresholds: Mapping[str, float]
+
+
+class FeatureLineage(BaseModel):
+    """Workload-declared source fields and transforms for one feature."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    feature: str
+    source_fields: tuple[str, ...]
+    transforms: tuple[str, ...] = ()
+
+
+class EvaluationContract(BaseModel):
+    """Opt-in declaration supplied only by workloads making evaluation claims."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    kind: Literal["evaluation"] = "evaluation"
+    dataset: DatasetDeclaration
+    sample_ids_by_split: Mapping[str, tuple[str, ...]]
+    required_holdout: bool = True
+    split_strategy: Literal["explicit_ids", "temporal"] = "explicit_ids"
+    temporal_boundaries: tuple[TemporalSplitBoundary, ...] = ()
+    evaluator: EvaluatorDeclaration
+    feature_lineage: tuple[FeatureLineage, ...]
+    label_fields: tuple[str, ...] = ()
+    protected_sources: tuple[Path, ...]
+
+
+class EvaluationFailure(BaseModel):
+    """Machine-readable rejection or limitation discovered by the contract."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    code: str
+    phase: Literal["start", "finalize"]
+    message: str
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class SplitIdentity(BaseModel):
+    """Privacy-preserving identity for a declared sample split."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    split: str
+    sample_count: int
+    unique_sample_count: int
+    sample_ids_sha256: str
+
+
+class ProtectedSourceIdentity(BaseModel):
+    """Content identity for a regular, non-symlink protected source file."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    path: str
+    bytes: int
+    sha256: str
+
+
+class EvaluationProvenanceError(RuntimeError):
+    """Raised when an evaluation provenance receipt contains failures."""
+
+    def __init__(self, failures: tuple[EvaluationFailure, ...]):
+        self.failures = failures
+        codes = ", ".join(failure.code for failure in failures)
+        super().__init__(f"evaluation provenance rejected: {codes}")
+
+
+class EvaluationProvenance(BaseModel):
+    """Serializable start/finalize receipt for an evaluation contract."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    declared: Literal[True] = True
+    status: Literal["PENDING", "PASS", "FAIL"]
+    dataset: DatasetDeclaration
+    splits: tuple[SplitIdentity, ...]
+    required_holdout: bool
+    split_strategy: Literal["explicit_ids", "temporal"]
+    temporal_boundaries: tuple[TemporalSplitBoundary, ...]
+    evaluator: EvaluatorDeclaration
+    evaluator_thresholds_sha256: str
+    feature_lineage: tuple[FeatureLineage, ...]
+    feature_lineage_sha256: str
+    label_fields: tuple[str, ...]
+    protected_source_paths: tuple[str, ...]
+    protected_sources_before: tuple[ProtectedSourceIdentity, ...]
+    protected_sources_after: tuple[ProtectedSourceIdentity, ...] = ()
+    contract_sha256: str
+    started_at: datetime
+    finalized_at: Optional[datetime] = None
+    failures: list[EvaluationFailure] = Field(default_factory=list)
+    limitations: tuple[str, ...] = (
+        "feature_lineage_is_workload_declared_not_independently_inferred",
+        "content_hashes_do_not_detect_semantic_dataset_contamination",
+        "before_after_source_hashes_do_not_detect_transient_restored_mutation",
+    )
+    schemaVersion: str = SCHEMA_VERSION
+
+    def raise_for_failures(self) -> None:
+        """Fail the caller without discarding the structured receipt."""
+
+        if self.failures:
+            raise EvaluationProvenanceError(tuple(self.failures))
+
+
+def _is_sha256(value: str) -> bool:
+    return len(value) == _SHA256_HEX_LENGTH and all(
+        character in "0123456789abcdef" for character in value
+    )
+
+
+def _canonical_digest(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _contract_digest(contract: EvaluationContract) -> str:
+    return _canonical_digest(contract.model_dump(mode="json"))
+
+
+def _sample_id_digest(sample_ids: tuple[str, ...]) -> str:
+    digest = hashlib.sha256()
+    for sample_id in sorted(sample_ids):
+        encoded = sample_id.encode("utf-8")
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
+    return digest.hexdigest()
+
+
+def _failure(
+    code: str,
+    phase: Literal["start", "finalize"],
+    message: str,
+    **details: Any,
+) -> EvaluationFailure:
+    return EvaluationFailure(
+        code=code,
+        phase=phase,
+        message=message,
+        details=details,
+    )
+
+
+def _validate_declaration(
+    contract: EvaluationContract,
+    *,
+    phase: Literal["start", "finalize"],
+) -> list[EvaluationFailure]:
+    failures: list[EvaluationFailure] = []
+    dataset = contract.dataset
+    if not dataset.name.strip() or not dataset.version.strip():
+        failures.append(
+            _failure(
+                "dataset_identity_missing",
+                phase,
+                "dataset name and version must be non-empty",
+            )
+        )
+    if not _is_sha256(dataset.content_sha256):
+        failures.append(
+            _failure(
+                "dataset_content_digest_invalid",
+                phase,
+                "dataset content_sha256 must be lowercase SHA-256",
+            )
+        )
+
+    splits = {
+        str(name): tuple(sample_ids) for name, sample_ids in contract.sample_ids_by_split.items()
+    }
+    required_splits = ["train", "test"]
+    if contract.required_holdout:
+        required_splits.append("holdout")
+    for name in required_splits:
+        if not splits.get(name):
+            code = "required_holdout_missing" if name == "holdout" else "required_split_missing"
+            failures.append(
+                _failure(
+                    code,
+                    phase,
+                    f"required evaluation split is missing or empty: {name}",
+                    split=name,
+                )
+            )
+
+    for name, sample_ids in sorted(splits.items()):
+        invalid_count = sum(
+            not isinstance(sample_id, str) or not sample_id.strip() for sample_id in sample_ids
+        )
+        if invalid_count:
+            failures.append(
+                _failure(
+                    "sample_id_invalid",
+                    phase,
+                    "sample IDs must be non-empty strings",
+                    split=name,
+                    invalid_count=invalid_count,
+                )
+            )
+        duplicate_count = len(sample_ids) - len(set(sample_ids))
+        if duplicate_count:
+            failures.append(
+                _failure(
+                    "duplicate_sample_id",
+                    phase,
+                    "sample IDs must be unique within each split",
+                    split=name,
+                    duplicate_count=duplicate_count,
+                )
+            )
+
+    split_names = sorted(splits)
+    for index, left_name in enumerate(split_names):
+        left_ids = set(splits[left_name])
+        for right_name in split_names[index + 1 :]:
+            overlap = left_ids.intersection(splits[right_name])
+            if overlap:
+                failures.append(
+                    _failure(
+                        "sample_id_overlap",
+                        phase,
+                        "sample IDs overlap across evaluation splits",
+                        left_split=left_name,
+                        right_split=right_name,
+                        overlap_count=len(overlap),
+                        overlap_ids_sha256=_sample_id_digest(tuple(overlap)),
+                    )
+                )
+
+    boundaries: dict[str, TemporalSplitBoundary] = {}
+    for boundary in contract.temporal_boundaries:
+        if boundary.split in boundaries:
+            failures.append(
+                _failure(
+                    "temporal_boundary_duplicate",
+                    phase,
+                    "each split may declare only one temporal boundary",
+                    split=boundary.split,
+                )
+            )
+            continue
+        boundaries[boundary.split] = boundary
+        if boundary.start.tzinfo is None or boundary.end.tzinfo is None:
+            failures.append(
+                _failure(
+                    "temporal_boundary_timezone_missing",
+                    phase,
+                    "temporal boundaries must be timezone-aware",
+                    split=boundary.split,
+                )
+            )
+        elif boundary.start >= boundary.end:
+            failures.append(
+                _failure(
+                    "temporal_boundary_invalid",
+                    phase,
+                    "temporal split start must precede its end",
+                    split=boundary.split,
+                )
+            )
+    if contract.split_strategy == "temporal":
+        for name in required_splits:
+            if name not in boundaries:
+                failures.append(
+                    _failure(
+                        "temporal_boundary_missing",
+                        phase,
+                        "temporal strategy requires a boundary for every required split",
+                        split=name,
+                    )
+                )
+        available = [name for name in _SPLIT_ORDER if name in boundaries]
+        for left_name, right_name in zip(available, available[1:]):
+            left = boundaries[left_name]
+            right = boundaries[right_name]
+            if (
+                left.end.tzinfo is not None
+                and right.start.tzinfo is not None
+                and left.end > right.start
+            ):
+                failures.append(
+                    _failure(
+                        "temporal_split_overlap",
+                        phase,
+                        "temporal split boundaries overlap",
+                        left_split=left_name,
+                        right_split=right_name,
+                    )
+                )
+
+    thresholds = contract.evaluator.thresholds
+    if not contract.evaluator.name.strip() or not contract.evaluator.version.strip():
+        failures.append(
+            _failure(
+                "evaluator_identity_missing",
+                phase,
+                "evaluator name and version must be non-empty",
+            )
+        )
+    if not thresholds:
+        failures.append(
+            _failure(
+                "evaluator_thresholds_missing",
+                phase,
+                "evaluation workloads must fix evaluator thresholds before timing",
+            )
+        )
+    for name, value in thresholds.items():
+        if not str(name).strip() or isinstance(value, bool) or not math.isfinite(float(value)):
+            failures.append(
+                _failure(
+                    "evaluator_threshold_invalid",
+                    phase,
+                    "evaluator threshold names and numeric values must be finite",
+                    threshold=str(name),
+                )
+            )
+
+    if not contract.feature_lineage:
+        failures.append(
+            _failure(
+                "feature_lineage_missing",
+                phase,
+                "evaluation workloads must declare feature lineage",
+            )
+        )
+    feature_names: set[str] = set()
+    label_fields = set(contract.label_fields)
+    for lineage in contract.feature_lineage:
+        if not lineage.feature.strip() or not lineage.source_fields:
+            failures.append(
+                _failure(
+                    "feature_lineage_invalid",
+                    phase,
+                    "each feature needs a name and at least one declared source field",
+                    feature=lineage.feature,
+                )
+            )
+        if lineage.feature in feature_names:
+            failures.append(
+                _failure(
+                    "feature_lineage_duplicate",
+                    phase,
+                    "feature lineage names must be unique",
+                    feature=lineage.feature,
+                )
+            )
+        feature_names.add(lineage.feature)
+        label_overlap = sorted(set(lineage.source_fields).intersection(label_fields))
+        if label_overlap:
+            failures.append(
+                _failure(
+                    "feature_label_lineage_overlap",
+                    phase,
+                    "declared feature sources include a declared label field",
+                    feature=lineage.feature,
+                    label_fields=label_overlap,
+                )
+            )
+
+    if not contract.protected_sources:
+        failures.append(
+            _failure(
+                "protected_sources_missing",
+                phase,
+                "evaluation workloads must declare protected test sources",
+            )
+        )
+    return failures
+
+
+def _capture_source_identity(path: Path) -> ProtectedSourceIdentity:
+    declared = path.expanduser()
+    if not declared.is_absolute():
+        raise ValueError("protected source path must be absolute")
+    before = declared.lstat()
+    if stat.S_ISLNK(before.st_mode) or not stat.S_ISREG(before.st_mode):
+        raise ValueError("protected source must be a regular non-symlink file")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(declared, flags)
+    digest = hashlib.sha256()
+    try:
+        opened = os.fstat(descriptor)
+        before_key = (
+            before.st_dev,
+            before.st_ino,
+            before.st_mode,
+            before.st_size,
+            before.st_mtime_ns,
+            before.st_ctime_ns,
+        )
+        opened_key = (
+            opened.st_dev,
+            opened.st_ino,
+            opened.st_mode,
+            opened.st_size,
+            opened.st_mtime_ns,
+            opened.st_ctime_ns,
+        )
+        if before_key != opened_key:
+            raise ValueError("protected source changed while opening")
+        while chunk := os.read(descriptor, 1024 * 1024):
+            digest.update(chunk)
+        after = os.fstat(descriptor)
+        after_key = (
+            after.st_dev,
+            after.st_ino,
+            after.st_mode,
+            after.st_size,
+            after.st_mtime_ns,
+            after.st_ctime_ns,
+        )
+        if opened_key != after_key:
+            raise ValueError("protected source changed while hashing")
+    finally:
+        os.close(descriptor)
+    return ProtectedSourceIdentity(
+        path=str(declared),
+        bytes=before.st_size,
+        sha256=digest.hexdigest(),
+    )
+
+
+def _capture_sources(
+    paths: tuple[Path, ...],
+    *,
+    phase: Literal["start", "finalize"],
+) -> tuple[tuple[ProtectedSourceIdentity, ...], list[EvaluationFailure]]:
+    identities: list[ProtectedSourceIdentity] = []
+    failures: list[EvaluationFailure] = []
+    seen: set[str] = set()
+    for path in paths:
+        declared = str(path.expanduser())
+        if declared in seen:
+            failures.append(
+                _failure(
+                    "protected_source_duplicate",
+                    phase,
+                    "protected source paths must be unique",
+                    path=declared,
+                )
+            )
+            continue
+        seen.add(declared)
+        try:
+            identities.append(_capture_source_identity(path))
+        except (OSError, ValueError) as exc:
+            failures.append(
+                _failure(
+                    "protected_source_unavailable",
+                    phase,
+                    "protected source identity could not be captured",
+                    path=declared,
+                    error=f"{type(exc).__name__}: {exc}",
+                )
+            )
+    return tuple(identities), failures
+
+
+def start_evaluation(contract: EvaluationContract) -> EvaluationProvenance:
+    """Validate and snapshot an explicit evaluation contract before setup/timing."""
+
+    failures = _validate_declaration(contract, phase="start")
+    sources_before, source_failures = _capture_sources(
+        tuple(contract.protected_sources),
+        phase="start",
+    )
+    failures.extend(source_failures)
+    splits = tuple(
+        SplitIdentity(
+            split=name,
+            sample_count=len(sample_ids),
+            unique_sample_count=len(set(sample_ids)),
+            sample_ids_sha256=_sample_id_digest(tuple(sample_ids)),
+        )
+        for name, sample_ids in sorted(contract.sample_ids_by_split.items())
+    )
+    evaluator = contract.evaluator.model_copy(deep=True)
+    feature_lineage = tuple(item.model_copy(deep=True) for item in contract.feature_lineage)
+    return EvaluationProvenance(
+        status="FAIL" if failures else "PENDING",
+        dataset=contract.dataset.model_copy(deep=True),
+        splits=splits,
+        required_holdout=contract.required_holdout,
+        split_strategy=contract.split_strategy,
+        temporal_boundaries=tuple(
+            boundary.model_copy(deep=True) for boundary in contract.temporal_boundaries
+        ),
+        evaluator=evaluator,
+        evaluator_thresholds_sha256=_canonical_digest(dict(evaluator.thresholds)),
+        feature_lineage=feature_lineage,
+        feature_lineage_sha256=_canonical_digest(
+            [item.model_dump(mode="json") for item in feature_lineage]
+        ),
+        label_fields=tuple(contract.label_fields),
+        protected_source_paths=tuple(str(path.expanduser()) for path in contract.protected_sources),
+        protected_sources_before=sources_before,
+        contract_sha256=_contract_digest(contract),
+        started_at=datetime.now(timezone.utc),
+        failures=failures,
+    )
+
+
+def finalize_evaluation(
+    provenance: EvaluationProvenance,
+    current_contract: Optional[EvaluationContract],
+) -> EvaluationProvenance:
+    """Capture post-run identity and reject declaration or threshold drift."""
+
+    result = provenance.model_copy(deep=True)
+    if result.finalized_at is not None:
+        result.failures.append(
+            _failure(
+                "evaluation_already_finalized",
+                "finalize",
+                "evaluation provenance may be finalized only once",
+            )
+        )
+        result.status = "FAIL"
+        return result
+
+    if current_contract is None:
+        result.failures.append(
+            _failure(
+                "evaluation_contract_missing_at_finalize",
+                "finalize",
+                "the opt-in evaluation contract was unavailable after execution",
+            )
+        )
+    else:
+        result.failures.extend(_validate_declaration(current_contract, phase="finalize"))
+        current_thresholds = dict(current_contract.evaluator.thresholds)
+        if current_thresholds != dict(result.evaluator.thresholds):
+            result.failures.append(
+                _failure(
+                    "evaluator_threshold_drift",
+                    "finalize",
+                    "evaluator thresholds changed after the pre-run snapshot",
+                    before_sha256=result.evaluator_thresholds_sha256,
+                    after_sha256=_canonical_digest(current_thresholds),
+                )
+            )
+        current_digest = _contract_digest(current_contract)
+        if current_digest != result.contract_sha256:
+            result.failures.append(
+                _failure(
+                    "evaluation_contract_drift",
+                    "finalize",
+                    "the evaluation declaration changed during execution",
+                    before_sha256=result.contract_sha256,
+                    after_sha256=current_digest,
+                )
+            )
+
+    source_paths = tuple(Path(path) for path in result.protected_source_paths)
+    sources_after, source_failures = _capture_sources(
+        source_paths,
+        phase="finalize",
+    )
+    result.protected_sources_after = sources_after
+    result.failures.extend(source_failures)
+    before_by_path = {identity.path: identity for identity in result.protected_sources_before}
+    after_by_path = {identity.path: identity for identity in result.protected_sources_after}
+    for path, before in before_by_path.items():
+        after = after_by_path.get(path)
+        if after is not None and (before.sha256 != after.sha256 or before.bytes != after.bytes):
+            result.failures.append(
+                _failure(
+                    "protected_source_mutated",
+                    "finalize",
+                    "protected evaluation source changed during execution",
+                    path=path,
+                    before_sha256=before.sha256,
+                    after_sha256=after.sha256,
+                    before_bytes=before.bytes,
+                    after_bytes=after.bytes,
+                )
+            )
+    result.finalized_at = datetime.now(timezone.utc)
+    result.status = "FAIL" if result.failures else "PASS"
+    return result
+
+
+__all__ = [
+    "DatasetDeclaration",
+    "EvaluationContract",
+    "EvaluationFailure",
+    "EvaluationProvenance",
+    "EvaluationProvenanceError",
+    "EvaluatorDeclaration",
+    "FeatureLineage",
+    "ProtectedSourceIdentity",
+    "SplitIdentity",
+    "TemporalSplitBoundary",
+    "finalize_evaluation",
+    "start_evaluation",
+]

--- a/code/core/benchmark/models.py
+++ b/code/core/benchmark/models.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, ConfigDict, field_validator
+from core.benchmark.evaluation_provenance import EvaluationProvenance
 from core.benchmark.run_manifest import RunManifest
 
 
@@ -385,6 +386,10 @@ class BenchmarkResult(BaseModel):
     gpu_metrics: Optional[Dict[str, Optional[float | str]]] = Field(
         None,
         description="Snapshot of GPU telemetry (temperature, power, utilization, timestamp)",
+    )
+    evaluation: Optional[EvaluationProvenance] = Field(
+        None,
+        description="Worker-captured provenance for benchmarks that explicitly opt in to evaluation claims",
     )
     
     schemaVersion: str = Field("1.0", description="Schema version for forward compatibility")

--- a/code/core/benchmark/run_manifest.py
+++ b/code/core/benchmark/run_manifest.py
@@ -13,6 +13,13 @@ from pathlib import Path
 from typing import Any, Dict, Optional, TypedDict
 
 import torch
+from core.benchmark.evaluation_provenance import (
+    EvaluationContract,
+    EvaluationFailure,
+    EvaluationProvenance,
+    finalize_evaluation as finalize_evaluation_provenance,
+    start_evaluation,
+)
 from core.profiling.gpu_telemetry import query_gpu_telemetry
 
 try:
@@ -564,6 +571,13 @@ class RunManifest(BaseModel):
     # Verification results (if verify mode was run)
     verify: Optional[VerifyManifestEntry] = Field(None, description="Verification results for this run")
 
+    # Explicit opt-in provenance for workloads that make dataset evaluation claims.
+    # Kernel and systems microbenchmarks leave this unset.
+    evaluation: Optional[EvaluationProvenance] = Field(
+        None,
+        description="Evaluation contract receipt, when the workload explicitly opts in",
+    )
+
     # Non-fatal provenance / collection warnings
     collection_warnings: list[str] = Field(
         default_factory=list,
@@ -710,6 +724,46 @@ class RunManifest(BaseModel):
             schemaVersion=SCHEMA_VERSION,
         )
     
+    def begin_evaluation(self, contract: EvaluationContract) -> EvaluationProvenance:
+        """Validate and snapshot an opted-in evaluation before execution."""
+
+        if self.evaluation is not None:
+            self.evaluation.failures.append(
+                EvaluationFailure(
+                    code="evaluation_already_started",
+                    phase="start",
+                    message="evaluation provenance may be started only once",
+                )
+            )
+            self.evaluation.status = "FAIL"
+            return self.evaluation
+        self.evaluation = start_evaluation(contract)
+        return self.evaluation
+
+    def finalize_evaluation(
+        self,
+        current_contract: Optional[EvaluationContract],
+    ) -> Optional[EvaluationProvenance]:
+        """Finalize an opted-in evaluation and retain structured failures."""
+
+        if self.evaluation is None:
+            if current_contract is None:
+                return None
+            self.evaluation = start_evaluation(current_contract)
+            self.evaluation.failures.append(
+                EvaluationFailure(
+                    code="evaluation_not_started",
+                    phase="finalize",
+                    message="evaluation provenance was not captured before execution",
+                )
+            )
+            self.evaluation.status = "FAIL"
+        self.evaluation = finalize_evaluation_provenance(
+            self.evaluation,
+            current_contract,
+        )
+        return self.evaluation
+
     def finalize(self, end_time: Optional[datetime] = None) -> None:
         """Finalize the manifest with end time and duration.
         
@@ -717,6 +771,10 @@ class RunManifest(BaseModel):
             end_time: Optional end time (defaults to now)
         """
         self.refresh_runtime_capability_limitations()
+        if self.evaluation is not None and self.evaluation.finalized_at is None:
+            # A caller that does not supply the post-run declaration cannot silently
+            # turn an unfinished evaluation receipt into a successful manifest.
+            self.finalize_evaluation(None)
         if end_time is None:
             end_time = datetime.now()
         

--- a/code/core/benchmark/verification.py
+++ b/code/core/benchmark/verification.py
@@ -92,6 +92,12 @@ class InputSignature:
     pipeline_stage_boundaries: Optional[List[Tuple[int, int]]] = None
     per_rank_batch_size: Optional[int] = None
     collective_type: Optional[str] = None
+    # Declared distributed work contract. These describe comparison policy only;
+    # runtime algorithm/completion proof is carried by explicit rank receipts.
+    collective_algorithm: Optional[str] = None
+    gradient_bucket_bytes: Optional[int] = None
+    barrier_policy: Optional[str] = None
+    async_completion_policy: Optional[str] = None
     
     # Optional launch config (required for streams/graphs)
     num_streams: Optional[int] = None
@@ -143,6 +149,14 @@ class InputSignature:
             result["per_rank_batch_size"] = self.per_rank_batch_size
         if self.collective_type is not None:
             result["collective_type"] = self.collective_type
+        if self.collective_algorithm is not None:
+            result["collective_algorithm"] = self.collective_algorithm
+        if self.gradient_bucket_bytes is not None:
+            result["gradient_bucket_bytes"] = self.gradient_bucket_bytes
+        if self.barrier_policy is not None:
+            result["barrier_policy"] = self.barrier_policy
+        if self.async_completion_policy is not None:
+            result["async_completion_policy"] = self.async_completion_policy
         if self.num_streams is not None:
             result["num_streams"] = self.num_streams
         if self.graph_capture_enabled is not None:
@@ -185,6 +199,10 @@ class InputSignature:
             pipeline_stage_boundaries=stage_boundaries,
             per_rank_batch_size=data.get("per_rank_batch_size"),
             collective_type=data.get("collective_type"),
+            collective_algorithm=data.get("collective_algorithm"),
+            gradient_bucket_bytes=data.get("gradient_bucket_bytes"),
+            barrier_policy=data.get("barrier_policy"),
+            async_completion_policy=data.get("async_completion_policy"),
             num_streams=data.get("num_streams"),
             graph_capture_enabled=data.get("graph_capture_enabled"),
             pruning_enabled=data.get("pruning_enabled"),
@@ -217,6 +235,46 @@ class InputSignature:
 
         if not isinstance(self.precision_flags, PrecisionFlags):
             errors.append("precision_flags must be a PrecisionFlags instance")
+
+        distributed_contract_values = (
+            self.collective_algorithm,
+            self.gradient_bucket_bytes,
+            self.barrier_policy,
+            self.async_completion_policy,
+        )
+        if any(value is not None for value in distributed_contract_values):
+            if self.world_size is None or self.world_size <= 1:
+                errors.append(
+                    "distributed work contract fields require world_size > 1"
+                )
+
+        if self.collective_algorithm is not None:
+            if not isinstance(self.collective_algorithm, str) or not self.collective_algorithm.strip():
+                errors.append("collective_algorithm must be a non-empty string when provided")
+            if not isinstance(self.collective_type, str) or not self.collective_type.strip():
+                errors.append("collective_algorithm requires a declared collective_type")
+
+        if self.gradient_bucket_bytes is not None:
+            if (
+                isinstance(self.gradient_bucket_bytes, bool)
+                or not isinstance(self.gradient_bucket_bytes, int)
+                or self.gradient_bucket_bytes <= 0
+            ):
+                errors.append("gradient_bucket_bytes must be a positive integer when provided")
+
+        if self.barrier_policy is not None and self.barrier_policy != "barrier_before_timed_close":
+            errors.append(
+                "barrier_policy must be 'barrier_before_timed_close' when provided"
+            )
+
+        if (
+            self.async_completion_policy is not None
+            and self.async_completion_policy != "wait_for_async_before_timed_close"
+        ):
+            errors.append(
+                "async_completion_policy must be "
+                "'wait_for_async_before_timed_close' when provided"
+            )
 
         if self.pipeline_stages is not None:
             if self.pipeline_stages < 1:
@@ -992,6 +1050,10 @@ class DistributedTopology:
     pipeline_stage_boundaries: Optional[List[Tuple[int, int]]] = None
     per_rank_batch_size: Optional[int] = None
     collective_type: Optional[str] = None  # allreduce, allgather, etc.
+    collective_algorithm: Optional[str] = None  # declared ring, tree, auto, etc.
+    gradient_bucket_bytes: Optional[int] = None
+    barrier_policy: Optional[str] = None
+    async_completion_policy: Optional[str] = None
     
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to dictionary."""
@@ -1011,6 +1073,14 @@ class DistributedTopology:
             result["per_rank_batch_size"] = self.per_rank_batch_size
         if self.collective_type is not None:
             result["collective_type"] = self.collective_type
+        if self.collective_algorithm is not None:
+            result["collective_algorithm"] = self.collective_algorithm
+        if self.gradient_bucket_bytes is not None:
+            result["gradient_bucket_bytes"] = self.gradient_bucket_bytes
+        if self.barrier_policy is not None:
+            result["barrier_policy"] = self.barrier_policy
+        if self.async_completion_policy is not None:
+            result["async_completion_policy"] = self.async_completion_policy
         return result
     
     @classmethod
@@ -1034,6 +1104,10 @@ class DistributedTopology:
             pipeline_stage_boundaries=stage_boundaries,
             per_rank_batch_size=data.get("per_rank_batch_size"),
             collective_type=data.get("collective_type"),
+            collective_algorithm=data.get("collective_algorithm"),
+            gradient_bucket_bytes=data.get("gradient_bucket_bytes"),
+            barrier_policy=data.get("barrier_policy"),
+            async_completion_policy=data.get("async_completion_policy"),
         )
 
 
@@ -1059,6 +1133,10 @@ def extract_distributed_topology(signature: InputSignature) -> Optional[Distribu
         pipeline_stage_boundaries=signature.pipeline_stage_boundaries,
         per_rank_batch_size=signature.per_rank_batch_size,
         collective_type=signature.collective_type,
+        collective_algorithm=signature.collective_algorithm,
+        gradient_bucket_bytes=signature.gradient_bucket_bytes,
+        barrier_policy=signature.barrier_policy,
+        async_completion_policy=signature.async_completion_policy,
     )
 
 
@@ -1086,6 +1164,11 @@ def compare_topologies(
     # Compare world size
     if baseline_topo.world_size != optimized_topo.world_size:
         return False, f"World size mismatch: {baseline_topo.world_size} vs {optimized_topo.world_size}"
+
+    # Compare participating ranks. Equal world size alone does not establish that
+    # the same ranks performed the measured work.
+    if baseline_topo.ranks != optimized_topo.ranks:
+        return False, f"Ranks mismatch: {baseline_topo.ranks} vs {optimized_topo.ranks}"
     
     # Compare shards
     if baseline_topo.shards != optimized_topo.shards:
@@ -1101,6 +1184,46 @@ def compare_topologies(
             False,
             "Pipeline stage boundaries mismatch: "
             f"{baseline_topo.pipeline_stage_boundaries} vs {optimized_topo.pipeline_stage_boundaries}",
+        )
+
+    if baseline_topo.per_rank_batch_size != optimized_topo.per_rank_batch_size:
+        return (
+            False,
+            "Per-rank batch size mismatch: "
+            f"{baseline_topo.per_rank_batch_size} vs {optimized_topo.per_rank_batch_size}",
+        )
+
+    if baseline_topo.collective_type != optimized_topo.collective_type:
+        return (
+            False,
+            f"Collective type mismatch: {baseline_topo.collective_type} vs {optimized_topo.collective_type}",
+        )
+
+    if baseline_topo.collective_algorithm != optimized_topo.collective_algorithm:
+        return (
+            False,
+            "Collective algorithm mismatch: "
+            f"{baseline_topo.collective_algorithm} vs {optimized_topo.collective_algorithm}",
+        )
+
+    if baseline_topo.gradient_bucket_bytes != optimized_topo.gradient_bucket_bytes:
+        return (
+            False,
+            "Gradient bucket bytes mismatch: "
+            f"{baseline_topo.gradient_bucket_bytes} vs {optimized_topo.gradient_bucket_bytes}",
+        )
+
+    if baseline_topo.barrier_policy != optimized_topo.barrier_policy:
+        return (
+            False,
+            f"Barrier policy mismatch: {baseline_topo.barrier_policy} vs {optimized_topo.barrier_policy}",
+        )
+
+    if baseline_topo.async_completion_policy != optimized_topo.async_completion_policy:
+        return (
+            False,
+            "Async completion policy mismatch: "
+            f"{baseline_topo.async_completion_policy} vs {optimized_topo.async_completion_policy}",
         )
     
     return True, None

--- a/code/core/benchmark/verification_mixin.py
+++ b/code/core/benchmark/verification_mixin.py
@@ -53,6 +53,10 @@ class VerificationPayloadMixin:
         "pipeline_stage_boundaries",
         "per_rank_batch_size",
         "collective_type",
+        "collective_algorithm",
+        "gradient_bucket_bytes",
+        "barrier_policy",
+        "async_completion_policy",
         "num_streams",
         "graph_capture_enabled",
         "pruning_enabled",
@@ -110,6 +114,10 @@ class VerificationPayloadMixin:
             normalized["shards"] = int(normalized["shards"])
         if "per_rank_batch_size" in normalized and normalized["per_rank_batch_size"] is not None:
             normalized["per_rank_batch_size"] = int(normalized["per_rank_batch_size"])
+        if "gradient_bucket_bytes" in normalized and normalized["gradient_bucket_bytes"] is not None:
+            if isinstance(normalized["gradient_bucket_bytes"], bool):
+                raise TypeError("signature_overrides['gradient_bucket_bytes'] must be an integer, not bool")
+            normalized["gradient_bucket_bytes"] = int(normalized["gradient_bucket_bytes"])
         if "num_streams" in normalized and normalized["num_streams"] is not None:
             normalized["num_streams"] = int(normalized["num_streams"])
         if "sparsity_ratio" in normalized and normalized["sparsity_ratio"] is not None:

--- a/code/core/benchmark/verify_runner.py
+++ b/code/core/benchmark/verify_runner.py
@@ -31,6 +31,11 @@ import numpy as np
 import torch
 
 from core.harness.backend_policy import apply_backend_policy, normalize_backend_policy, restore_backend_policy
+from core.benchmark.evaluation_provenance import (
+    EvaluationProvenance,
+    finalize_evaluation,
+    start_evaluation,
+)
 from core.benchmark.verification import (
     ComparisonDetails,
     EnforcementPhase,
@@ -417,6 +422,7 @@ class VerifyRunner:
         self._last_baseline_signature: Optional[InputSignature] = None
         self._last_baseline_cache_key: Optional[str] = None
         self._last_baseline_equivalence: Optional[SignatureEquivalenceSpec] = None
+        self._last_evaluation_provenance: Optional[EvaluationProvenance] = None
     
     def _extract_output(self, benchmark: Any) -> Dict[str, torch.Tensor]:
         """Extract output tensor from benchmark using ONLY get_verify_output().
@@ -829,10 +835,17 @@ class VerifyRunner:
                 )
                 cfg = None
 
+        self._last_evaluation_provenance = None
         policy_name = normalize_backend_policy(getattr(cfg, "backend_policy", None))
         backend_state = apply_backend_policy(policy_name, deterministic=True)
 
         try:
+            evaluation_getter = getattr(benchmark, "get_evaluation_contract", None)
+            evaluation_contract = evaluation_getter() if callable(evaluation_getter) else None
+            if evaluation_contract is not None:
+                self._last_evaluation_provenance = start_evaluation(evaluation_contract)
+                self._last_evaluation_provenance.raise_for_failures()
+
             # Setup creates model and fixed inputs deterministically
             benchmark.setup()
 
@@ -959,7 +972,21 @@ class VerifyRunner:
                         RuntimeWarning,
                         stacklevel=2,
                     )
-            restore_backend_policy(backend_state)
+            try:
+                if self._last_evaluation_provenance is not None:
+                    current_getter = getattr(benchmark, "get_evaluation_contract", None)
+                    try:
+                        current_contract = current_getter() if callable(current_getter) else None
+                    except Exception:
+                        # A failing getter cannot leave an opted-in receipt pending.
+                        # Finalization records the unavailable declaration as a failure.
+                        current_contract = None
+                    self._last_evaluation_provenance = finalize_evaluation(
+                        self._last_evaluation_provenance, current_contract
+                    )
+                    self._last_evaluation_provenance.raise_for_failures()
+            finally:
+                restore_backend_policy(backend_state)
 
     def _validate_inputs_match_signature(
         self,
@@ -1371,13 +1398,19 @@ class VerifyRunner:
                 baseline_checksum=golden.checksum,
                 workload_delta=None,
                 seed_info=seed_info,
+                details={"evaluation_provenance": self._last_evaluation_provenance.model_dump(mode="json")}
+                if self._last_evaluation_provenance is not None else None,
             )
 
         except Exception as e:
             msg = str(e)
             if msg.startswith("SKIPPED:"):
                 return VerifyResult.fail(msg)
-            return VerifyResult.fail(f"Baseline execution failed: {e}\n{traceback.format_exc()}")
+            return VerifyResult.fail(
+                f"Baseline execution failed: {e}\n{traceback.format_exc()}",
+                details={"evaluation_provenance": self._last_evaluation_provenance.model_dump(mode="json")}
+                if self._last_evaluation_provenance is not None else None,
+            )
     
     def verify_optimized(
         self,
@@ -1417,6 +1450,7 @@ class VerifyRunner:
         try:
             # Run optimized with same seed
             outputs, metrics, seed_info, inputs, signature = self._run_with_seed(optimized, config.seed)
+            evaluation_provenance = self._last_evaluation_provenance
             if not getattr(optimized, "parameter_signature_only", False):
                 try:
                     self._validate_inputs_match_signature(signature, inputs)
@@ -1629,6 +1663,9 @@ class VerifyRunner:
 
             advisory_warnings = [msg for msg in (fresh_msg, jitter_msg) if msg]
             details = {"warnings": advisory_warnings} if advisory_warnings else None
+            if evaluation_provenance is not None:
+                details = dict(details or {})
+                details["evaluation_provenance"] = evaluation_provenance.model_dump(mode="json")
 
             return VerifyResult.success(
                 signature_hash=sig_hash,
@@ -1643,7 +1680,11 @@ class VerifyRunner:
             msg = str(e)
             if msg.startswith("SKIPPED:"):
                 return VerifyResult.fail(msg)
-            return VerifyResult.fail(f"Optimized execution failed: {e}\n{traceback.format_exc()}")
+            return VerifyResult.fail(
+                f"Optimized execution failed: {e}\n{traceback.format_exc()}",
+                details={"evaluation_provenance": self._last_evaluation_provenance.model_dump(mode="json")}
+                if self._last_evaluation_provenance is not None else None,
+            )
     
     def _validate_timing_config(
         self,

--- a/code/core/harness/benchmark_harness.py
+++ b/code/core/harness/benchmark_harness.py
@@ -39,11 +39,22 @@ import numpy as np
 import torch
 
 from core.utils.compile_utils import enable_tf32
+from core.benchmark.evaluation_provenance import (
+    EvaluationFailure,
+    EvaluationProvenance,
+    finalize_evaluation as finalize_evaluation_provenance,
+    start_evaluation,
+)
 from core.benchmark.verification_mixin import VerificationPayloadMixin
 from core.harness.backend_policy import apply_backend_policy, normalize_backend_policy, restore_backend_policy
+from core.harness.device_identity_contract import (
+    DeviceIdentityContract,
+    build_device_identity_expectation,
+)
 from core.harness.verify_output_codec import deserialize_verify_tensor
 
 if TYPE_CHECKING:
+    from core.benchmark.evaluation_provenance import EvaluationContract
     from core.benchmark.verification import VerifyResult
 
 # Pydantic is required - fail fast if not available
@@ -798,6 +809,10 @@ class BenchmarkConfig:
     deterministic: bool = field(default_factory=lambda: _get_default_value("deterministic", False))
     seed: Optional[int] = field(default_factory=lambda: _get_default_value("seed", None))
     device: Optional[torch.device] = None  # Not in BenchmarkDefaults (runtime-specific)
+    expected_device_uuid: Optional[str] = None
+    """Expected full-device GPU UUID. Configure together with expected_compute_capability."""
+    expected_compute_capability: Optional[str] = None
+    """Expected CUDA compute capability, normalized to ``major.minor``."""
     enable_profiling: bool = field(default_factory=lambda: _get_default_value("enable_profiling", False))
     enable_nsys: bool = field(default_factory=lambda: _get_default_value("enable_nsys", False))
     enable_ncu: bool = field(default_factory=lambda: _get_default_value("enable_ncu", False))
@@ -1042,6 +1057,14 @@ class BenchmarkConfig:
             self.env_passthrough = []
         if self.target_extra_args is None:
             self.target_extra_args = {}
+
+        device_expectation = build_device_identity_expectation(
+            self.expected_device_uuid,
+            self.expected_compute_capability,
+        )
+        if device_expectation is not None:
+            self.expected_device_uuid = device_expectation.expected_uuid
+            self.expected_compute_capability = device_expectation.expected_compute_capability
 
         validity_profile = str(getattr(self, "validity_profile", "strict")).strip().lower()
         if validity_profile not in {"strict", "portable"}:
@@ -1331,6 +1354,8 @@ class BenchmarkProfilingView:
 @dataclass(frozen=True)
 class BenchmarkValidityView:
     validity_profile: str
+    expected_device_uuid: Optional[str]
+    expected_compute_capability: Optional[str]
     enforce_environment_validation: bool
     allow_virtualization: bool
     allow_foreign_gpu_processes: bool
@@ -1446,6 +1471,10 @@ def _build_profiling_view_from_mapping(values: Dict[str, Any]) -> BenchmarkProfi
 def _build_validity_view_from_mapping(values: Dict[str, Any]) -> BenchmarkValidityView:
     return BenchmarkValidityView(
         validity_profile=str(values["validity_profile"]),
+        expected_device_uuid=cast(Optional[str], values.get("expected_device_uuid")),
+        expected_compute_capability=cast(
+            Optional[str], values.get("expected_compute_capability")
+        ),
         enforce_environment_validation=bool(values["enforce_environment_validation"]),
         allow_virtualization=bool(values["allow_virtualization"]),
         allow_foreign_gpu_processes=bool(values["allow_foreign_gpu_processes"]),
@@ -1734,6 +1763,10 @@ class BaseBenchmark:
         will still stash the merged config on ``self._config`` for runtime checks.
         """
         return getattr(self, "_config", None)
+
+    def get_evaluation_contract(self) -> Optional["EvaluationContract"]:
+        """Return an explicit evaluation-provenance contract when applicable."""
+        return None
 
     def get_verify_inputs(self) -> Dict[str, torch.Tensor]:
         """Return input tensors used for verification/aliasing checks."""
@@ -3184,6 +3217,10 @@ class BenchmarkHarness:
         # Run benchmark
         result = self.benchmark(benchmark)
 
+        worker_evaluation = getattr(result, "evaluation", None)
+        if worker_evaluation is not None:
+            manifest.evaluation = worker_evaluation.model_copy(deep=True)
+
         result_seed_info = _seed_info_to_manifest(getattr(result, "seeds", None))
         if result_seed_info is not None:
             manifest.seeds = result_seed_info
@@ -3384,6 +3421,7 @@ class BenchmarkHarness:
         child_custom_metrics: Optional[Dict[str, float]] = None
         child_runtime_env: Optional[Dict[str, str]] = None
         child_gpu_metrics: Optional[Dict[str, Optional[float | str]]] = None
+        child_evaluation: Optional[EvaluationProvenance] = None
         stage_watchdog: Dict[str, Dict[str, Any]] = {
             "setup": {"status": "pending"},
             "warmup": {"status": "pending"},
@@ -3601,10 +3639,16 @@ class BenchmarkHarness:
                     if suffix and LOGGER_AVAILABLE:
                         logger.debug(f"Stripped non-JSON suffix from subprocess output: {suffix[:200]}")
                     result_success = bool(result_dict.get("success"))
-                    if result_success and result_dict.get("result_json"):
+                    result_json_str = result_dict.get("result_json")
+                    benchmark_result = (
+                        PydanticBenchmarkResult.model_validate_json(result_json_str)
+                        if result_json_str
+                        else None
+                    )
+                    if benchmark_result is not None and benchmark_result.evaluation is not None:
+                        child_evaluation = benchmark_result.evaluation.model_copy(deep=True)
+                    if result_success and benchmark_result is not None:
                         # Deserialize Pydantic BenchmarkResult from JSON
-                        result_json_str = result_dict["result_json"]
-                        benchmark_result = PydanticBenchmarkResult.model_validate_json(result_json_str)
                         child_gpu_metrics = getattr(benchmark_result, "gpu_metrics", None)
                         
                         # Preserve the child's measured summary when raw samples
@@ -3714,7 +3758,13 @@ class BenchmarkHarness:
                         if stderr:
                             _maybe_write_subprocess_stderr(stderr, benchmark_name, config)
                     else:
-                        errors.extend(result_dict.get("errors", ["Subprocess execution failed"]))
+                        if benchmark_result is not None:
+                            errors.extend(
+                                benchmark_result.errors
+                                or result_dict.get("errors", ["Subprocess execution failed"])
+                            )
+                        else:
+                            errors.extend(result_dict.get("errors", ["Subprocess execution failed"]))
                         times_ms = cast(List[float], [])
                         child_timing = None
                         if stderr:
@@ -3845,7 +3895,7 @@ class BenchmarkHarness:
                 "measurement": getattr(config, 'measurement_timeout_seconds', config.timeout_seconds),
             }
             limit = limit_lookup.get(failure_stage, getattr(config, 'measurement_timeout_seconds', config.timeout_seconds))
-            return self._create_timeout_result(
+            result = self._create_timeout_result(
                 stage=failure_stage,
                 duration=duration,
                 limit=limit,
@@ -3854,6 +3904,9 @@ class BenchmarkHarness:
                 config=config,
                 watchdog=stage_watchdog,
             )
+            if child_evaluation is not None:
+                result.evaluation = child_evaluation.model_copy(deep=True)
+            return result
         
         # Compute statistics only from actual samples. Summary-only children
         # retain exactly the statistics they supplied, including absent percentiles.
@@ -3868,6 +3921,8 @@ class BenchmarkHarness:
             result = self._result_from_timing(child_timing, config)
         if child_gpu_metrics is not None:
             result.gpu_metrics = child_gpu_metrics
+        if child_evaluation is not None:
+            result.evaluation = child_evaluation.model_copy(deep=True)
         if child_custom_metrics is not None:
             result.custom_metrics = child_custom_metrics
         else:
@@ -3983,6 +4038,7 @@ class BenchmarkHarness:
         seed_metadata = copy.deepcopy(getattr(self, "_seed_info", None))
         locked_gpu_metrics: Optional[Dict[str, Optional[float | str]]] = None
         captured_custom_metrics: Optional[Dict[str, float]] = None
+        evaluation_provenance: Optional[EvaluationProvenance] = None
         
         # Get benchmark name for error messages (same as subprocess path)
         benchmark_class = benchmark.__class__.__name__
@@ -4074,17 +4130,40 @@ class BenchmarkHarness:
             entry = stage_watchdog.get(stage, {})
             entry['status'] = status
             stage_watchdog[stage] = entry
+
+        def attach_evaluation(result: PydanticBenchmarkResult) -> PydanticBenchmarkResult:
+            """Attach a stable worker receipt to every result path."""
+
+            result.errors = list(errors)
+            if evaluation_provenance is not None:
+                receipt = evaluation_provenance.model_copy(deep=True)
+                if receipt.finalized_at is None:
+                    receipt = finalize_evaluation_provenance(receipt, None)
+                result.evaluation = receipt
+            return result
         
         def run_benchmark_internal():
             """Internal benchmark execution function."""
-            nonlocal times_ms, memory_peak_mb, memory_allocated_mb, profiling_outputs, errors, nsys_metrics, ncu_metrics, timeout_result_storage, inference_timing_data, locked_gpu_metrics, captured_custom_metrics
+            nonlocal times_ms, memory_peak_mb, memory_allocated_mb, profiling_outputs, errors, nsys_metrics, ncu_metrics, timeout_result_storage, inference_timing_data, locked_gpu_metrics, captured_custom_metrics, evaluation_provenance
             validity_profile = str(getattr(config, "validity_profile", "strict")).strip().lower()
             portable_mode = validity_profile == "portable"
             clock_lock_active = False
+            device_identity_contract: Optional[DeviceIdentityContract] = None
             
             with execution_lock:  # Acquire lock during execution
                 lock_stack = ExitStack()
                 try:
+                    if self.device.type == "cuda":
+                        device_identity_contract = DeviceIdentityContract(
+                            self.device,
+                            build_device_identity_expectation(
+                                getattr(config, "expected_device_uuid", None),
+                                getattr(config, "expected_compute_capability", None),
+                            ),
+                        )
+                        device_identity_contract.establish_configured_device()
+                        device_identity_contract.check("after_device_establishment")
+
                     if getattr(config, "lock_gpu_clocks", False) and self.device.type == "cuda":
                         device_index = self.device.index if self.device.index is not None else 0
                         try:
@@ -4163,8 +4242,15 @@ class BenchmarkHarness:
                         return outputs
 
                     def _run_setup_with_detection():
+                        nonlocal evaluation_provenance
                         start_stage('setup')
                         try:
+                            if device_identity_contract is not None:
+                                device_identity_contract.check("before_setup")
+                            evaluation_contract = benchmark.get_evaluation_contract()
+                            if evaluation_contract is not None:
+                                evaluation_provenance = start_evaluation(evaluation_contract)
+                                evaluation_provenance.raise_for_failures()
                             if getattr(config, "detect_setup_precomputation", True):
                                 precompute_ok, precompute_err = check_setup_precomputation(
                                     _collect_outputs_for_hash,
@@ -4174,6 +4260,8 @@ class BenchmarkHarness:
                                     raise RuntimeError(precompute_err or "Setup pre-computation detected")
                             else:
                                 benchmark.setup()
+                            if device_identity_contract is not None:
+                                device_identity_contract.check("after_setup")
                         except Exception:
                             finish_stage('setup', status='error')
                             raise
@@ -4223,7 +4311,11 @@ class BenchmarkHarness:
                         warmup_start_time = time.time()
                         start_stage('warmup')
                         try:
+                            if device_identity_contract is not None:
+                                device_identity_contract.check("before_warmup")
                             self._warmup(benchmark.benchmark_fn, config.warmup, config)
+                            if device_identity_contract is not None:
+                                device_identity_contract.check("after_warmup")
                         except Exception:
                             finish_stage('warmup', status='error')
                             raise
@@ -4320,6 +4412,8 @@ class BenchmarkHarness:
 
                     # Memory tracking: Use context manager to track peak memory during benchmark execution
                     start_stage('measurement')
+                    if device_identity_contract is not None:
+                        device_identity_contract.check("before_measurement")
                     with self._memory_tracking(config) as mem_result:
                         # Benchmark using selected mode
                         # Note: nsys/ncu profiling wraps the entire process, so it's handled separately
@@ -4412,6 +4506,9 @@ class BenchmarkHarness:
                         else:
                             mark_stage('profiling', 'skipped')
                             times_ms, inference_timing_data = self._benchmark_without_profiling(benchmark.benchmark_fn, config)
+
+                    if device_identity_contract is not None:
+                        device_identity_contract.check("after_measurement")
                     
                     # Extract memory tracking results from context manager
                     if mem_result is not None:
@@ -4465,19 +4562,75 @@ class BenchmarkHarness:
                     # Teardown is now safe to call - we hold the lock
                     # Only call teardown once - set flag to prevent double invocation
                     if not teardown_called.is_set():
+                        if device_identity_contract is not None:
+                            try:
+                                device_identity_contract.check("before_teardown")
+                            except Exception as e:
+                                errors.append(f"Device identity validation failed before teardown: {str(e)}")
+                                times_ms = cast(List[float], [])
                         try:
                             benchmark.teardown()
-                            teardown_called.set()
                         except Exception as e:
                             errors.append(f"Teardown failed: {str(e)}")
-                            teardown_called.set()  # Mark as called even on error
+                        finally:
+                            teardown_called.set()
+                            if device_identity_contract is not None:
+                                try:
+                                    device_identity_contract.check("after_teardown")
+                                except Exception as e:
+                                    errors.append(f"Device identity validation failed after teardown: {str(e)}")
+                                    times_ms = cast(List[float], [])
+
+                    try:
+                        current_evaluation_contract = benchmark.get_evaluation_contract()
+                    except Exception as e:
+                        errors.append(f"Evaluation contract unavailable after teardown: {str(e)}")
+                        current_evaluation_contract = None
+                        times_ms = cast(List[float], [])
+
+                    try:
+                        if evaluation_provenance is None and current_evaluation_contract is not None:
+                            evaluation_provenance = start_evaluation(current_evaluation_contract)
+                            evaluation_provenance.failures.append(
+                                EvaluationFailure(
+                                    code="evaluation_not_started",
+                                    phase="finalize",
+                                    message="evaluation provenance was not captured before execution",
+                                )
+                            )
+                            evaluation_provenance.status = "FAIL"
+                        if evaluation_provenance is not None:
+                            evaluation_provenance = finalize_evaluation_provenance(
+                                evaluation_provenance,
+                                current_evaluation_contract,
+                            )
+                            if evaluation_provenance.failures:
+                                failure_codes = ", ".join(
+                                    failure.code for failure in evaluation_provenance.failures
+                                )
+                                errors.append(
+                                    "Evaluation provenance rejected after teardown: "
+                                    f"{failure_codes}"
+                                )
+                                times_ms = cast(List[float], [])
+                    except Exception as e:
+                        errors.append(f"Evaluation provenance finalization failed: {str(e)}")
+                        times_ms = cast(List[float], [])
                     
                     # Force cleanup (only if enabled to avoid distorting timings)
-                    if config.enable_cleanup:
-                        if torch.cuda.is_available():
-                            torch.cuda.empty_cache()
-                        gc.collect()
-                    lock_stack.close()
+                    try:
+                        if config.enable_cleanup:
+                            if torch.cuda.is_available():
+                                torch.cuda.empty_cache()
+                            gc.collect()
+                        lock_stack.close()
+                    finally:
+                        if device_identity_contract is not None:
+                            try:
+                                device_identity_contract.restore_entry_device()
+                            except Exception as e:
+                                errors.append(f"Failed to restore entry CUDA device: {str(e)}")
+                                times_ms = cast(List[float], [])
         
         # ALWAYS run with timeout (required, default 15 seconds). Thread-mode benchmarks execute
         # inside a managed executor so we can recycle workers if a benchmark hangs.
@@ -4561,11 +4714,11 @@ class BenchmarkHarness:
             self._reset_thread_executor()
 
         if timeout_result is not None:
-            return timeout_result
+            return attach_evaluation(timeout_result)
         
         # Check if a timeout occurred in setup/warmup/profiling stages
         if timeout_result_storage[0] is not None:
-            return timeout_result_storage[0]
+            return attach_evaluation(timeout_result_storage[0])
         
         if execution_complete.is_set():
             # Thread completed normally - results are already set
@@ -4622,7 +4775,7 @@ class BenchmarkHarness:
                 "measurement": getattr(config, 'measurement_timeout_seconds', config.timeout_seconds),
             }
             limit = limit_lookup.get(failure_stage, getattr(config, 'measurement_timeout_seconds', config.timeout_seconds))
-            return self._create_timeout_result(
+            return attach_evaluation(self._create_timeout_result(
                 stage=failure_stage,
                 duration=duration,
                 limit=limit,
@@ -4630,10 +4783,11 @@ class BenchmarkHarness:
                 benchmark_name=benchmark_name,
                 config=config,
                 watchdog=stage_watchdog,
-            )
+            ))
         
         # Compute statistics
         result = self._compute_stats(times_ms, config)
+        result = attach_evaluation(result)
         if locked_gpu_metrics is not None:
             result.gpu_metrics = locked_gpu_metrics
         result.seeds = copy.deepcopy(seed_metadata)

--- a/code/core/harness/device_identity_contract.py
+++ b/code/core/harness/device_identity_contract.py
@@ -1,0 +1,304 @@
+"""Fail-fast CUDA device identity and current-context contract.
+
+This contract binds a configured logical CUDA device to an expected full-device
+UUID and compute capability when those expectations are supplied.  It also
+detects current-device drift at harness phase boundaries.
+
+The boundary checks do not prove that kernels never ran on another device.  A
+benchmark can switch devices and switch back between two checks, so undeclared
+device execution remains a trace-backed Nsys concern scoped to the measured
+NVTX range.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import torch
+
+from core.profiling.gpu_telemetry import normalize_gpu_uuid, resolve_nvml_device_handle
+
+ComputeCapabilityInput = str | Sequence[int]
+
+
+class DeviceIdentityError(RuntimeError):
+    """Raised when configured and observed CUDA device identity diverge."""
+
+
+def normalize_compute_capability(value: ComputeCapabilityInput) -> str:
+    """Return a canonical ``major.minor`` compute-capability string.
+
+    Accepted forms are ``(10, 0)``, ``"10.0"``, ``"sm_100"``, and
+    ``"compute_100"`` (with an optional architecture suffix such as ``a``).
+    Ambiguous integer-only values are rejected.
+    """
+    major: int
+    minor: int
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        dotted = re.fullmatch(r"(\d+)\.(\d+)", normalized)
+        if dotted:
+            major, minor = int(dotted.group(1)), int(dotted.group(2))
+        else:
+            compact = re.fullmatch(r"(?:sm_|compute_)(\d+)[a-z]?", normalized)
+            if compact is None:
+                raise ValueError(
+                    "Compute capability must use 'major.minor', 'sm_NN', "
+                    f"'compute_NN', or a two-integer sequence; got {value!r}"
+                )
+            digits = compact.group(1)
+            if len(digits) < 2:
+                raise ValueError(f"Invalid compact compute capability: {value!r}")
+            major, minor = int(digits[:-1]), int(digits[-1])
+    elif (
+        isinstance(value, Sequence)
+        and not isinstance(value, bytes | bytearray)
+        and len(value) == 2
+        and all(isinstance(part, int) and not isinstance(part, bool) for part in value)
+    ):
+        major, minor = int(value[0]), int(value[1])
+    else:
+        raise TypeError(
+            "Compute capability must be a string or a two-integer sequence; "
+            f"got {type(value).__name__}"
+        )
+
+    if major < 1 or minor < 0 or minor > 9:
+        raise ValueError(f"Invalid compute capability: {value!r}")
+    return f"{major}.{minor}"
+
+
+@dataclass(frozen=True)
+class DeviceIdentityExpectation:
+    """Caller-declared identity for one configured CUDA device."""
+
+    expected_uuid: str
+    expected_compute_capability: str
+
+    def __post_init__(self) -> None:
+        normalized_uuid = normalize_gpu_uuid(self.expected_uuid)
+        if normalized_uuid is None:
+            raise ValueError("expected_device_uuid must be a non-empty GPU UUID")
+        object.__setattr__(self, "expected_uuid", normalized_uuid)
+        object.__setattr__(
+            self,
+            "expected_compute_capability",
+            normalize_compute_capability(self.expected_compute_capability),
+        )
+
+
+@dataclass(frozen=True)
+class DeviceIdentityObservation:
+    """CUDA and NVML identity observed for a configured logical device."""
+
+    logical_index: int
+    current_logical_index: int
+    cuda_uuid: str | None
+    nvml_uuid: str
+    compute_capability: str
+
+
+def build_device_identity_expectation(
+    expected_uuid: object | None,
+    expected_compute_capability: ComputeCapabilityInput | None,
+) -> DeviceIdentityExpectation | None:
+    """Build an all-or-nothing expected-device declaration."""
+    if expected_uuid is None and expected_compute_capability is None:
+        return None
+    if expected_uuid is None or expected_compute_capability is None:
+        raise ValueError(
+            "expected_device_uuid and expected_compute_capability must be configured together"
+        )
+    return DeviceIdentityExpectation(
+        expected_uuid=str(expected_uuid),
+        expected_compute_capability=normalize_compute_capability(expected_compute_capability),
+    )
+
+
+def _configured_logical_index(device: torch.device) -> int:
+    if device.type != "cuda":
+        raise ValueError(f"CUDA device identity requires a CUDA device, got {device}")
+    if not torch.cuda.is_available():
+        raise DeviceIdentityError(f"CUDA device {device} was configured but CUDA is unavailable")
+    logical_index = int(device.index) if device.index is not None else int(torch.cuda.current_device())
+    device_count = int(torch.cuda.device_count())
+    if logical_index < 0 or logical_index >= device_count:
+        raise DeviceIdentityError(
+            f"Configured CUDA logical index {logical_index} is outside visible device count {device_count}"
+        )
+    return logical_index
+
+
+def observe_cuda_device_identity(device: torch.device) -> DeviceIdentityObservation:
+    """Read one logical CUDA device through both CUDA and NVML."""
+    logical_index = _configured_logical_index(device)
+    current_logical_index = int(torch.cuda.current_device())
+    properties = torch.cuda.get_device_properties(logical_index)
+    cuda_uuid = normalize_gpu_uuid(getattr(properties, "uuid", None))
+    compute_capability = normalize_compute_capability(
+        torch.cuda.get_device_capability(logical_index)
+    )
+
+    try:
+        import pynvml
+    except ImportError as exc:
+        raise DeviceIdentityError(
+            "CUDA device identity validation requires pynvml (nvidia-ml-py)"
+        ) from exc
+
+    nvml_initialized = False
+    try:
+        pynvml.nvmlInit()
+        nvml_initialized = True
+        handle = resolve_nvml_device_handle(
+            pynvml,
+            logical_index,
+            cuda_device_uuid=cuda_uuid,
+        )
+        nvml_uuid = normalize_gpu_uuid(pynvml.nvmlDeviceGetUUID(handle))
+        if nvml_uuid is None:
+            raise DeviceIdentityError(
+                f"NVML returned an empty UUID for configured CUDA logical index {logical_index}"
+            )
+    except DeviceIdentityError:
+        raise
+    except Exception as exc:
+        raise DeviceIdentityError(
+            f"Failed to resolve CUDA logical index {logical_index} through NVML: {exc}"
+        ) from exc
+    finally:
+        if nvml_initialized:
+            try:
+                pynvml.nvmlShutdown()
+            except Exception as exc:
+                raise DeviceIdentityError(f"Failed to shut down NVML after identity query: {exc}") from exc
+
+    return DeviceIdentityObservation(
+        logical_index=logical_index,
+        current_logical_index=current_logical_index,
+        cuda_uuid=cuda_uuid,
+        nvml_uuid=nvml_uuid,
+        compute_capability=compute_capability,
+    )
+
+
+def validate_device_identity(
+    expectation: DeviceIdentityExpectation | None,
+    observation: DeviceIdentityObservation,
+    boundary: str,
+) -> None:
+    """Reject current-context, CUDA/NVML, or declared-identity mismatches."""
+    boundary_name = str(boundary).strip()
+    if not boundary_name:
+        raise ValueError("Device identity boundary must be non-empty")
+    if observation.current_logical_index != observation.logical_index:
+        raise DeviceIdentityError(
+            f"CUDA current-device drift at {boundary_name}: configured logical index "
+            f"{observation.logical_index}, current logical index {observation.current_logical_index}"
+        )
+    if observation.cuda_uuid is not None and observation.cuda_uuid != observation.nvml_uuid:
+        raise DeviceIdentityError(
+            f"CUDA/NVML device identity mismatch at {boundary_name}: "
+            f"cuda={observation.cuda_uuid!r}, nvml={observation.nvml_uuid!r}"
+        )
+    if expectation is None:
+        return
+    if observation.nvml_uuid != expectation.expected_uuid:
+        raise DeviceIdentityError(
+            f"Expected GPU UUID mismatch at {boundary_name}: "
+            f"expected={expectation.expected_uuid!r}, observed={observation.nvml_uuid!r}"
+        )
+    if observation.cuda_uuid is not None and observation.cuda_uuid != expectation.expected_uuid:
+        raise DeviceIdentityError(
+            f"Expected CUDA UUID mismatch at {boundary_name}: "
+            f"expected={expectation.expected_uuid!r}, observed={observation.cuda_uuid!r}"
+        )
+    if observation.compute_capability != expectation.expected_compute_capability:
+        raise DeviceIdentityError(
+            f"Expected compute capability mismatch at {boundary_name}: "
+            f"expected={expectation.expected_compute_capability!r}, "
+            f"observed={observation.compute_capability!r}"
+        )
+
+
+def validate_device_identity_stable(
+    initial: DeviceIdentityObservation,
+    observation: DeviceIdentityObservation,
+    boundary: str,
+) -> None:
+    """Reject identity changes relative to the first harness boundary."""
+    drift = []
+    if observation.logical_index != initial.logical_index:
+        drift.append(f"logical_index {initial.logical_index}->{observation.logical_index}")
+    if observation.cuda_uuid != initial.cuda_uuid:
+        drift.append(f"cuda_uuid {initial.cuda_uuid!r}->{observation.cuda_uuid!r}")
+    if observation.nvml_uuid != initial.nvml_uuid:
+        drift.append(f"nvml_uuid {initial.nvml_uuid!r}->{observation.nvml_uuid!r}")
+    if observation.compute_capability != initial.compute_capability:
+        drift.append(
+            "compute_capability "
+            f"{initial.compute_capability!r}->{observation.compute_capability!r}"
+        )
+    if drift:
+        raise DeviceIdentityError(
+            f"CUDA device identity drift at {boundary}: {'; '.join(drift)}"
+        )
+
+
+class DeviceIdentityContract:
+    """Track CUDA identity across the phase boundaries of one harness run."""
+
+    def __init__(
+        self,
+        device: torch.device,
+        expectation: DeviceIdentityExpectation | None = None,
+    ) -> None:
+        if device.type != "cuda":
+            raise ValueError(f"DeviceIdentityContract requires a CUDA device, got {device}")
+        self.device = device
+        self.expectation = expectation
+        self._logical_index: int | None = None
+        self._entry_logical_index: int | None = None
+        self._initial_observation: DeviceIdentityObservation | None = None
+
+    def establish_configured_device(self) -> int:
+        """Select the configured device and remember the caller's entry context."""
+        if self._entry_logical_index is not None:
+            raise RuntimeError("Configured CUDA device was already established for this contract")
+        entry_index = int(torch.cuda.current_device())
+        logical_index = _configured_logical_index(self.device)
+        self._entry_logical_index = entry_index
+        self._logical_index = logical_index
+        if entry_index != logical_index:
+            torch.cuda.set_device(logical_index)
+        return entry_index
+
+    def check(self, boundary: str) -> DeviceIdentityObservation:
+        """Validate the current boundary and reject identity drift."""
+        if self._logical_index is None:
+            raise RuntimeError("establish_configured_device() must run before device identity checks")
+        observation = observe_cuda_device_identity(torch.device("cuda", self._logical_index))
+        validate_device_identity(self.expectation, observation, boundary)
+        initial = self._initial_observation
+        if initial is None:
+            self._initial_observation = observation
+            return observation
+        validate_device_identity_stable(initial, observation, boundary)
+        return observation
+
+    def restore_entry_device(self) -> None:
+        """Restore the caller's CUDA current device after the run."""
+        if self._entry_logical_index is None:
+            return
+        entry_index = self._entry_logical_index
+        if not torch.cuda.is_available():
+            raise DeviceIdentityError(
+                f"CUDA became unavailable before restoring entry logical index {entry_index}"
+            )
+        if int(torch.cuda.current_device()) != entry_index:
+            torch.cuda.set_device(entry_index)
+        self._entry_logical_index = None
+        self._logical_index = None
+        self._initial_observation = None

--- a/code/labs/decode_optimization/decode_multigpu_demo.py
+++ b/code/labs/decode_optimization/decode_multigpu_demo.py
@@ -141,8 +141,13 @@ def main() -> None:
     parser.add_argument("--iters", type=int, default=4)
     parser.add_argument("--warmup", type=int, default=1)
     args = parser.parse_args()
+    _resolve_world_size()
     _run_worker(args.iters, args.warmup)
 
 
 def get_benchmark() -> BaseBenchmark:
     return MultiGPUDecodeBenchmark()
+
+
+if __name__ == "__main__":
+    main()

--- a/code/tests/test_benchmark_linter.py
+++ b/code/tests/test_benchmark_linter.py
@@ -9,6 +9,25 @@ from core.benchmark.contract import check_benchmark_file_ast
 from core.discovery import discover_benchmark_entrypoints
 
 
+@pytest.mark.parametrize("relative_path", [
+    "ch10/warpgroup_specialization_demo.py",
+    "ch13/fp8_perchannel_demo.py",
+    "labs/decode_optimization/decode_multigpu_demo.py",
+    "ch13/dtensor_mesh_tool.py",
+    "ch19/fp8_calibration_free_tool.py",
+    "ch13/fp8_perchannel_bench.py",
+    "ch20/kernel_verification_tool.py",
+    "ch15/kv_cache_management_math.py",
+    "ch18/nvfp4_trtllm_tool.py",
+    "ch20/proofwright_verify_tool.py",
+])
+def test_registered_standalone_workloads_allow_real_main_entrypoint(relative_path):
+    path = Path(__file__).resolve().parents[1] / relative_path
+    valid, errors, warnings = check_benchmark_file_ast(path)
+    assert valid, errors
+    assert not warnings
+
+
 def _lint_tmp_file(tmp_path: Path, name: str, source: str):
     path = tmp_path / name
     path.write_text(source)

--- a/code/tests/test_demo_entrypoints.py
+++ b/code/tests/test_demo_entrypoints.py
@@ -1,0 +1,71 @@
+"""Real CLI regressions for registered demo entrypoints."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+CODE_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize(
+    ("demo_name", "cli_args", "expected_diagnostic"),
+    [
+        (
+            "ch10-warpgroup-specialization",
+            [],
+            "CUDA required for ch10 warpgroup specialization demo",
+        ),
+        (
+            "ch13-fp8-perchannel",
+            [],
+            "CUDA required for ch13 FP8 per-channel demo",
+        ),
+        (
+            "labs-decode-multigpu",
+            ["--nproc-per-node", "2"],
+            "CUDA required for multi-GPU decode demo",
+        ),
+    ],
+)
+def test_registered_demo_reaches_explicit_cuda_gate(
+    demo_name: str,
+    cli_args: list[str],
+    expected_diagnostic: str,
+) -> None:
+    """A CUDA-hidden real CLI launch must execute the script, not exit zero after import."""
+    env = os.environ.copy()
+    env.update(
+        {
+            "CUDA_VISIBLE_DEVICES": "",
+            "PATH": f"{Path(sys.executable).parent}{os.pathsep}{env.get('PATH', '')}",
+            "PYTHONNOUSERSITE": "1",
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONPATH": str(CODE_ROOT),
+        }
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "cli.aisp",
+            "demos",
+            demo_name,
+            *cli_args,
+        ],
+        cwd=CODE_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=45,
+        check=False,
+    )
+
+    combined_output = completed.stdout + completed.stderr
+    assert completed.returncode != 0, combined_output
+    assert expected_diagnostic in combined_output

--- a/code/tests/test_device_identity_contract.py
+++ b/code/tests/test_device_identity_contract.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+import torch
+
+from core.harness.benchmark_harness import BaseBenchmark, BenchmarkConfig, BenchmarkHarness
+from core.harness.device_identity_contract import (
+    DeviceIdentityContract,
+    DeviceIdentityError,
+    DeviceIdentityExpectation,
+    DeviceIdentityObservation,
+    build_device_identity_expectation,
+    normalize_compute_capability,
+    observe_cuda_device_identity,
+    validate_device_identity,
+    validate_device_identity_stable,
+)
+
+GPU_UUID_A = "GPU-12345678-1234-5678-1234-567812345678"
+GPU_UUID_B = "GPU-87654321-4321-8765-4321-876543218765"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ((10, 0), "10.0"),
+        ([12, 1], "12.1"),
+        ("10.3", "10.3"),
+        ("sm_100", "10.0"),
+        ("sm_103a", "10.3"),
+        ("compute_121", "12.1"),
+    ],
+)
+def test_normalize_compute_capability(value, expected) -> None:
+    assert normalize_compute_capability(value) == expected
+
+
+@pytest.mark.parametrize("value", ["", "10", "sm_1", "sm_10.0", (10,), (10, 0, 1), 100, True])
+def test_normalize_compute_capability_rejects_ambiguous_values(value) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        normalize_compute_capability(value)
+
+
+def test_expected_device_contract_is_all_or_nothing_and_normalized() -> None:
+    bare_uuid = GPU_UUID_A.removeprefix("GPU-").upper()
+    expectation = build_device_identity_expectation(bare_uuid, "sm_100")
+    assert expectation == DeviceIdentityExpectation(GPU_UUID_A, "10.0")
+    assert build_device_identity_expectation(None, None) is None
+
+    with pytest.raises(ValueError, match="configured together"):
+        build_device_identity_expectation(GPU_UUID_A, None)
+    with pytest.raises(ValueError, match="configured together"):
+        build_device_identity_expectation(None, "10.0")
+    with pytest.raises(ValueError, match="configured together"):
+        BenchmarkConfig(expected_device_uuid=GPU_UUID_A)
+
+
+def test_benchmark_config_normalizes_and_serializes_expected_device_fields() -> None:
+    config = BenchmarkConfig(
+        expected_device_uuid=GPU_UUID_A.removeprefix("GPU-"),
+        expected_compute_capability="compute_100",
+    )
+    serialized = {
+        key: value
+        for key, value in config.__dict__.items()
+        if not key.startswith("_") and value is not None
+    }
+    assert serialized["expected_device_uuid"] == GPU_UUID_A
+    assert serialized["expected_compute_capability"] == "10.0"
+    assert config.validity.expected_device_uuid == GPU_UUID_A
+    assert config.validity.expected_compute_capability == "10.0"
+
+
+@pytest.mark.parametrize("validity_profile", ["strict", "portable"])
+def test_expected_identity_mismatch_is_hard_failure_in_every_validity_profile(
+    validity_profile: str,
+) -> None:
+    config = BenchmarkConfig(
+        validity_profile=validity_profile,
+        expected_device_uuid=GPU_UUID_A,
+        expected_compute_capability="10.0",
+    )
+    expectation = build_device_identity_expectation(
+        config.expected_device_uuid,
+        config.expected_compute_capability,
+    )
+    observation = DeviceIdentityObservation(
+        logical_index=0,
+        current_logical_index=0,
+        cuda_uuid=GPU_UUID_B,
+        nvml_uuid=GPU_UUID_B,
+        compute_capability="10.0",
+    )
+    with pytest.raises(DeviceIdentityError, match="Expected GPU UUID mismatch"):
+        validate_device_identity(expectation, observation, "before_measurement")
+
+
+def test_validate_device_identity_accepts_matching_cuda_and_nvml_identity() -> None:
+    expectation = DeviceIdentityExpectation(GPU_UUID_A, "10.0")
+    observation = DeviceIdentityObservation(
+        logical_index=1,
+        current_logical_index=1,
+        cuda_uuid=GPU_UUID_A,
+        nvml_uuid=GPU_UUID_A,
+        compute_capability="10.0",
+    )
+    validate_device_identity(expectation, observation, "after_warmup")
+
+
+@pytest.mark.parametrize(
+    ("observation", "message"),
+    [
+        (
+            DeviceIdentityObservation(0, 1, GPU_UUID_A, GPU_UUID_A, "10.0"),
+            "current-device drift",
+        ),
+        (
+            DeviceIdentityObservation(0, 0, GPU_UUID_A, GPU_UUID_B, "10.0"),
+            "CUDA/NVML device identity mismatch",
+        ),
+        (
+            DeviceIdentityObservation(0, 0, GPU_UUID_A, GPU_UUID_A, "9.0"),
+            "Expected compute capability mismatch",
+        ),
+    ],
+)
+def test_validate_device_identity_rejects_each_mismatch(
+    observation: DeviceIdentityObservation,
+    message: str,
+) -> None:
+    with pytest.raises(DeviceIdentityError, match=message):
+        validate_device_identity(
+            DeviceIdentityExpectation(GPU_UUID_A, "10.0"),
+            observation,
+            "after_setup",
+        )
+
+
+def test_validate_device_identity_uses_nvml_when_cuda_uuid_is_unavailable() -> None:
+    observation = DeviceIdentityObservation(
+        logical_index=0,
+        current_logical_index=0,
+        cuda_uuid=None,
+        nvml_uuid=GPU_UUID_A,
+        compute_capability="10.0",
+    )
+    validate_device_identity(
+        DeviceIdentityExpectation(GPU_UUID_A, "10.0"),
+        observation,
+        "before_setup",
+    )
+
+
+class _CpuControlBenchmark(BaseBenchmark):
+    allow_cpu = True
+
+    def setup(self) -> None:
+        self.input = torch.arange(8, dtype=torch.float32)
+
+    def benchmark_fn(self) -> None:
+        self.output = self.input + 1
+
+    def get_input_signature(self):
+        return {"shape": tuple(self.input.shape), "dtype": str(self.input.dtype)}
+
+    def get_verify_inputs(self):
+        return {"input": self.input}
+
+    def get_verify_output(self):
+        return self.output
+
+    def get_output_tolerance(self):
+        return (0.0, 0.0)
+
+
+def test_cpu_harness_path_is_unchanged_by_gpu_identity_expectations() -> None:
+    config = BenchmarkConfig(
+        device=torch.device("cpu"),
+        expected_device_uuid=GPU_UUID_A,
+        expected_compute_capability="10.0",
+        use_subprocess=False,
+        iterations=1,
+        warmup=5,
+        adaptive_iterations=False,
+        enforce_environment_validation=False,
+        clear_compile_cache=False,
+        monitor_backend_policy=False,
+        detect_benchmark_fn_sync=False,
+        detect_benchmark_fn_antipatterns=False,
+    )
+    run = BenchmarkHarness(config=config).benchmark_with_manifest(
+        _CpuControlBenchmark(),
+        run_id="cpu-device-identity-control",
+    )
+    result = run.result
+    assert result.timing.iterations == 1
+    assert not result.errors
+    assert run.manifest.config is not None
+    assert run.manifest.config["expected_device_uuid"] == GPU_UUID_A
+    assert run.manifest.config["expected_compute_capability"] == "10.0"
+
+
+def _live_observation_for_current_device() -> DeviceIdentityObservation:
+    if not torch.cuda.is_available():
+        pytest.skip("real CUDA device identity validation requires a CUDA device")
+    pytest.importorskip("pynvml", reason="real CUDA device identity validation requires pynvml")
+    current = int(torch.cuda.current_device())
+    return observe_cuda_device_identity(torch.device("cuda", current))
+
+
+def test_live_cuda_device_identity_contract_matches_observed_device() -> None:
+    observed = _live_observation_for_current_device()
+    contract = DeviceIdentityContract(
+        torch.device("cuda", observed.logical_index),
+        DeviceIdentityExpectation(observed.nvml_uuid, observed.compute_capability),
+    )
+    contract.establish_configured_device()
+    try:
+        assert contract.check("before_setup") == observed
+        assert contract.check("after_teardown").nvml_uuid == observed.nvml_uuid
+    finally:
+        contract.restore_entry_device()
+
+
+def test_live_cuda_device_identity_contract_rejects_wrong_expected_uuid() -> None:
+    observed = _live_observation_for_current_device()
+    wrong_uuid = GPU_UUID_A if observed.nvml_uuid != GPU_UUID_A else GPU_UUID_B
+    contract = DeviceIdentityContract(
+        torch.device("cuda", observed.logical_index),
+        DeviceIdentityExpectation(wrong_uuid, observed.compute_capability),
+    )
+    contract.establish_configured_device()
+    try:
+        with pytest.raises(DeviceIdentityError, match="Expected GPU UUID mismatch"):
+            contract.check("before_setup")
+    finally:
+        contract.restore_entry_device()
+
+
+def test_live_cuda_device_identity_contract_establishes_and_restores_cuda_one() -> None:
+    observed = _live_observation_for_current_device()
+    if torch.cuda.device_count() < 2:
+        pytest.skip("configured cuda:1 establishment requires two visible CUDA devices")
+    entry_index = observed.current_logical_index
+    target_index = next(index for index in range(torch.cuda.device_count()) if index != entry_index)
+    contract = DeviceIdentityContract(torch.device("cuda", target_index))
+    contract.establish_configured_device()
+    try:
+        target_observation = contract.check("before_setup")
+        assert target_observation.current_logical_index == target_index
+    finally:
+        contract.restore_entry_device()
+    assert torch.cuda.current_device() == entry_index
+
+
+class _CudaSetupDriftBenchmark(BaseBenchmark):
+    def __init__(self, alternate_index: int) -> None:
+        super().__init__()
+        self.alternate_index = alternate_index
+
+    def setup(self) -> None:
+        torch.cuda.set_device(self.alternate_index)
+
+    def benchmark_fn(self) -> None:
+        raise AssertionError("measurement must not run after setup changes the CUDA device")
+
+
+class _CudaSetupMustNotRunBenchmark(BaseBenchmark):
+    def setup(self) -> None:
+        raise AssertionError("setup must not run when declared device identity is wrong")
+
+    def benchmark_fn(self) -> None:
+        raise AssertionError("measurement must not run when declared device identity is wrong")
+
+
+@pytest.mark.parametrize("mismatch", ["uuid", "compute_capability"])
+def test_live_harness_rejects_wrong_identity_before_setup(mismatch: str) -> None:
+    observed = _live_observation_for_current_device()
+    wrong_uuid = GPU_UUID_A if observed.nvml_uuid != GPU_UUID_A else GPU_UUID_B
+    wrong_capability = "9.0" if observed.compute_capability != "9.0" else "10.0"
+    config = BenchmarkConfig(
+        device=torch.device("cuda", observed.logical_index),
+        expected_device_uuid=(wrong_uuid if mismatch == "uuid" else observed.nvml_uuid),
+        expected_compute_capability=(
+            wrong_capability if mismatch == "compute_capability" else observed.compute_capability
+        ),
+        use_subprocess=False,
+        iterations=1,
+        warmup=5,
+        adaptive_iterations=False,
+        enforce_environment_validation=False,
+        lock_gpu_clocks=False,
+        clear_compile_cache=False,
+        monitor_gpu_state=False,
+    )
+    result = BenchmarkHarness(config=config)._benchmark_with_threading(
+        _CudaSetupMustNotRunBenchmark(),
+        config,
+    )
+    assert result.timing.iterations == 0
+    expected_message = (
+        "Expected GPU UUID mismatch"
+        if mismatch == "uuid"
+        else "Expected compute capability mismatch"
+    )
+    assert any(expected_message in error for error in result.errors)
+
+
+def test_live_harness_rejects_setup_device_drift_and_restores_entry_context() -> None:
+    observed = _live_observation_for_current_device()
+    if torch.cuda.device_count() < 2:
+        pytest.skip("real harness context-drift rejection requires two visible CUDA devices")
+    entry_index = observed.current_logical_index
+    alternate_index = next(index for index in range(torch.cuda.device_count()) if index != entry_index)
+    config = BenchmarkConfig(
+        device=torch.device("cuda", entry_index),
+        expected_device_uuid=observed.nvml_uuid,
+        expected_compute_capability=observed.compute_capability,
+        use_subprocess=False,
+        iterations=1,
+        warmup=5,
+        adaptive_iterations=False,
+        enforce_environment_validation=False,
+        lock_gpu_clocks=False,
+        clear_compile_cache=False,
+        monitor_gpu_state=False,
+    )
+    harness = BenchmarkHarness(config=config)
+    result = harness._benchmark_with_threading(
+        _CudaSetupDriftBenchmark(alternate_index),
+        config,
+    )
+    assert result.timing.iterations == 0
+    assert any("CUDA current-device drift at after_setup" in error for error in result.errors)
+    assert torch.cuda.current_device() == entry_index
+
+
+def test_observation_fixture_detects_baseline_identity_drift() -> None:
+    baseline = DeviceIdentityObservation(0, 0, GPU_UUID_A, GPU_UUID_A, "10.0")
+    changed = replace(baseline, compute_capability="10.3")
+    with pytest.raises(DeviceIdentityError, match="CUDA device identity drift"):
+        validate_device_identity_stable(baseline, changed, "after_setup")

--- a/code/tests/test_distributed_work_contract.py
+++ b/code/tests/test_distributed_work_contract.py
@@ -1,0 +1,488 @@
+"""Distributed work-contract controls with an actual CPU/Gloo execution path."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from core.benchmark.distributed_work_contract import (
+    BARRIER_BEFORE_TIMED_CLOSE,
+    DECLARED_ALGORITHM_EVIDENCE,
+    WAIT_FOR_ASYNC_BEFORE_TIMED_CLOSE,
+    DistributedRankWorkReceipt,
+    DistributedWorkRecorder,
+    validate_distributed_work_receipts,
+)
+from core.benchmark.quarantine import QuarantineManager
+from core.benchmark.verification import (
+    DistributedTopology,
+    InputSignature,
+    PrecisionFlags,
+    QuarantineReason,
+    compare_topologies,
+    extract_distributed_topology,
+)
+from core.benchmark.verification_mixin import VerificationPayloadMixin
+from core.benchmark.verify_runner import VerifyConfig, VerifyRunner
+
+
+def _topology(**overrides: object) -> DistributedTopology:
+    values = {
+        "world_size": 2,
+        "ranks": [0, 1],
+        "shards": 2,
+        "per_rank_batch_size": 2,
+        "collective_type": "all_reduce",
+        "collective_algorithm": "ring",
+        "gradient_bucket_bytes": 4096,
+        "barrier_policy": BARRIER_BEFORE_TIMED_CLOSE,
+        "async_completion_policy": WAIT_FOR_ASYNC_BEFORE_TIMED_CLOSE,
+    }
+    values.update(overrides)
+    return DistributedTopology(**values)
+
+
+def _signature(**overrides: object) -> InputSignature:
+    values = {
+        "shapes": {"input": (4,)},
+        "dtypes": {"input": "float32"},
+        "batch_size": 4,
+        "parameter_count": 0,
+        "precision_flags": PrecisionFlags(tf32=False),
+        "world_size": 2,
+        "ranks": [0, 1],
+        "shards": 2,
+        "per_rank_batch_size": 2,
+        "collective_type": "all_reduce",
+        "collective_algorithm": "ring",
+        "gradient_bucket_bytes": 4096,
+        "barrier_policy": BARRIER_BEFORE_TIMED_CLOSE,
+        "async_completion_policy": WAIT_FOR_ASYNC_BEFORE_TIMED_CLOSE,
+    }
+    values.update(overrides)
+    return InputSignature(**values)
+
+
+def _gloo_topology() -> DistributedTopology:
+    # Gloo does not expose ring/tree execution proof through this test. The
+    # declared value intentionally says only that the backend selects it.
+    return _topology(collective_algorithm="backend_selected")
+
+
+@dataclass
+class _WorkloadMetadata:
+    requests_per_iteration: float = 1.0
+    tokens_per_iteration: float | None = None
+    samples_per_iteration: float | None = 4.0
+    bytes_per_iteration: float | None = 16.0
+    custom_units_per_iteration: float | None = None
+
+
+class _CpuPairBenchmark:
+    """Real tensor work used to exercise VerifyRunner's signature cache path."""
+
+    _is_deterministic = True
+
+    def __init__(self, signature: InputSignature) -> None:
+        self._signature = signature
+        self._input = torch.arange(4, dtype=torch.float32)
+        self._output = self._input * 2
+        self._workload = _WorkloadMetadata()
+
+    def setup(self) -> None:
+        self._input = torch.arange(4, dtype=torch.float32)
+
+    def benchmark_fn(self) -> None:
+        self._output = self._input * 2
+
+    def teardown(self) -> None:
+        pass
+
+    def get_input_signature(self) -> InputSignature:
+        return self._signature
+
+    def get_verify_inputs(self) -> dict[str, torch.Tensor]:
+        return {"input": self._input}
+
+    def get_verify_output(self) -> torch.Tensor:
+        return self._output
+
+    def get_output_tolerance(self) -> tuple[float, float]:
+        return (0.0, 0.0)
+
+    def get_workload_metadata(self) -> _WorkloadMetadata:
+        return self._workload
+
+    def validate_result(self) -> None:
+        return None
+
+
+class _MixinCpuPairBenchmark(VerificationPayloadMixin):
+    """Actual CPU tensor work declared through the preferred payload mixin."""
+
+    _is_deterministic = True
+
+    def __init__(self, *, algorithm: str, bucket_bytes: object) -> None:
+        self._algorithm = algorithm
+        self._bucket_bytes = bucket_bytes
+        self._input = torch.arange(4, dtype=torch.float32)
+        self._output = self._input * 2
+        self._workload = _WorkloadMetadata()
+
+    def setup(self) -> None:
+        self._input = torch.arange(4, dtype=torch.float32)
+
+    def benchmark_fn(self) -> None:
+        self._output = self._input * 2
+
+    def capture_verification_payload(self) -> None:
+        self._set_verification_payload(
+            inputs={"input": self._input},
+            output=self._output,
+            batch_size=4,
+            precision_flags=PrecisionFlags(tf32=False),
+            output_tolerance=(0.0, 0.0),
+            signature_overrides={
+                "world_size": 2,
+                "ranks": [0, 1],
+                "shards": 2,
+                "per_rank_batch_size": 2,
+                "collective_type": "all_reduce",
+                "collective_algorithm": self._algorithm,
+                "gradient_bucket_bytes": self._bucket_bytes,
+                "barrier_policy": BARRIER_BEFORE_TIMED_CLOSE,
+                "async_completion_policy": WAIT_FOR_ASYNC_BEFORE_TIMED_CLOSE,
+            },
+        )
+
+    def teardown(self) -> None:
+        pass
+
+    def get_workload_metadata(self) -> _WorkloadMetadata:
+        return self._workload
+
+    def validate_result(self) -> None:
+        return None
+
+
+def _receipt(rank: int, **overrides: object) -> DistributedRankWorkReceipt:
+    values = {
+        "rank": rank,
+        "world_size": 2,
+        "backend": "gloo",
+        "collective_type": "all_reduce",
+        "declared_collective_algorithm": "ring",
+        "gradient_bucket_bytes": 4096,
+        "barrier_policy": BARRIER_BEFORE_TIMED_CLOSE,
+        "async_completion_policy": WAIT_FOR_ASYNC_BEFORE_TIMED_CLOSE,
+        "timed_region_start_ns": 100,
+        "collective_launch_ns": (110,),
+        "collective_completion_ns": (130,),
+        "barrier_entry_ns": 140,
+        "barrier_completion_ns": 150,
+        "timed_region_close_ns": 160,
+    }
+    values.update(overrides)
+    return DistributedRankWorkReceipt(**values)
+
+
+def test_distributed_signature_round_trip_and_undeclared_compatibility() -> None:
+    declared = _signature()
+    restored = InputSignature.from_dict(declared.to_dict())
+    assert restored == declared
+    assert extract_distributed_topology(restored) == _topology()
+    assert declared.validate(strict=True) == []
+
+    undeclared = _signature(
+        collective_algorithm=None,
+        gradient_bucket_bytes=None,
+        barrier_policy=None,
+        async_completion_policy=None,
+    )
+    payload = undeclared.to_dict()
+    assert "collective_algorithm" not in payload
+    assert "gradient_bucket_bytes" not in payload
+    assert "barrier_policy" not in payload
+    assert "async_completion_policy" not in payload
+    assert InputSignature.from_dict(payload) == undeclared
+
+
+@pytest.mark.parametrize(
+    ("field_name", "optimized_value", "diagnostic"),
+    [
+        ("ranks", [1, 0], "Ranks mismatch"),
+        ("per_rank_batch_size", 1, "Per-rank batch size mismatch"),
+        ("collective_type", "all_gather", "Collective type mismatch"),
+        ("collective_algorithm", "tree", "Collective algorithm mismatch"),
+        ("gradient_bucket_bytes", 8192, "Gradient bucket bytes mismatch"),
+        ("barrier_policy", None, "Barrier policy mismatch"),
+        ("async_completion_policy", None, "Async completion policy mismatch"),
+    ],
+)
+def test_compare_topologies_checks_every_distributed_work_field(
+    field_name: str,
+    optimized_value: object,
+    diagnostic: str,
+) -> None:
+    match, reason = compare_topologies(
+        _topology(),
+        _topology(**{field_name: optimized_value}),
+    )
+    assert not match
+    assert reason is not None and diagnostic in reason
+
+
+@pytest.mark.parametrize(
+    ("optimized_overrides", "mismatch_path"),
+    [
+        ({"collective_algorithm": "tree"}, "collective_algorithm"),
+        ({"gradient_bucket_bytes": 8192}, "gradient_bucket_bytes"),
+    ],
+)
+def test_verify_runner_rejects_distributed_contract_mismatch(
+    tmp_path: Path,
+    optimized_overrides: dict[str, object],
+    mismatch_path: str,
+) -> None:
+    runner = VerifyRunner(
+        cache_dir=tmp_path / "cache",
+        quarantine_manager=QuarantineManager(tmp_path / "quarantine.json"),
+    )
+    result = runner.verify_pair(
+        _CpuPairBenchmark(_signature()),
+        _CpuPairBenchmark(_signature(**optimized_overrides)),
+        VerifyConfig(skip_jitter_check=True, skip_fresh_input_check=True),
+    )
+    assert not result.passed
+    assert result.reason == QuarantineReason.SIGNATURE_MISMATCH.value
+    assert mismatch_path in result.details["signature_mismatches"]
+
+
+def test_verify_runner_accepts_matching_declared_distributed_contract(
+    tmp_path: Path,
+) -> None:
+    runner = VerifyRunner(
+        cache_dir=tmp_path / "cache",
+        quarantine_manager=QuarantineManager(tmp_path / "quarantine.json"),
+    )
+    result = runner.verify_pair(
+        _CpuPairBenchmark(_signature()),
+        _CpuPairBenchmark(_signature()),
+        VerifyConfig(skip_jitter_check=True, skip_fresh_input_check=True),
+    )
+    assert result.passed
+
+
+@pytest.mark.parametrize(
+    ("optimized_algorithm", "optimized_bucket", "mismatch_path"),
+    [
+        ("tree", "4096", "collective_algorithm"),
+        ("ring", 8192, "gradient_bucket_bytes"),
+    ],
+)
+def test_payload_mixin_reaches_real_signature_comparison_path(
+    tmp_path: Path,
+    optimized_algorithm: str,
+    optimized_bucket: object,
+    mismatch_path: str,
+) -> None:
+    runner = VerifyRunner(
+        cache_dir=tmp_path / "cache",
+        quarantine_manager=QuarantineManager(tmp_path / "quarantine.json"),
+    )
+    result = runner.verify_pair(
+        _MixinCpuPairBenchmark(algorithm="ring", bucket_bytes="4096"),
+        _MixinCpuPairBenchmark(
+            algorithm=optimized_algorithm,
+            bucket_bytes=optimized_bucket,
+        ),
+        VerifyConfig(skip_jitter_check=True, skip_fresh_input_check=True),
+    )
+    assert not result.passed
+    assert result.reason == QuarantineReason.SIGNATURE_MISMATCH.value
+    assert mismatch_path in result.details["signature_mismatches"]
+
+
+def test_payload_mixin_rejects_boolean_bucket_size() -> None:
+    benchmark = _MixinCpuPairBenchmark(algorithm="ring", bucket_bytes=True)
+    benchmark.setup()
+    benchmark.benchmark_fn()
+    with pytest.raises(TypeError, match="gradient_bucket_bytes.*not bool"):
+        benchmark.capture_verification_payload()
+
+
+@pytest.mark.parametrize(
+    ("overrides", "diagnostic"),
+    [
+        ({"collective_algorithm": ""}, "collective_algorithm"),
+        ({"collective_algorithm": "ring", "collective_type": None}, "collective_type"),
+        ({"gradient_bucket_bytes": 0}, "gradient_bucket_bytes"),
+        ({"barrier_policy": "outside_timing"}, "barrier_policy"),
+        ({"async_completion_policy": "fire_and_forget"}, "async_completion_policy"),
+        ({"world_size": 1}, "world_size > 1"),
+    ],
+)
+def test_input_signature_rejects_invalid_declared_distributed_contract(
+    overrides: dict[str, object],
+    diagnostic: str,
+) -> None:
+    errors = _signature(**overrides).validate(strict=True)
+    assert any(diagnostic in error for error in errors)
+
+
+def test_receipt_round_trip_requires_every_evidence_field() -> None:
+    receipt = _receipt(0)
+    assert DistributedRankWorkReceipt.from_dict(receipt.to_dict()) == receipt
+    incomplete = receipt.to_dict()
+    del incomplete["barrier_completion_ns"]
+    with pytest.raises(ValueError, match="barrier_completion_ns"):
+        DistributedRankWorkReceipt.from_dict(incomplete)
+
+
+def test_receipt_validator_clean_control_and_algorithm_boundary() -> None:
+    validation = validate_distributed_work_receipts(
+        _topology(),
+        [_receipt(0), _receipt(1)],
+        expected_backend="gloo",
+    )
+    assert validation.passed
+    assert validation.errors == ()
+    assert validation.backend == "gloo"
+    assert validation.collective_algorithm_evidence == DECLARED_ALGORITHM_EVIDENCE
+
+
+@pytest.mark.parametrize(
+    ("receipts", "diagnostic"),
+    [
+        ([_receipt(0)], "missing receipts from ranks [1]"),
+        (
+            [_receipt(0), _receipt(1, collective_completion_ns=())],
+            "asynchronous collectives incomplete",
+        ),
+        (
+            [_receipt(0), _receipt(1, barrier_completion_ns=170)],
+            "barrier must enter and complete before timed-region close",
+        ),
+        (
+            [_receipt(0), _receipt(1, collective_completion_ns=(145,))],
+            "was not observed complete before the final barrier",
+        ),
+        (
+            [_receipt(0), _receipt(1, declared_collective_algorithm="tree")],
+            "declared_collective_algorithm mismatch",
+        ),
+    ],
+)
+def test_receipt_validator_rejects_incomplete_or_late_evidence(
+    receipts: list[DistributedRankWorkReceipt],
+    diagnostic: str,
+) -> None:
+    validation = validate_distributed_work_receipts(
+        _topology(),
+        receipts,
+        expected_backend="gloo",
+    )
+    assert not validation.passed
+    assert any(diagnostic in error for error in validation.errors)
+    with pytest.raises(RuntimeError, match="DISTRIBUTED WORK RECEIPT INVALID"):
+        validation.raise_for_failure()
+
+
+def test_recorder_refuses_to_close_before_async_completion_or_barrier() -> None:
+    recorder = DistributedWorkRecorder(_topology(), rank=0, backend="gloo")
+    recorder.begin_timed_region()
+    with pytest.raises(RuntimeError, match="no asynchronous collective work"):
+        recorder.close_timed_region()
+
+
+def _gloo_receipt_worker(
+    rank: int,
+    world_size: int,
+    rendezvous: str,
+    output_dir: str,
+) -> None:
+    torch.set_num_threads(1)
+    dist.init_process_group(
+        "gloo",
+        init_method=rendezvous,
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=15),
+    )
+    try:
+        topology = _gloo_topology()
+        recorder = DistributedWorkRecorder(topology, rank=rank, backend="gloo")
+        value = torch.full((1024,), float(rank + 1), dtype=torch.float32)
+        assert value.numel() * value.element_size() == topology.gradient_bucket_bytes
+        recorder.begin_timed_region()
+        work = dist.all_reduce(value, async_op=True)
+        recorder.record_async_collective(work)
+        recorder.wait_for_async_collectives()
+        torch.testing.assert_close(
+            value,
+            torch.full_like(value, 3.0),
+            rtol=0,
+            atol=0,
+        )
+        recorder.run_final_barrier(dist.barrier)
+        receipt = recorder.close_timed_region()
+        Path(output_dir, f"rank-{rank}.json").write_text(
+            json.dumps(
+                {
+                    "receipt": receipt.to_dict(),
+                    "output_elements_verified": value.numel(),
+                },
+                sort_keys=True,
+            )
+            + "\n"
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(
+    not dist.is_available() or not dist.is_gloo_available(),
+    reason="Actual Gloo backend required",
+)
+def test_actual_two_rank_gloo_async_completion_and_barrier_receipts(
+    tmp_path: Path,
+) -> None:
+    context = mp.spawn(
+        _gloo_receipt_worker,
+        args=(2, f"file://{tmp_path / 'gloo-store'}", str(tmp_path)),
+        nprocs=2,
+        join=False,
+    )
+    deadline = time.monotonic() + 30
+    try:
+        while not context.join(timeout=2):
+            if time.monotonic() >= deadline:
+                pytest.fail("Actual two-rank Gloo receipt control exceeded 30 seconds")
+    finally:
+        for process in context.processes:
+            if process.is_alive():
+                process.terminate()
+        for process in context.processes:
+            process.join(timeout=2)
+            if process.is_alive():
+                process.kill()
+                process.join(timeout=2)
+
+    payloads = [json.loads((tmp_path / f"rank-{rank}.json").read_text()) for rank in range(2)]
+    assert [payload["output_elements_verified"] for payload in payloads] == [1024, 1024]
+    receipts = [DistributedRankWorkReceipt.from_dict(payload["receipt"]) for payload in payloads]
+    validation = validate_distributed_work_receipts(
+        _gloo_topology(),
+        receipts,
+        expected_backend="gloo",
+    )
+    assert validation.passed, validation.errors
+    assert validation.collective_algorithm_evidence == DECLARED_ALGORITHM_EVIDENCE

--- a/code/tests/test_evaluation_harness_integration.py
+++ b/code/tests/test_evaluation_harness_integration.py
@@ -1,0 +1,232 @@
+"""Real CPU lifecycle coverage for opt-in evaluation provenance."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import torch
+
+from core.benchmark.evaluation_provenance import (
+    DatasetDeclaration,
+    EvaluationContract,
+    EvaluatorDeclaration,
+    FeatureLineage,
+)
+from core.harness.benchmark_harness import (
+    BaseBenchmark,
+    BenchmarkConfig,
+    BenchmarkHarness,
+    BenchmarkMode,
+    ExecutionMode,
+)
+
+
+class EvaluationLifecycleBenchmark(BaseBenchmark):
+    """Importable CPU benchmark used by both thread and isolated-process tests."""
+
+    allow_cpu = True
+    allowed_benchmark_fn_antipatterns = ("io",)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.device = torch.device("cpu")
+        self.protected_path = ""
+        self.mutation_phase = "none"
+        self.failure_phase = "none"
+        self.threshold = 0.5
+        self.mutation_done = False
+        self.benchmark_calls = 0
+        self.input_tensor: Optional[torch.Tensor] = None
+        self.output: Optional[torch.Tensor] = None
+
+    def _mutate_if_requested(self, phase: str) -> None:
+        if self.mutation_done or not self.mutation_phase.startswith(phase):
+            return
+        if self.mutation_phase.endswith("source"):
+            Path(self.protected_path).write_text("changed during evaluation\n", encoding="utf-8")
+        elif self.mutation_phase.endswith("threshold"):
+            self.threshold = 0.75
+        else:  # pragma: no cover - test fixture configuration guard
+            raise AssertionError(f"unknown mutation: {self.mutation_phase}")
+        self.mutation_done = True
+
+    def setup(self) -> None:
+        self.input_tensor = torch.tensor([1.0], device=self.device)
+        self._mutate_if_requested("setup")
+        if self.failure_phase == "setup":
+            raise RuntimeError("intentional setup failure")
+
+    def benchmark_fn(self) -> torch.Tensor:
+        if self.input_tensor is None:
+            raise RuntimeError("setup() must initialize input_tensor")
+        self.benchmark_calls += 1
+        if self.benchmark_calls > 5:
+            self._mutate_if_requested("timing")
+            if self.failure_phase == "timing":
+                raise RuntimeError("intentional timing failure")
+        self.output = self.input_tensor + 1.0
+        return self.output
+
+    def teardown(self) -> None:
+        self._mutate_if_requested("teardown")
+        if self.failure_phase == "teardown":
+            raise RuntimeError("intentional teardown failure")
+
+    def validate_result(self) -> Optional[str]:
+        return None
+
+    def get_verify_inputs(self) -> dict[str, torch.Tensor]:
+        if self.input_tensor is None:
+            raise RuntimeError("setup() must initialize input_tensor")
+        return {"input": self.input_tensor}
+
+    def get_verify_output(self) -> torch.Tensor:
+        if self.output is None:
+            raise RuntimeError("benchmark_fn() must set output")
+        return self.output
+
+    def get_output_tolerance(self) -> tuple[float, float]:
+        return (0.0, 0.0)
+
+    def get_input_signature(self) -> dict[str, object]:
+        return {"shape": (1,), "dtype": "torch.float32"}
+
+    def get_evaluation_contract(self) -> Optional[EvaluationContract]:
+        if not self.protected_path:
+            return None
+        return EvaluationContract(
+            dataset=DatasetDeclaration(
+                name="cpu-fixture",
+                version="1",
+                content_sha256="0" * 64,
+            ),
+            sample_ids_by_split={
+                "train": ("train-1",),
+                "test": ("test-1",),
+                "holdout": ("holdout-1",),
+            },
+            evaluator=EvaluatorDeclaration(
+                name="accuracy",
+                version="1",
+                thresholds={"minimum": self.threshold},
+            ),
+            feature_lineage=(
+                FeatureLineage(feature="value", source_fields=("value",)),
+            ),
+            label_fields=("label",),
+            protected_sources=(Path(self.protected_path),),
+        )
+
+
+def _harness(*, subprocess_mode: bool = False) -> BenchmarkHarness:
+    execution_mode = ExecutionMode.SUBPROCESS if subprocess_mode else ExecutionMode.THREAD
+    config = BenchmarkConfig(
+        device=torch.device("cpu"),
+        iterations=2,
+        warmup=5,
+        use_subprocess=subprocess_mode,
+        execution_mode=execution_mode,
+        enable_profiling=False,
+        enable_memory_tracking=False,
+        enable_cleanup=False,
+        lock_gpu_clocks=False,
+        enforce_environment_validation=False,
+        detect_setup_precomputation=False,
+        adaptive_iterations=False,
+        clear_compile_cache=False,
+        measurement_timeout_seconds=15,
+    )
+    return BenchmarkHarness(mode=BenchmarkMode.CUSTOM, config=config)
+
+
+def _benchmark(tmp_path: Path, mutation_phase: str = "none") -> EvaluationLifecycleBenchmark:
+    protected = tmp_path / "protected_source.py"
+    protected.write_text("stable source\n", encoding="utf-8")
+    benchmark = EvaluationLifecycleBenchmark()
+    benchmark.protected_path = str(protected)
+    benchmark.mutation_phase = mutation_phase
+    return benchmark
+
+
+def test_thread_lifecycle_serializes_pass_receipt_into_result_and_manifest(tmp_path: Path) -> None:
+    run = _harness().benchmark_with_manifest(_benchmark(tmp_path), run_id="evaluation-pass")
+
+    assert run.result.evaluation is not None
+    assert run.result.evaluation.status == "PASS"
+    assert run.result.evaluation.finalized_at is not None
+    assert run.manifest is not None
+    assert run.manifest.evaluation is not None
+    assert run.manifest.evaluation.model_dump(mode="json") == run.result.evaluation.model_dump(mode="json")
+    payload = run.model_dump(mode="json")
+    assert payload["result"]["evaluation"]["status"] == "PASS"
+    assert payload["manifest"]["evaluation"]["status"] == "PASS"
+
+
+def test_default_benchmark_path_keeps_evaluation_provenance_absent() -> None:
+    benchmark = EvaluationLifecycleBenchmark()
+    run = _harness().benchmark_with_manifest(benchmark, run_id="evaluation-absent")
+
+    assert run.result.evaluation is None
+    assert run.manifest is not None
+    assert run.manifest.evaluation is None
+
+
+def test_setup_source_mutation_rejects_timing_result(tmp_path: Path) -> None:
+    result = _harness().benchmark(_benchmark(tmp_path, "setup_source"))
+
+    assert result.evaluation is not None
+    assert result.evaluation.status == "FAIL"
+    assert result.timing.iterations == 0
+    assert "protected_source_mutated" in {failure.code for failure in result.evaluation.failures}
+
+
+def test_timed_threshold_mutation_rejects_timing_result(tmp_path: Path) -> None:
+    benchmark = _benchmark(tmp_path, "timing_threshold")
+    result = _harness().benchmark(benchmark)
+
+    assert benchmark.benchmark_calls > 5
+    assert result.evaluation is not None
+    assert result.evaluation.status == "FAIL"
+    assert result.timing.iterations == 0
+    failure_codes = {failure.code for failure in result.evaluation.failures}
+    assert {"evaluator_threshold_drift", "evaluation_contract_drift"} <= failure_codes
+
+
+def test_teardown_source_mutation_rejects_timing_result(tmp_path: Path) -> None:
+    result = _harness().benchmark(_benchmark(tmp_path, "teardown_source"))
+
+    assert result.evaluation is not None
+    assert result.evaluation.status == "FAIL"
+    assert result.timing.iterations == 0
+    assert "protected_source_mutated" in {failure.code for failure in result.evaluation.failures}
+
+
+def test_teardown_failure_still_finalizes_source_mutation_receipt(tmp_path: Path) -> None:
+    benchmark = _benchmark(tmp_path, "teardown_source")
+    benchmark.failure_phase = "teardown"
+    result = _harness().benchmark(benchmark)
+
+    assert result.evaluation is not None
+    assert result.evaluation.finalized_at is not None
+    assert result.evaluation.status == "FAIL"
+    assert "protected_source_mutated" in {failure.code for failure in result.evaluation.failures}
+    assert any("Teardown failed: intentional teardown failure" in error for error in result.errors)
+
+
+def test_subprocess_worker_detects_drift_and_transports_receipt_to_manifest(tmp_path: Path) -> None:
+    benchmark = _benchmark(tmp_path, "timing_threshold")
+    run = _harness(subprocess_mode=True).benchmark_with_manifest(
+        benchmark,
+        run_id="evaluation-subprocess-fail",
+    )
+
+    assert benchmark.threshold == 0.5
+    assert run.result.evaluation is not None
+    assert run.result.evaluation.status == "FAIL"
+    assert run.result.timing.iterations == 0
+    failure_codes = {failure.code for failure in run.result.evaluation.failures}
+    assert {"evaluator_threshold_drift", "evaluation_contract_drift"} <= failure_codes
+    assert run.manifest is not None
+    assert run.manifest.evaluation is not None
+    assert run.manifest.evaluation.model_dump(mode="json") == run.result.evaluation.model_dump(mode="json")

--- a/code/tests/test_evaluation_provenance.py
+++ b/code/tests/test_evaluation_provenance.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from core.benchmark.evaluation_provenance import (
+    DatasetDeclaration,
+    EvaluationContract,
+    EvaluationProvenanceError,
+    EvaluatorDeclaration,
+    FeatureLineage,
+    TemporalSplitBoundary,
+    finalize_evaluation,
+    start_evaluation,
+)
+from core.benchmark.run_manifest import (
+    EnvironmentInfo,
+    GitInfo,
+    HardwareInfo,
+    RunManifest,
+    SoftwareInfo,
+)
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _contract(
+    protected_source: Path,
+    *,
+    sample_ids_by_split: dict[str, tuple[str, ...]] | None = None,
+    thresholds: dict[str, float] | None = None,
+    split_strategy: str = "temporal",
+    temporal_boundaries: tuple[TemporalSplitBoundary, ...] | None = None,
+) -> EvaluationContract:
+    boundaries = temporal_boundaries
+    if boundaries is None:
+        boundaries = (
+            TemporalSplitBoundary(
+                split="train",
+                start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                end=datetime(2024, 2, 1, tzinfo=timezone.utc),
+            ),
+            TemporalSplitBoundary(
+                split="test",
+                start=datetime(2024, 2, 1, tzinfo=timezone.utc),
+                end=datetime(2024, 3, 1, tzinfo=timezone.utc),
+            ),
+            TemporalSplitBoundary(
+                split="holdout",
+                start=datetime(2024, 3, 1, tzinfo=timezone.utc),
+                end=datetime(2024, 4, 1, tzinfo=timezone.utc),
+            ),
+        )
+    return EvaluationContract(
+        dataset=DatasetDeclaration(
+            name="fraud-events",
+            version="2024-04",
+            content_sha256=_sha256(b"declared dataset fixture"),
+        ),
+        sample_ids_by_split=sample_ids_by_split
+        or {
+            "train": ("train-001", "train-002"),
+            "test": ("test-001",),
+            "holdout": ("holdout-001",),
+        },
+        required_holdout=True,
+        split_strategy=split_strategy,
+        temporal_boundaries=boundaries,
+        evaluator=EvaluatorDeclaration(
+            name="binary-classification",
+            version="2",
+            thresholds=thresholds or {"minimum_accuracy": 0.90, "maximum_fpr": 0.05},
+        ),
+        feature_lineage=(
+            FeatureLineage(
+                feature="account_age_days",
+                source_fields=("account_created_at", "event_at"),
+                transforms=("elapsed_days",),
+            ),
+        ),
+        label_fields=("is_fraud",),
+        protected_sources=(protected_source,),
+    )
+
+
+def _manifest() -> RunManifest:
+    return RunManifest(
+        hardware=HardwareInfo(),
+        software=SoftwareInfo(
+            pytorch_version="test-runtime",
+            python_version="test-runtime",
+            os="test-runtime",
+        ),
+        environment=EnvironmentInfo(cuda_visible_devices=""),
+        git=GitInfo(commit="a" * 40, branch="test", dirty=False),
+        start_time=datetime.now(),
+    )
+
+
+def _failure_codes(receipt) -> set[str]:
+    return {failure.code for failure in receipt.failures}
+
+
+def test_clean_evaluation_serializes_counts_and_digests_without_sample_ids(
+    tmp_path: Path,
+) -> None:
+    protected = tmp_path / "holdout.jsonl"
+    protected.write_text('{"sample": 1}\n', encoding="utf-8")
+    contract = _contract(protected)
+
+    receipt = start_evaluation(contract)
+    assert receipt.status == "PENDING"
+    receipt.raise_for_failures()
+    receipt = finalize_evaluation(receipt, contract)
+    receipt.raise_for_failures()
+
+    assert receipt.status == "PASS"
+    assert receipt.protected_sources_before == receipt.protected_sources_after
+    assert {split.split: split.sample_count for split in receipt.splits} == {
+        "holdout": 1,
+        "test": 1,
+        "train": 2,
+    }
+    payload = json.dumps(receipt.model_dump(mode="json"), sort_keys=True)
+    for raw_sample_id in ("train-001", "train-002", "test-001", "holdout-001"):
+        assert raw_sample_id not in payload
+    assert "content_hashes_do_not_detect_semantic_dataset_contamination" in payload
+
+
+def test_one_sample_overlap_is_a_structured_start_failure(tmp_path: Path) -> None:
+    protected = tmp_path / "holdout.jsonl"
+    protected.write_text("immutable\n", encoding="utf-8")
+    contract = _contract(
+        protected,
+        sample_ids_by_split={
+            "train": ("train-001", "shared-secret-id"),
+            "test": ("shared-secret-id",),
+            "holdout": ("holdout-001",),
+        },
+    )
+
+    receipt = start_evaluation(contract)
+
+    assert receipt.status == "FAIL"
+    assert "sample_id_overlap" in _failure_codes(receipt)
+    assert "shared-secret-id" not in json.dumps(receipt.model_dump(mode="json"))
+    with pytest.raises(EvaluationProvenanceError, match="sample_id_overlap"):
+        receipt.raise_for_failures()
+
+
+def test_required_holdout_and_temporal_boundary_are_enforced(tmp_path: Path) -> None:
+    protected = tmp_path / "holdout.jsonl"
+    protected.write_text("immutable\n", encoding="utf-8")
+    contract = _contract(
+        protected,
+        sample_ids_by_split={"train": ("a",), "test": ("b",)},
+        temporal_boundaries=(
+            TemporalSplitBoundary(
+                split="train",
+                start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                end=datetime(2024, 2, 1, tzinfo=timezone.utc),
+            ),
+            TemporalSplitBoundary(
+                split="test",
+                start=datetime(2024, 2, 1, tzinfo=timezone.utc),
+                end=datetime(2024, 3, 1, tzinfo=timezone.utc),
+            ),
+        ),
+    )
+
+    receipt = start_evaluation(contract)
+
+    assert {"required_holdout_missing", "temporal_boundary_missing"}.issubset(
+        _failure_codes(receipt)
+    )
+
+
+def test_overlapping_temporal_boundaries_are_rejected(tmp_path: Path) -> None:
+    protected = tmp_path / "holdout.jsonl"
+    protected.write_text("immutable\n", encoding="utf-8")
+    contract = _contract(
+        protected,
+        temporal_boundaries=(
+            TemporalSplitBoundary(
+                split="train",
+                start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                end=datetime(2024, 3, 1, tzinfo=timezone.utc),
+            ),
+            TemporalSplitBoundary(
+                split="test",
+                start=datetime(2024, 2, 1, tzinfo=timezone.utc),
+                end=datetime(2024, 4, 1, tzinfo=timezone.utc),
+            ),
+            TemporalSplitBoundary(
+                split="holdout",
+                start=datetime(2024, 4, 1, tzinfo=timezone.utc),
+                end=datetime(2024, 5, 1, tzinfo=timezone.utc),
+            ),
+        ),
+    )
+
+    receipt = start_evaluation(contract)
+
+    assert "temporal_split_overlap" in _failure_codes(receipt)
+
+
+def test_evaluator_threshold_drift_is_rejected_at_finalize(tmp_path: Path) -> None:
+    protected = tmp_path / "holdout.jsonl"
+    protected.write_text("immutable\n", encoding="utf-8")
+    original = _contract(protected)
+    changed = _contract(
+        protected,
+        thresholds={"minimum_accuracy": 0.80, "maximum_fpr": 0.05},
+    )
+
+    receipt = finalize_evaluation(start_evaluation(original), changed)
+
+    assert receipt.status == "FAIL"
+    assert {"evaluator_threshold_drift", "evaluation_contract_drift"}.issubset(
+        _failure_codes(receipt)
+    )
+
+
+def test_declared_feature_label_overlap_is_rejected_without_claiming_inference(
+    tmp_path: Path,
+) -> None:
+    protected = tmp_path / "holdout.jsonl"
+    protected.write_text("immutable\n", encoding="utf-8")
+    clean = _contract(protected)
+    contract = clean.model_copy(
+        update={
+            "feature_lineage": (
+                FeatureLineage(feature="leaked_label", source_fields=("is_fraud",)),
+            )
+        }
+    )
+
+    receipt = start_evaluation(contract)
+
+    assert "feature_label_lineage_overlap" in _failure_codes(receipt)
+    assert (
+        "feature_lineage_is_workload_declared_not_independently_inferred"
+        in receipt.limitations
+    )
+
+
+def test_protected_source_mutation_is_rejected_at_finalize(tmp_path: Path) -> None:
+    protected = tmp_path / "holdout.jsonl"
+    protected.write_text("before\n", encoding="utf-8")
+    contract = _contract(protected)
+    receipt = start_evaluation(contract)
+
+    protected.write_text("after with different content\n", encoding="utf-8")
+    receipt = finalize_evaluation(receipt, contract)
+
+    assert receipt.status == "FAIL"
+    assert "protected_source_mutated" in _failure_codes(receipt)
+    assert receipt.protected_sources_before[0].sha256 != receipt.protected_sources_after[0].sha256
+
+
+def test_removed_contract_is_rejected_and_manifest_serializes_receipt(
+    tmp_path: Path,
+) -> None:
+    protected = tmp_path / "holdout.jsonl"
+    protected.write_text("immutable\n", encoding="utf-8")
+    manifest = _manifest()
+    manifest.begin_evaluation(_contract(protected)).raise_for_failures()
+
+    receipt = manifest.finalize_evaluation(None)
+
+    assert receipt is not None
+    assert receipt.status == "FAIL"
+    assert "evaluation_contract_missing_at_finalize" in _failure_codes(receipt)
+    serialized = manifest.model_dump(mode="json")
+    assert serialized["evaluation"]["status"] == "FAIL"
+
+
+def test_manifest_finalize_fail_closes_unfinished_evaluation(tmp_path: Path) -> None:
+    protected = tmp_path / "holdout.jsonl"
+    protected.write_text("immutable\n", encoding="utf-8")
+    manifest = _manifest()
+    manifest.begin_evaluation(_contract(protected)).raise_for_failures()
+
+    manifest.finalize()
+
+    assert manifest.evaluation is not None
+    assert "evaluation_contract_missing_at_finalize" in _failure_codes(manifest.evaluation)
+
+
+def test_kernel_manifest_has_no_invented_evaluation_semantics() -> None:
+    manifest = _manifest()
+
+    manifest.finalize()
+
+    assert manifest.evaluation is None
+    assert manifest.model_dump(mode="json")["evaluation"] is None
+
+
+def test_protected_source_symlink_is_rejected(tmp_path: Path) -> None:
+    protected = tmp_path / "holdout.jsonl"
+    protected.write_text("immutable\n", encoding="utf-8")
+    alias = tmp_path / "holdout-link.jsonl"
+    alias.symlink_to(protected)
+
+    receipt = start_evaluation(_contract(alias))
+
+    assert receipt.status == "FAIL"
+    assert "protected_source_unavailable" in _failure_codes(receipt)

--- a/code/tests/test_evaluation_verify_runner.py
+++ b/code/tests/test_evaluation_verify_runner.py
@@ -1,0 +1,145 @@
+"""Exercise evaluation provenance through actual CPU verification work."""
+
+from dataclasses import dataclass
+import hashlib
+from pathlib import Path
+
+import pytest
+import torch
+
+from core.benchmark.evaluation_provenance import (
+    DatasetDeclaration,
+    EvaluationContract,
+    EvaluatorDeclaration,
+    FeatureLineage,
+)
+from core.benchmark.quarantine import QuarantineManager
+from core.benchmark.verification import InputSignature, PrecisionFlags
+from core.benchmark.verify_runner import VerifyRunner
+
+
+@dataclass
+class Workload:
+    requests_per_iteration: float = 1.0
+    samples_per_iteration: float = 4.0
+    bytes_per_iteration: float = 16.0
+    tokens_per_iteration: float | None = None
+    custom_units_per_iteration: float | None = None
+
+
+class EvaluationBenchmark:
+    _is_deterministic = True
+
+    def __init__(self, source: Path, mutation: str | None = None):
+        self.source = source
+        self.mutation = mutation
+        self.ran = False
+        self.torn_down = False
+        self.contract = EvaluationContract(
+            dataset=DatasetDeclaration(
+                name="tensor-evaluation", version="1",
+                content_sha256=hashlib.sha256(b"tensor-evaluation-v1").hexdigest(),
+            ),
+            sample_ids_by_split={"train": ("a",), "test": ("b",), "holdout": ("c",)},
+            split_strategy="explicit_ids",
+            evaluator=EvaluatorDeclaration(name="exact", version="1", thresholds={"accuracy": 1.0}),
+            feature_lineage=(FeatureLineage(feature="input", source_fields=("input",)),),
+            label_fields=("expected",),
+            protected_sources=(source,),
+        )
+
+    def get_evaluation_contract(self):
+        if self.ran and self.mutation == "getter":
+            raise RuntimeError("evaluation getter failed after execution")
+        return self.contract
+
+    def setup(self):
+        self.inputs = torch.arange(4, dtype=torch.float32)
+
+    def benchmark_fn(self):
+        self.output = self.inputs * 2
+        self.ran = True
+        if self.mutation == "threshold":
+            self.contract.evaluator.thresholds["accuracy"] = 0.1
+        elif self.mutation == "source":
+            self.source.write_text("changed during execution\n")
+        elif self.mutation == "removed":
+            self.contract = None
+
+    def teardown(self):
+        self.torn_down = True
+        if self.mutation == "teardown":
+            self.source.write_text("changed during teardown\n")
+
+    def get_input_signature(self):
+        return InputSignature(
+            shapes={"input": (4,)}, dtypes={"input": "float32"},
+            batch_size=4, parameter_count=0, precision_flags=PrecisionFlags(tf32=False),
+        )
+
+    def get_verify_inputs(self):
+        if not hasattr(self, "inputs"):
+            raise RuntimeError("Run setup() before extracting evaluation inputs")
+        return {"input": self.inputs}
+
+    def get_verify_output(self):
+        if not self.ran:
+            raise RuntimeError("Run benchmark_fn() before extracting evaluation output")
+        return self.output
+
+    def get_output_tolerance(self):
+        return 0.0, 0.0
+
+    def get_workload_metadata(self):
+        return Workload()
+
+    def validate_result(self):
+        assert torch.equal(self.output, self.inputs * 2)
+
+
+def _case(tmp_path, mutation=None):
+    source = tmp_path / "protected.py"
+    source.write_text("THRESHOLD = 1.0\n")
+    benchmark = EvaluationBenchmark(source, mutation)
+    runner = VerifyRunner(
+        cache_dir=tmp_path / "cache",
+        quarantine_manager=QuarantineManager(tmp_path / "quarantine.json"),
+    )
+    return runner, benchmark
+
+
+def test_real_verification_records_finalized_provenance(tmp_path):
+    runner, benchmark = _case(tmp_path)
+    result = runner.verify_baseline(benchmark)
+    assert result.passed, result.reason
+    assert benchmark.ran and benchmark.torn_down
+    receipt = result.details["evaluation_provenance"]
+    assert receipt["status"] == "PASS"
+    assert receipt["finalized_at"] is not None
+
+
+@pytest.mark.parametrize("mutation", ["threshold", "source", "teardown", "removed", "getter"])
+def test_real_verification_rejects_evaluation_drift(tmp_path, mutation):
+    runner, benchmark = _case(tmp_path, mutation)
+    result = runner.verify_baseline(benchmark)
+    assert not result.passed
+    assert "evaluation" in result.reason.lower()
+    assert benchmark.ran and benchmark.torn_down
+    assert result.details["evaluation_provenance"]["status"] == "FAIL"
+
+
+def test_real_verification_rejects_overlap_before_execution(tmp_path):
+    runner, benchmark = _case(tmp_path)
+    benchmark.contract.sample_ids_by_split["test"] = ("a",)
+    result = runner.verify_baseline(benchmark)
+    assert not result.passed
+    assert "overlap" in result.reason.lower()
+    assert not benchmark.ran
+
+
+def test_ordinary_verification_does_not_require_dataset_contract(tmp_path):
+    runner, benchmark = _case(tmp_path)
+    benchmark.contract = None
+    result = runner.verify_baseline(benchmark)
+    assert result.passed, result.reason
+    assert result.details is None

--- a/code/tests/test_tool_workload_entrypoints.py
+++ b/code/tests/test_tool_workload_entrypoints.py
@@ -1,0 +1,66 @@
+"""Real CLI regressions for registered tool workload entrypoints."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+CODE_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "expected_diagnostic"),
+    [
+        ("dtensor-mesh", "CUDA required for ch13 DTensor mesh tool"),
+        (
+            "fp8-calibration-free",
+            "CUDA required for ch19 calibration-free FP8 tool",
+        ),
+        ("fp8-perchannel-bench", "CUDA required for ch13 FP8 per-channel tool"),
+        ("kernel-verification", "CUDA required for ch20 kernel verification tool"),
+        ("kv-cache-math", "CUDA required for ch15 KV-cache math tool"),
+        ("nvfp4-trtllm", "CUDA required for ch18 NVFP4/TRT-LLM tool"),
+        (
+            "proofwright-verify",
+            "CUDA required for ch20 ProofWright verification tool",
+        ),
+    ],
+)
+def test_registered_tool_reaches_explicit_cuda_gate(
+    tool_name: str,
+    expected_diagnostic: str,
+) -> None:
+    """A CUDA-hidden real CLI launch must execute the workload entrypoint."""
+    env = os.environ.copy()
+    env.update(
+        {
+            "CUDA_VISIBLE_DEVICES": "",
+            "PATH": f"{Path(sys.executable).parent}{os.pathsep}{env.get('PATH', '')}",
+            "PYTHONNOUSERSITE": "1",
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONPATH": str(CODE_ROOT),
+        }
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "cli.aisp",
+            "tools",
+            tool_name,
+        ],
+        cwd=CODE_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=45,
+        check=False,
+    )
+
+    combined_output = completed.stdout + completed.stderr
+    assert completed.returncode != 0, combined_output
+    assert expected_diagnostic in combined_output

--- a/docs/reviews/2026-09-06-codebase-repair-checkpoint.md
+++ b/docs/reviews/2026-09-06-codebase-repair-checkpoint.md
@@ -51,6 +51,61 @@ performance wins while required validation remains incomplete.
 
 ## Remaining work
 
+### September 6 direct execution follow-up
+
+PR #15 merged as `c40767b8294d0471082aea9cfb8f5636b8961aec`. The final
+candidate's hosted CPU suite completed with 4,598 passed, 492 skipped, and no
+failures or errors (5,090 collected). Static, dashboard, and native build checks
+also passed. Both retained KV NCU reports were successfully reprocessed after
+the large-artifact hashing repair; the original interrupted/failed runs retain
+their original status.
+
+The unfiltered GPU test suite ran directly on the two-B200 host on
+September 6 starting at 10:05:44 UTC, using the clean merged source, Torch
+2.9.1+cu130, and `python -m pytest tests -q --tb=short`. It completed in
+1,831.28 seconds: **5,008 passed, 77 skipped, and 5 failed**. Two-rank NCCL
+tests executed. One failure selected system CMake 3.28.3 instead of the
+already-installed 3.31.10; four process-lifecycle checks encountered exited
+children retained as zombies by the outer validation supervisor until final
+drain. The supervisor ultimately drained all owned processes. These five
+failures remain recorded and require a rerun after correcting the run's PATH
+and supervisor reaping loop. No full GPU pass is claimed. No Slurm allocation
+is required. The subsequent example
+inventory includes benchmark pairs, registered demos, and tools; the pytest
+suite alone does not establish that all of those entrypoints executed.
+
+The next patch adds explicit optional device-identity and evaluation contracts,
+and distributed workload metadata. Focused CPU checks have passed for these
+components; CUDA/NCCL runtime coverage and integration validation are separate
+pending checks. Declared collective algorithms are not profiler observations,
+and dataset hashes do not prove semantic freedom from contamination.
+
+The integrated local contract/harness suite passed 172 tests and skipped 24
+hardware/platform cases. Evaluation receipts now originate in the actual worker,
+survive subprocess serialization on failure, and finalize after teardown; source
+or threshold drift rejects timing results. The default 873-file benchmark lint
+scan passed without errors or warnings.
+
+Discovery confirmed 486 benchmark targets, 29 demos, and 34 tools. Ten registered
+demo/tool paths previously had factories but no invoked workload entrypoint;
+they now invoke their actual standalone execution paths. Real CLI tests with
+CUDA hidden reject execution with explicit diagnostics rather than exiting
+successfully after import. These remain
+demo/tool runs, not baseline-versus-optimized performance evidence.
+
+The broad sweep has two practical continuation gaps: aggregate preflight can
+reject a whole bucket, and an exception escaping a chapter can abort later
+chapters. The direct validation queue therefore gives each target a separate
+process and result record, continues on nonzero exits, and preserves earlier
+results. Native tier-1, cluster, and fabric entrypoints run separately from this
+486-target pass. Repairing native per-target continuation and resume accounting
+remains an improvement item; the queue does not claim to fix that source path.
+
+CI's broader `--include-unpaired --fail-on-warnings` lint scan also passed:
+932 files, zero errors and warnings. The contract checker recognizes exact
+registered demo/tool paths as standalone entrypoints while continuing to reject
+`__main__` blocks in paired benchmark modules.
+
 - Run the complete GPU test suite on the final merged revision.
 - Complete all four sweep stages and reconcile the 486-target inventory,
   including unsupported and failed cases rather than silently dropping them.


### PR DESCRIPTION
Ten registered demos and tools previously exited successfully after import without executing their workloads. They now enter the real standalone workload or report an explicit CUDA capability failure. The linter permits standalone entrypoints only for exact registered demos/tools and retains the paired-benchmark rule.

This also adds optional GPU UUID/compute-capability expectations, distributed workload parity fields, and evaluation provenance captured inside the executing worker. Evaluation source or threshold drift invalidates timings, and receipts survive subprocess failures and manifest serialization. Ordinary benchmarks remain opted out of dataset contracts.

Validation:
- Integrated local verification/harness suite: 172 passed, 24 platform/hardware skips. Final VerifyRunner review: 8 passed.
- Real demo CLI controls: 9 passed, 1 existing optional skip. Seven tool entrypoint controls passed; related tool compatibility checks passed.
- Linter tests: 32 passed. CI-style include-unpaired lint: 932 files, zero errors/warnings. Fatal Ruff, AST parsing, and diff checks passed.
- Prior merged main completed unfiltered direct B200 pytest: 5,008 passed, 77 skipped, 5 failed. The five failures all passed on unchanged main after selecting existing CMake3.31.10 and fixing the private supervisor's adopted-zombie reaping loop (5passed/26.31s; all processes drained). The original failed full run remains preserved.

- Candidate7b7728a8 completed86 focused contract tests on the two-B200 host with no failures/skips; the serial demo/tool/486-target queue is now executing from that clean frozen checkout.

The Markdown checkpoint preserves the original full-run result and execution boundaries. Collective algorithm metadata is declared rather than profiler-observed, and evaluation hashes do not establish semantic contamination freedom. Full example execution and optimization measurements remain in progress.
