### PR TITLE
Repair B200 demo execution and isolate benchmark failures

### DIFF
--- a/code/ch10/tma_multicast_cluster.cu
+++ b/code/ch10/tma_multicast_cluster.cu
@@ -14,6 +14,7 @@
 #include <cuda/barrier>
 #include <cuda_runtime.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -66,8 +67,28 @@ constexpr int TILE_K = 128;
 constexpr int BLOCK_SIZE = 128;
 constexpr size_t B_SMEM_BYTES =
     static_cast<size_t>(TILE_K) * TILE_N * sizeof(float);
-constexpr size_t DYNAMIC_SMEM_BYTES = B_SMEM_BYTES;
-static_assert(DYNAMIC_SMEM_BYTES == 65536);
+constexpr size_t A_SMEM_BYTES =
+    static_cast<size_t>(TILE_M) * TILE_K * sizeof(float);
+
+using block_barrier = cuda::barrier<cuda::thread_scope_block>;
+
+// Keep every shared object in one aligned dynamic allocation so the TMA
+// destination and multicast barrier have fixed, aligned CTA-relative offsets in
+// every block.
+struct alignas(128) TmaMulticastSharedStorage {
+    alignas(128) float B[TILE_K][TILE_N];
+    alignas(128) float A[TILE_M][TILE_K];
+    alignas(block_barrier) unsigned char barrier[sizeof(block_barrier)];
+};
+
+constexpr size_t DYNAMIC_SMEM_BYTES = sizeof(TmaMulticastSharedStorage);
+static_assert(B_SMEM_BYTES == 65536);
+static_assert(A_SMEM_BYTES == 2048);
+static_assert(offsetof(TmaMulticastSharedStorage, B) % 128 == 0);
+static_assert(offsetof(TmaMulticastSharedStorage, A) % 128 == 0);
+static_assert(
+    offsetof(TmaMulticastSharedStorage, barrier) % alignof(block_barrier) == 0);
+static_assert(DYNAMIC_SMEM_BYTES % 128 == 0);
 
 // Cluster configuration: 16x1 cluster along M (shares B tiles).
 constexpr int CLUSTER_M = 16;
@@ -117,7 +138,9 @@ void tma_multicast_gemm_kernel(
     int M, int N, int K
 ) {
     extern __shared__ __align__(128) unsigned char smem_raw[];
-    auto* B_smem = reinterpret_cast<float (*)[TILE_N]>(smem_raw);
+    auto& shared = *reinterpret_cast<TmaMulticastSharedStorage*>(smem_raw);
+    auto& B_smem = shared.B;
+    auto& A_smem = shared.A;
 #if TMA_MULTICAST_TARGET == 100 || TMA_MULTICAST_TARGET == 103
     cg::cluster_group cluster = cg::this_cluster();
     const int cluster_rank = cluster.block_rank();
@@ -133,11 +156,7 @@ void tma_multicast_gemm_kernel(
     const int thread_m = tid / THREADS_PER_ROW;                // 0..3
     const int thread_n = (tid % THREADS_PER_ROW) * COLS_PER_THREAD;  // 0..124
 
-    __shared__ alignas(128) float A_smem[TILE_M][TILE_K];
-
-    using block_barrier = cuda::barrier<cuda::thread_scope_block>;
-    __shared__ alignas(block_barrier) unsigned char barrier_storage[sizeof(block_barrier)];
-    auto* bar = reinterpret_cast<block_barrier*>(barrier_storage);
+    auto* bar = reinterpret_cast<block_barrier*>(shared.barrier);
     if (tid == 0) {
         init(bar, static_cast<int>(blockDim.x));
         cde::fence_proxy_async_shared_cta();
@@ -226,7 +245,6 @@ void tma_multicast_gemm_kernel(
     const int tile_n = blockIdx.y;
     const int tid = threadIdx.x;
 
-    __shared__ float A_smem[TILE_M][TILE_K];
     constexpr int COLS_PER_THREAD = 4;
     constexpr int THREADS_PER_ROW = TILE_N / COLS_PER_THREAD;
     float acc[COLS_PER_THREAD] = {0.0f};

--- a/code/ch15/context_parallel_demo.py
+++ b/code/ch15/context_parallel_demo.py
@@ -4,7 +4,8 @@ This wrapper calls the Chapter 13 context-parallelism implementation, which is
 shared across chapters.
 
 Run with torchrun, e.g.:
-  torchrun --nproc_per_node <num_gpus> ch15/context_parallel_demo.py
+  python -m torch.distributed.run --nproc_per_node 2 \
+      -m ch15.context_parallel_demo --sequence-length 4096
 """
 
 from __future__ import annotations

--- a/code/core/benchmark/bench_commands.py
+++ b/code/core/benchmark/bench_commands.py
@@ -517,6 +517,76 @@ else:
     app = None
 
 
+def _isolated_benchmark_failure_result(
+    *,
+    chapter_id: str,
+    only_examples: Optional[List[str]],
+    status: str,
+    error: str,
+    preflight_issues: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Build a normal result entry for a continuation-mode unit failure."""
+    benchmark_failures = [
+        {
+            "example": example,
+            "status": "failed_error",
+            "error": error,
+        }
+        for example in (only_examples or [])
+    ]
+    failure_count = max(1, len(benchmark_failures))
+    result: Dict[str, Any] = {
+        "chapter": chapter_id,
+        "status": status,
+        "reason": error,
+        "error": error,
+        "benchmarks": benchmark_failures,
+        "manifests": [],
+        "summary": {
+            "total_benchmarks": len(benchmark_failures),
+            "successful": 0,
+            "failed": failure_count,
+            "failed_error": failure_count,
+            "failed_verification": 0,
+            "failed_regression": 0,
+            "failed_no_speedup": 0,
+            "failed_generic": 0,
+            "failed_other": 0,
+            "skipped_hardware": 0,
+            "skipped_distributed": 0,
+            "total_skipped": 0,
+            "total_speedups": 0,
+            "average_speedup": 0.0,
+            "max_speedup": 0.0,
+            "min_speedup": 0.0,
+            "informational": 0,
+        },
+    }
+    if preflight_issues:
+        result["preflight_failed"] = True
+        result["preflight_issues"] = list(preflight_issues)
+    return result
+
+
+def _run_test_chapter_with_failure_boundary(
+    *,
+    isolate_failures: bool,
+    **kwargs: Any,
+) -> Tuple[Optional[Dict[str, Any]], Optional[Exception]]:
+    """Invoke one chapter unit, returning ordinary failures only when requested."""
+    try:
+        result = test_chapter(**kwargs)
+        if not isinstance(result, dict):
+            raise TypeError(
+                f"test_chapter() returned {type(result).__name__}; expected a result mapping"
+            )
+        return result, None
+    except Exception as exc:
+        if not isolate_failures:
+            raise
+        return None, exc
+
+
 @restore_cuda_visible_devices_after_call
 def _execute_benchmarks(
     targets: Optional[List[str]] = None,
@@ -722,18 +792,66 @@ def _execute_benchmarks(
     explicit_targets = bool(targets) and not all(
         str(target).strip().lower() == "all" for target in targets
     )
-    preflight_issues = _preflight_target_coverage_and_assets(
-        chapter_dirs,
-        chapter_filters,
-        only_cuda=bool(only_cuda),
-        only_python=bool(only_python),
-        target_extra_args=parsed_extra_args,
-        enforce_external_assets=(
-            len(chapter_dirs) == 1
-            if enforce_external_assets is None
-            else bool(enforce_external_assets)
-        ),
+    preflight_enforces_external_assets = (
+        len(chapter_dirs) == 1
+        if enforce_external_assets is None
+        else bool(enforce_external_assets)
     )
+    execution_units: List[Tuple[Path, Optional[List[str]]]] = []
+    for chapter_dir in chapter_dirs:
+        chapter_id = chapter_slug(
+            chapter_dir,
+            active_bench_root,
+            bench_root=active_bench_root,
+        )
+        example_filters = chapter_filters.get(chapter_id)
+        if not exit_on_failure and example_filters:
+            execution_units.extend((chapter_dir, [example]) for example in sorted(example_filters))
+        else:
+            execution_units.append(
+                (chapter_dir, sorted(example_filters) if example_filters else None)
+            )
+
+    isolated_preflight_issues: Dict[Tuple[Path, Optional[str]], List[str]] = {}
+    if exit_on_failure:
+        preflight_issues = _preflight_target_coverage_and_assets(
+            chapter_dirs,
+            chapter_filters,
+            only_cuda=bool(only_cuda),
+            only_python=bool(only_python),
+            target_extra_args=parsed_extra_args,
+            enforce_external_assets=preflight_enforces_external_assets,
+        )
+    else:
+        for chapter_dir, only_examples in execution_units:
+            chapter_id = chapter_slug(
+                chapter_dir,
+                active_bench_root,
+                bench_root=active_bench_root,
+            )
+            unit_filters = {chapter_id: set(only_examples)} if only_examples else {}
+            unit_issues = _preflight_target_coverage_and_assets(
+                [chapter_dir],
+                unit_filters,
+                only_cuda=bool(only_cuda),
+                only_python=bool(only_python),
+                target_extra_args=parsed_extra_args,
+                enforce_external_assets=preflight_enforces_external_assets,
+            )
+            if unit_issues:
+                unit_key = (
+                    chapter_dir.resolve(),
+                    only_examples[0] if only_examples and len(only_examples) == 1 else None,
+                )
+                isolated_preflight_issues[unit_key] = list(unit_issues)
+
+        preflight_issues = []
+        if len(isolated_preflight_issues) == len(execution_units):
+            for unit_issues in isolated_preflight_issues.values():
+                for issue in unit_issues:
+                    if issue not in preflight_issues:
+                        preflight_issues.append(issue)
+
     if preflight_issues:
         for issue in preflight_issues:
             logger.error("PREFLIGHT FAILED: %s", issue)
@@ -1124,11 +1242,54 @@ def _execute_benchmarks(
 
         all_results = []
         output_json = artifact_manager.get_result_path("benchmark_test_results.json")
-        for chapter_dir in chapter_dirs:
+
+        def _record_result(result: Dict[str, Any]) -> None:
+            all_results.append(result)
+            if output_format in ["json", "both"]:
+                with open(output_json, "w") as f:
+                    json.dump(
+                        {
+                            "run_id": artifact_manager.run_id,
+                            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+                            "results": all_results,
+                        },
+                        f,
+                        indent=2,
+                    )
+                logger.info(f"JSON results checkpoint saved to: {output_json}")
+
+        for chapter_dir, only_examples in execution_units:
             chapter_id = chapter_slug(chapter_dir, active_bench_root, bench_root=active_bench_root)
-            example_filters = chapter_filters.get(chapter_id)
-            only_examples = sorted(example_filters) if example_filters else None
-            result = test_chapter(
+            unit_key = (
+                chapter_dir.resolve(),
+                only_examples[0] if only_examples and len(only_examples) == 1 else None,
+            )
+            unit_preflight_issues = isolated_preflight_issues.get(unit_key, [])
+            if unit_preflight_issues:
+                error = "Benchmark preflight failed: " + " | ".join(unit_preflight_issues)
+                result = _isolated_benchmark_failure_result(
+                    chapter_id=chapter_id,
+                    only_examples=only_examples,
+                    status="failed_preflight",
+                    error=error,
+                    preflight_issues=unit_preflight_issues,
+                )
+                for issue in unit_preflight_issues:
+                    logger.error("PREFLIGHT FAILED [%s]: %s", chapter_id, issue)
+                emit_event(
+                    event_logger,
+                    logger,
+                    "benchmark_unit_failed",
+                    chapter=chapter_id,
+                    examples=only_examples or [],
+                    failure_kind="preflight",
+                    issues=unit_preflight_issues,
+                )
+                _record_result(result)
+                continue
+
+            result, unit_exception = _run_test_chapter_with_failure_boundary(
+                isolate_failures=not exit_on_failure,
                 chapter_dir=chapter_dir,
                 enable_profiling=enable_profiling,
                 profile_type=profile_type if enable_profiling else "none",
@@ -1181,19 +1342,34 @@ def _execute_benchmarks(
                 fail_on_no_benchmarks=explicit_targets,
                 event_logger=event_logger,
             )
-            all_results.append(result)
-            if output_format in ["json", "both"]:
-                with open(output_json, "w") as f:
-                    json.dump(
-                        {
-                            "run_id": artifact_manager.run_id,
-                            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
-                            "results": all_results,
-                        },
-                        f,
-                        indent=2,
-                    )
-                logger.info(f"JSON results checkpoint saved to: {output_json}")
+            if unit_exception is not None:
+                exc = unit_exception
+                error = f"{type(exc).__name__}: {exc}"
+                logger.error(
+                    "Benchmark unit failed [%s, examples=%s]: %s",
+                    chapter_id,
+                    only_examples or ["<all>"],
+                    error,
+                    exc_info=(type(exc), exc, exc.__traceback__),
+                )
+                result = _isolated_benchmark_failure_result(
+                    chapter_id=chapter_id,
+                    only_examples=only_examples,
+                    status="failed_error",
+                    error=error,
+                )
+                emit_event(
+                    event_logger,
+                    logger,
+                    "benchmark_unit_failed",
+                    chapter=chapter_id,
+                    examples=only_examples or [],
+                    failure_kind="exception",
+                    error=error,
+                )
+            if result is None:
+                raise RuntimeError("Benchmark unit returned neither a result nor an exception")
+            _record_result(result)
 
         progress_recorder.emit(
             ProgressEvent(
@@ -1267,13 +1443,19 @@ def _execute_benchmarks(
             total_skipped=total_skipped,
             output_json=str(output_json),
             output_markdown=str(output_md) if output_format in ["markdown", "both"] else None,
+            preflight_failed=bool(isolated_preflight_issues),
+            preflight_issues=[
+                issue
+                for issues in isolated_preflight_issues.values()
+                for issue in issues
+            ],
         )
         heartbeat_stop.set()
         heartbeat_thread.join(timeout=5.0)
         event_logger.close()
         if total_failed > 0 and exit_on_failure:
             sys.exit(1)
-        return {
+        execution_result = {
             "run_id": artifact_manager.run_id,
             "artifact_root": str(artifact_manager.run_dir),
             "output_json": str(output_json),
@@ -1285,6 +1467,14 @@ def _execute_benchmarks(
             "total_skipped": total_skipped,
             "results": all_results,
         }
+        if isolated_preflight_issues:
+            execution_result["preflight_failed"] = True
+            execution_result["preflight_issues"] = [
+                issue
+                for issues in isolated_preflight_issues.values()
+                for issue in issues
+            ]
+        return execution_result
     finally:
         restore_suite_timeout()
 

--- a/code/core/common/tcgen05/__init__.py
+++ b/code/core/common/tcgen05/__init__.py
@@ -69,6 +69,33 @@ _REQUIRED_CUTLASS_HEADERS = (
     Path("cute/tensor.hpp"),
 )
 
+# CUTLASS 4.2.0 at the repository-pinned 57e3cfb revision predates
+# cutlass/detail/collective/moe_stride_utils.hpp. The same four packed-stride
+# overloads exist in its tools utility header under make_cute_packed_stride.
+# This exact-content allowlist keeps the compatibility path scoped to that
+# known implementation. Retire it when the pinned CUTLASS provides the native
+# moe_stride_utils.hpp header.
+_CUTLASS_42_VERSION = (4, 2, 0)
+_CUTLASS_MOE_STRIDE_HEADER = Path("cutlass/detail/collective/moe_stride_utils.hpp")
+_CUTLASS_42_PACKED_STRIDE_HEADER = Path("cutlass/util/packed_stride.hpp")
+_CUTLASS_42_PACKED_STRIDE_SHA256 = (
+    "ca7f6b722a87848a53730cf8049991dcd781a5d79b37d7cda683ab6367710650"
+)
+_CUTLASS_42_MOE_STRIDE_COMPAT_SOURCE = """\
+// Generated compatibility header for repository-pinned CUTLASS 4.2.0.
+#pragma once
+#include <cutlass/util/packed_stride.hpp>
+
+namespace cutlass {
+template <class Stride, class Shape>
+CUTLASS_HOST_DEVICE
+auto make_internal_packed_stride(Stride stride, Shape const& shape)
+    -> decltype(make_cute_packed_stride(stride, shape)) {
+  return make_cute_packed_stride(stride, shape);
+}
+}  // namespace cutlass
+"""
+
 
 def _detect_compute_capability() -> tuple[int, int] | None:
     """Return the visible CUDA compute capability without requiring a GPU at import time."""
@@ -98,6 +125,91 @@ def _current_compute_capability() -> tuple[int, int]:
     return capability
 
 
+def _cutlass_version(include_dir: Path) -> tuple[int, int, int] | None:
+    """Read the numeric CUTLASS version macros from an include directory."""
+    version_path = include_dir / "cutlass" / "version.h"
+    try:
+        lines = version_path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError):
+        return None
+
+    values: dict[str, int] = {}
+    wanted = {"CUTLASS_MAJOR", "CUTLASS_MINOR", "CUTLASS_PATCH"}
+    for line in lines:
+        parts = line.split()
+        if len(parts) < 3 or parts[0] != "#define" or parts[1] not in wanted:
+            continue
+        try:
+            values[parts[1]] = int(parts[2])
+        except ValueError:
+            return None
+    if set(values) != wanted:
+        return None
+    return values["CUTLASS_MAJOR"], values["CUTLASS_MINOR"], values["CUTLASS_PATCH"]
+
+
+def _write_cutlass_42_compat_header(destination: Path) -> None:
+    """Atomically materialize the narrow CUTLASS 4.2 stride-name adapter."""
+    if destination.is_file():
+        try:
+            if destination.read_text(encoding="utf-8") == _CUTLASS_42_MOE_STRIDE_COMPAT_SOURCE:
+                return
+        except (OSError, UnicodeError):
+            pass
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=destination.parent,
+            prefix=f".{destination.name}.",
+            delete=False,
+        ) as temporary_file:
+            temporary_file.write(_CUTLASS_42_MOE_STRIDE_COMPAT_SOURCE)
+            temporary_file.flush()
+            os.fsync(temporary_file.fileno())
+            temporary_path = Path(temporary_file.name)
+        temporary_path.replace(destination)
+    finally:
+        if temporary_path is not None:
+            with suppress(FileNotFoundError):
+                temporary_path.unlink()
+
+
+def _cutlass_42_compat_includes(candidate: Path) -> tuple[tuple[Path, ...] | None, str]:
+    """Return verified include roots for the repository-pinned CUTLASS 4.2 shim."""
+    version = _cutlass_version(candidate)
+    if version != _CUTLASS_42_VERSION:
+        return None, f"CUTLASS version is {version!r}, expected {_CUTLASS_42_VERSION!r}"
+
+    utility_include = candidate.parent / "tools" / "util" / "include"
+    utility_header = utility_include / _CUTLASS_42_PACKED_STRIDE_HEADER
+    if not utility_header.is_file():
+        return None, f"missing {_CUTLASS_42_PACKED_STRIDE_HEADER}"
+
+    try:
+        utility_digest = hashlib.sha256(utility_header.read_bytes()).hexdigest()
+    except OSError as error:
+        return None, f"cannot read {_CUTLASS_42_PACKED_STRIDE_HEADER}: {error}"
+    if utility_digest != _CUTLASS_42_PACKED_STRIDE_SHA256:
+        return None, (
+            f"unverified {_CUTLASS_42_PACKED_STRIDE_HEADER} digest {utility_digest}"
+        )
+
+    overlay_digest = hashlib.sha256(
+        (_CUTLASS_42_MOE_STRIDE_COMPAT_SOURCE + utility_digest).encode("utf-8")
+    ).hexdigest()[:16]
+    overlay_include = (
+        _get_extension_build_dir("tcgen05_cutlass_42_compat")
+        / overlay_digest
+        / "include"
+    )
+    _write_cutlass_42_compat_header(overlay_include / _CUTLASS_MOE_STRIDE_HEADER)
+    return (overlay_include, candidate, utility_include), ""
+
+
 def _cutlass_includes_for_capability(
     capability: tuple[int, int],
 ) -> tuple[Path, ...]:
@@ -116,6 +228,15 @@ def _cutlass_includes_for_capability(
         ]
         if not missing:
             return (candidate,)
+        if missing == [_CUTLASS_MOE_STRIDE_HEADER]:
+            compat_includes, incompatibility = _cutlass_42_compat_includes(candidate)
+            if compat_includes is not None:
+                return compat_includes
+            checked.append(
+                f"{candidate} (missing {_CUTLASS_MOE_STRIDE_HEADER}; "
+                f"CUTLASS 4.2 compatibility unavailable: {incompatibility})"
+            )
+            continue
         missing_names = ", ".join(str(header) for header in missing)
         checked.append(f"{candidate} (missing {missing_names})")
 
@@ -129,7 +250,7 @@ def _cutlass_includes_for_capability(
 _CLANG_HOST = _REPO_ROOT / "third_party" / "llvm" / "bin" / "clang++"
 
 # Build fingerprint version. Bump this when changing build logic.
-_BUILD_FINGERPRINT_VERSION = "v3"
+_BUILD_FINGERPRINT_VERSION = "v4"
 
 
 def _tcgen05_cuda_flags() -> list[str]:

--- a/code/core/demos/demos_commands.py
+++ b/code/core/demos/demos_commands.py
@@ -8,7 +8,6 @@ separated from:
 
 from __future__ import annotations
 
-import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -270,10 +269,6 @@ def _run_demo(
             argv=demo_args or [],
         )
     elif resolved_launch == LaunchVia.TORCHRUN.value:
-        torchrun_path = shutil.which("torchrun")
-        if torchrun_path is None:
-            raise FileNotFoundError("torchrun not found in PATH; install PyTorch with distributed support.")
-
         if nproc_per_node is None:
             raise ValueError(
                 f"Demo '{demo}' requires torchrun; pass --nproc-per-node <N> (e.g., --nproc-per-node 2)."
@@ -284,7 +279,6 @@ def _run_demo(
         if nnodes is not None and int(nnodes) <= 0:
             raise ValueError(f"--nnodes must be >= 1, got {nnodes}")
         cmd = build_torchrun_entry_command(
-            torchrun_path,
             module_name=spec.module_name,
             script_path=None if spec.module_name else spec.script_path,
             argv=demo_args or [],

--- a/code/core/harness/run_benchmarks.py
+++ b/code/core/harness/run_benchmarks.py
@@ -2768,21 +2768,14 @@ def _build_torchrun_profile_command(
     if use_direct_wrapper:
         torchrun_cmd = [sys.executable]
     else:
-        torchrun_path = shutil.which("torchrun")
-        if torchrun_path:
-            torchrun_cmd = [
-                torchrun_path,
-                "--nproc_per_node",
-                str(nproc_per_node),
-            ]
-        else:
-            torchrun_cmd = [
-                sys.executable,
-                "-m",
-                "torch.distributed.run",
-                "--nproc_per_node",
-                str(nproc_per_node),
-            ]
+        # Profile with the same Python/PyTorch environment used for timing.
+        torchrun_cmd = [
+            sys.executable,
+            "-m",
+            "torch.distributed.run",
+            "--nproc_per_node",
+            str(nproc_per_node),
+        ]
         if getattr(config, "nnodes", None):
             torchrun_cmd.extend(["--nnodes", str(config.nnodes)])
 

--- a/code/core/harness/run_benchmarks.py
+++ b/code/core/harness/run_benchmarks.py
@@ -16,7 +16,6 @@ import os
 import atexit
 from pathlib import Path
 import json
-import shutil
 import argparse
 import csv
 import shlex

--- a/code/core/utils/python_entrypoints.py
+++ b/code/core/utils/python_entrypoints.py
@@ -128,7 +128,6 @@ def build_python_entry_command(
 
 
 def build_torchrun_entry_command(
-    torchrun_executable: str,
     *,
     module_name: Optional[str] = None,
     script_path: Optional[Path] = None,
@@ -137,12 +136,15 @@ def build_torchrun_entry_command(
     nnodes: Optional[int] = None,
     rdzv_backend: Optional[str] = None,
     rdzv_endpoint: Optional[str] = None,
+    python_executable: Optional[str] = None,
 ) -> List[str]:
-    """Build ``torchrun`` command for either a module or a script path."""
+    """Launch distributed workers using the selected Python environment."""
     if bool(module_name) == bool(script_path):
         raise ValueError("Specify exactly one of module_name or script_path.")
     cmd = [
-        torchrun_executable,
+        python_executable or sys.executable,
+        "-m",
+        "torch.distributed.run",
         "--nproc_per_node",
         str(int(nproc_per_node)),
     ]

--- a/code/tests/cuda/run_tma_2d_layout_validation.py
+++ b/code/tests/cuda/run_tma_2d_layout_validation.py
@@ -95,7 +95,11 @@ def main() -> int:
     feature_target = args.arch.removeprefix("sm_").removesuffix("a")
     for case_id, name in enumerate(CASES):
         binary = (args.output_dir / name).resolve()
-        command = [nvcc, "-O2", "-std=c++17", "-rdc=true", f"-arch={args.arch}",
+        # The shorthand -arch=sm_100a also emits generic compute_100 PTX,
+        # which cannot compile the architecture-specific multicast caller.
+        compute_arch = args.arch.replace("sm_", "compute_", 1)
+        command = [nvcc, "-O2", "-std=c++17", "-rdc=true",
+                   f"-gencode=arch={compute_arch},code={args.arch}",
                    f"-DTMA_MULTICAST_TARGET={feature_target}", f"-DTMA_VALIDATION_CASE={case_id}",
                    str(source), "-lcuda", "-o", str(binary)]
         if run(f"{name}-compile", command).returncode != 0:

--- a/code/tests/test_bench_commands_failure_isolation.py
+++ b/code/tests/test_bench_commands_failure_isolation.py
@@ -1,0 +1,178 @@
+"""Continuation-mode failure isolation for the real benchmark command loop."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.benchmark import bench_commands
+from core.benchmark.e2e_sweep import _E2EAbort, _benchmark_stage_details_from_output
+from core.harness import run_benchmarks as run_benchmarks_module
+
+
+def _write_pair(chapter_dir: Path, example: str) -> None:
+    chapter_dir.mkdir(parents=True, exist_ok=True)
+    source = "def get_benchmark():\n    raise RuntimeError('GPU execution is not used by this test')\n"
+    (chapter_dir / f"baseline_{example}.py").write_text(source, encoding="utf-8")
+    (chapter_dir / f"optimized_{example}.py").write_text(source, encoding="utf-8")
+
+
+def _prepare_cuda_hidden_control(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
+    monkeypatch.setattr(bench_commands, "BENCHMARK_AVAILABLE", True)
+    monkeypatch.setattr(bench_commands, "TEST_FUNCTIONS_AVAILABLE", True)
+    monkeypatch.setattr(bench_commands, "dump_environment_and_capabilities", lambda: None)
+    monkeypatch.setattr(bench_commands, "get_gpu_state", lambda **_kwargs: {})
+    monkeypatch.setattr(run_benchmarks_module.torch.cuda, "is_available", lambda: False)
+
+
+def test_continuation_records_one_target_preflight_and_attempts_the_next(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bench_root = tmp_path / "bench"
+    chapter_dir = bench_root / "ch01"
+    _write_pair(chapter_dir, "blocked")
+    _write_pair(chapter_dir, "later")
+    _prepare_cuda_hidden_control(monkeypatch)
+
+    preflight_calls: list[set[str]] = []
+
+    def selective_preflight(_chapter_dirs, chapter_filters, **_kwargs):
+        examples = {
+            example
+            for selected in chapter_filters.values()
+            for example in selected
+        }
+        preflight_calls.append(examples)
+        if examples == {"blocked"}:
+            return ["ch01: synthetic target preflight failure"]
+        return []
+
+    attempted_examples: list[list[str] | None] = []
+    real_test_chapter = bench_commands.test_chapter
+
+    def tracking_test_chapter(**kwargs):
+        attempted_examples.append(kwargs["only_examples"])
+        return real_test_chapter(**kwargs)
+
+    monkeypatch.setattr(
+        bench_commands,
+        "_preflight_target_coverage_and_assets",
+        selective_preflight,
+    )
+    monkeypatch.setattr(bench_commands, "test_chapter", tracking_test_chapter)
+
+    result = bench_commands._execute_benchmarks(
+        targets=["ch01:blocked", "ch01:later"],
+        bench_root=bench_root,
+        output_format="json",
+        profile_type="none",
+        suite_timeout=0,
+        artifacts_dir=str(tmp_path / "artifacts"),
+        run_id="target_preflight_isolation",
+        exit_on_failure=False,
+    )
+
+    assert preflight_calls == [{"blocked"}, {"later"}]
+    assert attempted_examples == [["later"]]
+    assert result["total_failed"] == 1
+    assert result["preflight_failed"] is True
+    assert [entry["status"] for entry in result["results"]] == [
+        "failed_preflight",
+        "skipped",
+    ]
+    failed_target = result["results"][0]["benchmarks"][0]
+    assert failed_target["example"] == "blocked"
+    assert failed_target["status"] == "failed_error"
+    assert "synthetic target preflight failure" in failed_target["error"]
+
+    persisted = json.loads(Path(result["output_json"]).read_text(encoding="utf-8"))
+    assert persisted["results"] == result["results"]
+    stage_details = _benchmark_stage_details_from_output(result["output_json"])
+    assert stage_details is not None
+    assert stage_details["target_outcomes"] == [
+        {"target": "ch01:blocked", "status": "failed_error"}
+    ]
+
+
+@pytest.mark.parametrize("split_across_chapters", [False, True])
+def test_continuation_records_ordinary_exception_and_attempts_later_unit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    split_across_chapters: bool,
+) -> None:
+    bench_root = tmp_path / "bench"
+    first_chapter = bench_root / "ch01"
+    later_chapter = bench_root / ("ch02" if split_across_chapters else "ch01")
+    _write_pair(first_chapter, "first")
+    _write_pair(later_chapter, "later")
+    _prepare_cuda_hidden_control(monkeypatch)
+
+    attempted: list[tuple[str, list[str] | None]] = []
+    real_test_chapter = bench_commands.test_chapter
+
+    def fault_then_real_test_chapter(**kwargs):
+        call = (kwargs["chapter_dir"].name, kwargs["only_examples"])
+        attempted.append(call)
+        if len(attempted) == 1:
+            raise RuntimeError("synthetic ordinary chapter failure")
+        return real_test_chapter(**kwargs)
+
+    monkeypatch.setattr(bench_commands, "test_chapter", fault_then_real_test_chapter)
+    targets = (
+        ["ch01:first", "ch02:later"]
+        if split_across_chapters
+        else ["ch01:first", "ch01:later"]
+    )
+
+    result = bench_commands._execute_benchmarks(
+        targets=targets,
+        bench_root=bench_root,
+        output_format="json",
+        profile_type="none",
+        suite_timeout=0,
+        artifacts_dir=str(tmp_path / "artifacts"),
+        run_id=f"exception_isolation_{int(split_across_chapters)}",
+        exit_on_failure=False,
+    )
+
+    assert len(attempted) == 2
+    assert attempted[0] == ("ch01", ["first"])
+    assert attempted[1] == (
+        "ch02" if split_across_chapters else "ch01",
+        ["later"],
+    )
+    assert result["total_failed"] == 1
+    assert [entry["status"] for entry in result["results"]] == [
+        "failed_error",
+        "skipped",
+    ]
+    failed_target = result["results"][0]["benchmarks"][0]
+    assert failed_target["example"] == "first"
+    assert failed_target["status"] == "failed_error"
+    assert failed_target["error"] == "RuntimeError: synthetic ordinary chapter failure"
+
+    persisted = json.loads(Path(result["output_json"]).read_text(encoding="utf-8"))
+    assert persisted["results"] == result["results"]
+
+
+@pytest.mark.parametrize(
+    "abort",
+    [KeyboardInterrupt(), SystemExit(17), _E2EAbort("synthetic e2e abort")],
+)
+def test_failure_boundary_does_not_capture_run_level_abort(
+    monkeypatch: pytest.MonkeyPatch,
+    abort: BaseException,
+) -> None:
+    def raise_abort(**_kwargs):
+        raise abort
+
+    monkeypatch.setattr(bench_commands, "test_chapter", raise_abort)
+
+    with pytest.raises(type(abort)):
+        bench_commands._run_test_chapter_with_failure_boundary(isolate_failures=True)

--- a/code/tests/test_ch10_makefile_contract.py
+++ b/code/tests/test_ch10_makefile_contract.py
@@ -170,14 +170,31 @@ def test_tma_cluster_gemm_tiles_use_opt_in_dynamic_shared_memory(
     assert (
         "constexpr size_t B_SMEM_BYTES =\n    static_cast<size_t>(TILE_K) * TILE_N * sizeof(float);"
     ) in source
-    assert "constexpr size_t DYNAMIC_SMEM_BYTES = B_SMEM_BYTES;" in source
-    assert "static_assert(DYNAMIC_SMEM_BYTES == 65536);" in source
     assert "extern __shared__ __align__(128) unsigned char smem_raw[];" in source
-    assert "reinterpret_cast<float (*)[TILE_N]>(smem_raw)" in source
-    assert source.count("__shared__ alignas(128) float A_smem") == 1
-    assert source.count("__shared__ float A_smem") == 1
     assert "__shared__ alignas(128) float B_smem" not in source
     assert "__shared__ float B_smem" not in source
+    if source_name == "tma_multicast_cluster.cu":
+        assert "struct alignas(128) TmaMulticastSharedStorage" in source
+        assert "alignas(128) float B[TILE_K][TILE_N];" in source
+        assert "alignas(128) float A[TILE_M][TILE_K];" in source
+        assert "alignas(block_barrier) unsigned char barrier[sizeof(block_barrier)];" in source
+        assert (
+            "constexpr size_t DYNAMIC_SMEM_BYTES = sizeof(TmaMulticastSharedStorage);"
+            in source
+        )
+        assert "offsetof(TmaMulticastSharedStorage, B) % 128 == 0" in source
+        assert "offsetof(TmaMulticastSharedStorage, A) % 128 == 0" in source
+        assert "DYNAMIC_SMEM_BYTES % 128 == 0" in source
+        assert "auto& shared = *reinterpret_cast<TmaMulticastSharedStorage*>(smem_raw);" in source
+        assert source.count("__shared__") == 1
+        assert "__shared__ alignas(128) float A_smem" not in source
+        assert "__shared__ float A_smem" not in source
+    else:
+        assert "constexpr size_t DYNAMIC_SMEM_BYTES = B_SMEM_BYTES;" in source
+        assert "static_assert(DYNAMIC_SMEM_BYTES == 65536);" in source
+        assert "reinterpret_cast<float (*)[TILE_N]>(smem_raw)" in source
+        assert source.count("__shared__ alignas(128) float A_smem") == 1
+        assert source.count("__shared__ float A_smem") == 1
     assert "cudaDevAttrMaxSharedMemoryPerBlockOptin" in source
     assert "DYNAMIC_SMEM_BYTES + kernel_attributes.sharedSizeBytes" in source
     assert "cudaFuncAttributeMaxDynamicSharedMemorySize" in source

--- a/code/tests/test_demos_cli.py
+++ b/code/tests/test_demos_cli.py
@@ -134,7 +134,6 @@ def test_module_backed_torchrun_demo_launches_via_module(monkeypatch):
         return SimpleNamespace(returncode=0)
 
     monkeypatch.setattr(demos_commands.subprocess, "run", fake_run)
-    monkeypatch.setattr(demos_commands.shutil, "which", lambda name: "/usr/bin/torchrun" if name == "torchrun" else None)
 
     exit_code = demos_commands._run_demo(
         "ch15-tensor-parallel",
@@ -143,12 +142,14 @@ def test_module_backed_torchrun_demo_launches_via_module(monkeypatch):
     )
 
     assert exit_code == 0
-    assert recorded["cmd"][:5] == [
-        "/usr/bin/torchrun",
+    assert recorded["cmd"][:7] == [
+        sys.executable,
+        "-m",
+        "torch.distributed.run",
         "--nproc_per_node",
         "2",
         "-m",
         "ch15.tensor_parallel_demo",
     ]
-    assert recorded["cmd"][5:] == ["--batch", "1"]
+    assert recorded["cmd"][7:] == ["--batch", "1"]
     assert str(demos_commands.REPO_ROOT) in recorded["env"]["PYTHONPATH"].split(os.pathsep)

--- a/code/tests/test_python_entrypoints.py
+++ b/code/tests/test_python_entrypoints.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
 import os
+import signal
+import socket
 import subprocess
 import sys
 from pathlib import Path
@@ -56,14 +59,15 @@ def test_build_python_entry_command_requires_exactly_one_target(tmp_path: Path) 
 
 def test_build_torchrun_entry_command_supports_module_launch() -> None:
     cmd = build_torchrun_entry_command(
-        "torchrun",
         module_name="ch15.tensor_parallel_demo",
         argv=["--batch", "1"],
         nproc_per_node=2,
         nnodes=1,
     )
     assert cmd == [
-        "torchrun",
+        sys.executable,
+        "-m",
+        "torch.distributed.run",
         "--nproc_per_node",
         "2",
         "--nnodes",
@@ -73,6 +77,45 @@ def test_build_torchrun_entry_command_supports_module_launch() -> None:
         "--batch",
         "1",
     ]
+
+
+def test_real_torchrun_workers_keep_python_when_path_has_another_launcher(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "other-environment-bin"
+    fake_bin.mkdir()
+    other_launcher = fake_bin / "torchrun"
+    other_launcher.write_text("#!/bin/sh\nexit 99\n", encoding="utf-8")
+    other_launcher.chmod(0o755)
+    probe = tmp_path / "worker_identity.py"
+    probe.write_text(
+        "import json, os, sys\n"
+        "from pathlib import Path\n"
+        "Path(sys.argv[1], os.environ['RANK'] + '.json').write_text("
+        "json.dumps({'executable': sys.executable, 'prefix': sys.prefix}))\n",
+        encoding="utf-8",
+    )
+    with socket.socket() as rendezvous_socket:
+        rendezvous_socket.bind(("127.0.0.1", 0))
+        rendezvous_port = rendezvous_socket.getsockname()[1]
+    command = build_torchrun_entry_command(
+        script_path=probe, argv=[str(tmp_path)], nproc_per_node=2, nnodes=1,
+        rdzv_backend="static", rdzv_endpoint=f"127.0.0.1:{rendezvous_port}",
+    )
+    env = dict(os.environ, PATH=str(fake_bin) + os.pathsep + os.environ.get("PATH", ""))
+    env.pop("PYTHON_EXEC", None)
+    process = subprocess.Popen(
+        command, env=env, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    try:
+        output, _ = process.communicate(timeout=45)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGKILL)
+        output, _ = process.communicate()
+        pytest.fail(f"Distributed worker identity probe timed out:\n{output}")
+    assert process.returncode == 0, output
+    for rank in (0, 1):
+        identity = json.loads((tmp_path / f"{rank}.json").read_text())
+        assert identity == {"executable": sys.executable, "prefix": sys.prefix}
 
 
 def test_install_local_module_override_loads_package_without_sys_path_mutation(tmp_path: Path) -> None:

--- a/code/tests/test_run_benchmarks_profiler_contract.py
+++ b/code/tests/test_run_benchmarks_profiler_contract.py
@@ -483,6 +483,7 @@ def test_build_torchrun_profile_command_keeps_launcher_for_multi_process(tmp_pat
 
     command, _env = _build_torchrun_profile_command(config, spec=spec)
 
+    assert command[:3] == [sys.executable, "-m", "torch.distributed.run"]
     assert "--nproc_per_node" in command
     assert "2" in command
     assert "-m" in command

--- a/code/tests/test_tcgen05_cutlass_42_compat.py
+++ b/code/tests/test_tcgen05_cutlass_42_compat.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import hashlib
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import core.common.tcgen05 as tcgen05
+
+_PACKED_STRIDE_FIXTURE = """\
+#pragma once
+#define CUTLASS_HOST_DEVICE
+namespace cutlass {
+template <class Stride, class Shape>
+int make_cute_packed_stride(Stride, Shape const&) { return 7; }
+}  // namespace cutlass
+"""
+
+
+def _create_cutlass_candidate(
+    tmp_path: Path,
+    *,
+    version: tuple[int, int, int] = (4, 2, 0),
+) -> tuple[Path, Path]:
+    cutlass_root = tmp_path / "cutlass"
+    include_dir = cutlass_root / "include"
+    for header in tcgen05._REQUIRED_CUTLASS_HEADERS:
+        if header == tcgen05._CUTLASS_MOE_STRIDE_HEADER:
+            continue
+        header_path = include_dir / header
+        header_path.parent.mkdir(parents=True, exist_ok=True)
+        header_path.write_text(f"// {header}\n", encoding="utf-8")
+
+    major, minor, patch = version
+    version_header = include_dir / "cutlass" / "version.h"
+    version_header.write_text(
+        f"#define CUTLASS_MAJOR {major}\n"
+        f"#define CUTLASS_MINOR {minor}\n"
+        f"#define CUTLASS_PATCH {patch}\n",
+        encoding="utf-8",
+    )
+
+    utility_include = cutlass_root / "tools" / "util" / "include"
+    utility_header = utility_include / tcgen05._CUTLASS_42_PACKED_STRIDE_HEADER
+    utility_header.parent.mkdir(parents=True, exist_ok=True)
+    utility_header.write_text(_PACKED_STRIDE_FIXTURE, encoding="utf-8")
+    return include_dir, utility_include
+
+
+def _configure_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    include_dir: Path,
+) -> Path:
+    build_root = tmp_path / "extensions"
+    monkeypatch.setattr(tcgen05, "_SM100_CUTLASS_CANDIDATES", (include_dir,))
+    monkeypatch.setattr(tcgen05, "_FALLBACK_CUTLASS_CANDIDATES", ())
+    monkeypatch.setattr(
+        tcgen05,
+        "_get_extension_build_dir",
+        lambda name: build_root / name,
+    )
+    return build_root
+
+
+def test_pinned_cutlass_42_uses_verified_packed_stride_compatibility(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    include_dir, utility_include = _create_cutlass_candidate(tmp_path)
+    build_root = _configure_candidate(monkeypatch, tmp_path, include_dir)
+    fixture_digest = hashlib.sha256(_PACKED_STRIDE_FIXTURE.encode("utf-8")).hexdigest()
+    monkeypatch.setattr(tcgen05, "_CUTLASS_42_PACKED_STRIDE_SHA256", fixture_digest)
+
+    include_roots = tcgen05._cutlass_includes_for_capability((10, 0))
+
+    overlay_include = include_roots[0]
+    assert include_roots == (overlay_include, include_dir, utility_include)
+    compat_header = overlay_include / tcgen05._CUTLASS_MOE_STRIDE_HEADER
+    assert compat_header.read_text(encoding="utf-8") == (
+        tcgen05._CUTLASS_42_MOE_STRIDE_COMPAT_SOURCE
+    )
+    assert all(
+        any((root / header).is_file() for root in include_roots)
+        for header in tcgen05._REQUIRED_CUTLASS_HEADERS
+    )
+    assert compat_header.is_relative_to(build_root)
+
+    compiler = shutil.which("c++")
+    if compiler is None:
+        pytest.skip("C++ compiler unavailable for compatibility-header syntax check")
+    probe = tmp_path / "probe.cpp"
+    executable = tmp_path / "probe"
+    probe.write_text(
+        "#include <cutlass/detail/collective/moe_stride_utils.hpp>\n"
+        "int main() {\n"
+        "  return cutlass::make_internal_packed_stride(1, 2) == 7 ? 0 : 1;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    compile_result = subprocess.run(
+        [
+            compiler,
+            "-std=c++17",
+            *(f"-I{root}" for root in include_roots),
+            str(probe),
+            "-o",
+            str(executable),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert compile_result.returncode == 0, compile_result.stdout + compile_result.stderr
+    run_result = subprocess.run(
+        [str(executable)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert run_result.returncode == 0, run_result.stdout + run_result.stderr
+
+
+def test_cutlass_42_compatibility_rejects_unverified_utility_header(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    include_dir, _ = _create_cutlass_candidate(tmp_path)
+    build_root = _configure_candidate(monkeypatch, tmp_path, include_dir)
+
+    with pytest.raises(RuntimeError, match="unverified cutlass/util/packed_stride.hpp digest"):
+        tcgen05._cutlass_includes_for_capability((10, 0))
+
+    assert not build_root.exists()
+
+
+def test_cutlass_compatibility_is_not_applied_to_other_versions(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    include_dir, _ = _create_cutlass_candidate(tmp_path, version=(4, 3, 0))
+    build_root = _configure_candidate(monkeypatch, tmp_path, include_dir)
+    fixture_digest = hashlib.sha256(_PACKED_STRIDE_FIXTURE.encode("utf-8")).hexdigest()
+    monkeypatch.setattr(tcgen05, "_CUTLASS_42_PACKED_STRIDE_SHA256", fixture_digest)
+
+    with pytest.raises(RuntimeError, match=r"CUTLASS version is \(4, 3, 0\)"):
+        tcgen05._cutlass_includes_for_capability((10, 0))
+
+    assert not build_root.exists()

--- a/docs/reviews/2026-09-06-codebase-repair-checkpoint.md
+++ b/docs/reviews/2026-09-06-codebase-repair-checkpoint.md
@@ -67,17 +67,21 @@ September 6 starting at 10:05:44 UTC, using the clean merged source, Torch
 tests executed. One failure selected system CMake 3.28.3 instead of the
 already-installed 3.31.10; four process-lifecycle checks encountered exited
 children retained as zombies by the outer validation supervisor until final
-drain. The supervisor ultimately drained all owned processes. These five
-failures remain recorded and require a rerun after correcting the run's PATH
-and supervisor reaping loop. No full GPU pass is claimed. No Slurm allocation
-is required. The subsequent example
+drain. The supervisor ultimately drained all owned processes. All five tests
+then passed on the same merged source in 26.31 seconds after selecting CMake
+3.31.10 and reaping the supervisor's adopted, exited children during execution.
+Both receipts are retained: the original full run remains failed, and the
+targeted rerun passed and drained its processes. No Slurm allocation is required.
+The subsequent example
 inventory includes benchmark pairs, registered demos, and tools; the pytest
 suite alone does not establish that all of those entrypoints executed.
 
-The next patch adds explicit optional device-identity and evaluation contracts,
-and distributed workload metadata. Focused CPU checks have passed for these
-components; CUDA/NCCL runtime coverage and integration validation are separate
-pending checks. Declared collective algorithms are not profiler observations,
+PR #16 (`7b7728a8dd043a1e9a07a29565626dfed89c8984`) adds explicit optional
+device-identity and evaluation contracts, and distributed workload metadata.
+It merged as `3d7982a8860506505d1ca24b8c3754f3826fdba1` after CPU validation,
+dashboard, static analysis, and dual-architecture native build checks passed.
+Its 86 focused contract tests passed on the B200 host with no skips in 9.29
+seconds. Declared collective algorithms are not profiler observations,
 and dataset hashes do not prove semantic freedom from contamination.
 
 The integrated local contract/harness suite passed 172 tests and skipped 24
@@ -93,13 +97,38 @@ CUDA hidden reject execution with explicit diagnostics rather than exiting
 successfully after import. These remain
 demo/tool runs, not baseline-versus-optimized performance evidence.
 
-The broad sweep has two practical continuation gaps: aggregate preflight can
+The broad sweep exposed two practical continuation gaps: aggregate preflight can
 reject a whole bucket, and an exception escaping a chapter can abort later
 chapters. The direct validation queue therefore gives each target a separate
 process and result record, continues on nonzero exits, and preserves earlier
 results. Native tier-1, cluster, and fabric entrypoints run separately from this
-486-target pass. Repairing native per-target continuation and resume accounting
-remains an improvement item; the queue does not claim to fix that source path.
+486-target pass. A follow-up repair now isolates explicit filtered targets when
+continuation is requested, records preflight failures and ordinary exceptions,
+and proceeds to later units. Its 78 focused and existing regression tests passed.
+Run-level aborts still propagate. Batch target resolution and contiguous-prefix
+native resume accounting remain improvement items.
+
+The first direct demo pass attempted all 29 registered demos: 23 exited
+successfully and six required follow-up. One requires GB10 coherent memory;
+two need explicit workload arguments; the other three exposed a TMA alignment
+failure, a CUTLASS dependency preflight failure, and a distributed launcher
+selecting another environment's Python through `PATH`. Tools also began
+executing. Completed results were preserved before replacing the coordinator
+to resume with corrected source and arguments.
+
+The launcher repair uses the selected Python's `torch.distributed.run` for demos
+and profiler workers, matching benchmark timing. A real two-worker identity test
+passes even with another environment's `torchrun` first on `PATH`. The combined
+launcher and TMA static contract selection passed 82 tests with two skips.
+The CUDA alignment repair then passed the actual production kernel's three
+full-output and canary shapes under Compute Sanitizer with zero reported errors,
+and the original 2048-square demo completed. The focused B200 regression
+selection passed 90 tests with no skips. The initial standalone validator
+compile exposed a separate flag defect: `-arch=sm_100a` emits generic PTX as well;
+the architecture-specific caller requires an explicit `compute_100a` to
+`sm_100a` code-generation target. The launcher, alignment, and continuation
+repairs are committed in `a738687c28c10161e3000a97ce2ed640795872b6`; they are
+not yet merged. The validator flag repair follows that commit.
 
 CI's broader `--include-unpaired --fail-on-warnings` lint scan also passed:
 932 files, zero errors and warnings. The contract checker recognizes exact


### PR DESCRIPTION
Distributed demos and profiler workers could select a different Python environment when `torchrun` from another virtual environment appeared first on PATH. They now invoke the selected Python's `torch.distributed.run`, matching benchmark timing. Continuation-mode benchmark execution also records per-target preflight failures and ordinary chapter exceptions while allowing later units to run.

The direct B200 sweep exposed misaligned shared storage in the TMA multicast demo and a tcgen05 dependency mismatch with the pinned CUTLASS 4.2 tree. The TMA kernel now uses one aligned dynamic shared allocation, and its standalone validator explicitly targets architecture-specific code generation. A version- and content-checked CUTLASS stride adapter uses the pinned implementation under its older API name; unknown versions or content still fail explicitly.

Validation: the actual TMA production kernel passed three full-output/canary cases under Compute Sanitizer with zero errors, and the original 2048-square demo completed on B200. The focused B200 launcher/TMA/continuation suite passed 90 tests without skips. Local continuation regressions passed 78 tests; CUTLASS compatibility checks passed 26 tests, including a real host compiler probe and negative controls. The tcgen05 demo now compiles and runs on B200. The broader seven-caller CUDA validator exposed a separate odd-width padding overwrite in the Chapter 7 async prefetch caller; its original failure is retained for a follow-up repair. This PR does not claim that whole gate passed. No performance improvement is claimed from these correctness checks.

The review checkpoint records the earlier full B200 suite (5,008 passed, 77 skipped, five failures), all five successful targeted reruns after runner-environment corrections, and the remaining example/lab sweep. Execution uses direct processes without a Slurm requirement; virtualized-host evidence remains noncanonical.
