### PR TITLE
Repair compilation verification and Chapter 13/16 runtime failures

### DIFF
--- a/code/ch13/baseline_memory_profiling.py
+++ b/code/ch13/baseline_memory_profiling.py
@@ -73,6 +73,7 @@ class BaselineMemoryProfilingBenchmark(VerificationPayloadMixin, BaseBenchmark):
         if self.model is None or self.inputs is None or self.targets is None or self.criterion is None:
             raise RuntimeError("Benchmark not configured")
         with self._nvtx_range("baseline_memory_profiling"):
+            self.model.zero_grad(set_to_none=True)
             outputs = self.model(self.inputs)
             loss = self.criterion(outputs, self.targets)
             loss.backward()

--- a/code/ch13/baseline_precisionfp8_te.py
+++ b/code/ch13/baseline_precisionfp8_te.py
@@ -60,6 +60,9 @@ class TEFP16MLP(nn.Module):
 class BaselineTEFP8Benchmark(VerificationPayloadMixin, BaseBenchmark):
     """Baseline Transformer Engine run in float16 precision."""
 
+    signature_equivalence_group = "ch13_precisionfp8_te_precision"
+    signature_equivalence_ignore_fields = ("precision_flags",)
+
     def __init__(self):
         super().__init__()
         self.model: Optional[nn.Module] = None
@@ -176,10 +179,6 @@ class BaselineTEFP8Benchmark(VerificationPayloadMixin, BaseBenchmark):
             reduced_precision_time_ms=None,
             precision_type="fp8",
         )
-
-    def get_output_for_verification(self) -> Optional[torch.Tensor]:
-        # Use the latest inputs as representative output; optimized path returns a static input snapshot.
-        return self.inputs
 
     def validate_result(self) -> Optional[str]:
         if self.model is None:

--- a/code/ch13/baseline_regional_compile.py
+++ b/code/ch13/baseline_regional_compile.py
@@ -124,7 +124,7 @@ class BaselineFullGraphCompileBenchmark(VerificationPayloadMixin, BaseBenchmark)
             )
         self._verify_output_buffer = torch.empty(
             self.batch_size,
-            min(128, max(self.sequence_schedule)),
+            max(self.sequence_schedule),
             self.hidden,
             device=self.device,
             dtype=torch.float32,
@@ -156,9 +156,10 @@ class BaselineFullGraphCompileBenchmark(VerificationPayloadMixin, BaseBenchmark)
             self.output = self.compiled_model(x)
         if self.output is None:
             raise RuntimeError("benchmark_fn() must produce output for verification")
-        if self._verify_x is None:
-            self._verify_x = x
-            self._verify_output = self.output
+        # Compiled graph storage can be reused on subsequent iterations. Keep
+        # the input and output from the latest timed invocation together.
+        self._verify_x = x
+        self._verify_output = self.output
 
     def capture_verification_payload(self) -> None:
         if self._verify_x is None or self._verify_output is None or self._verify_output_buffer is None:
@@ -166,11 +167,10 @@ class BaselineFullGraphCompileBenchmark(VerificationPayloadMixin, BaseBenchmark)
         x = self._verify_x
         verify_output = self._verify_output_buffer[
             : self._verify_output.shape[0],
-            : min(self._verify_output.shape[1], self._verify_output_buffer.shape[1]),
+            : self._verify_output.shape[1],
             :,
         ]
-        output_slice = self._verify_output[:, : verify_output.shape[1], :]
-        verify_output.copy_(output_slice)
+        verify_output.copy_(self._verify_output)
         self._set_verification_payload(
             inputs={"input": x},
             output=verify_output,
@@ -196,6 +196,7 @@ class BaselineFullGraphCompileBenchmark(VerificationPayloadMixin, BaseBenchmark)
 
     def get_config(self) -> BenchmarkConfig:
         return BenchmarkConfig(
+            adaptive_iterations=False,
             iterations=8,
             warmup=10,
             enable_memory_tracking=False,

--- a/code/ch13/optimized_kv_cache_naive_pool.py
+++ b/code/ch13/optimized_kv_cache_naive_pool.py
@@ -133,9 +133,10 @@ class SimpleAttentionLayer(nn.Module):
             self.prepare_inference()
         x_2d = x.reshape(x.size(0) * x.size(1), self.hidden_dim)
         qkv_2d = self._qkv_buffer_for(x)
-        qkv = torch.matmul(x_2d, self._qkv_weight_t, out=qkv_2d)
         if self.qkv.bias is not None:
-            qkv.add_(self.qkv.bias)
+            qkv = torch.addmm(self.qkv.bias, x_2d, self._qkv_weight_t, out=qkv_2d)
+        else:
+            qkv = torch.mm(x_2d, self._qkv_weight_t, out=qkv_2d)
         return qkv.view(x.size(0), x.size(1), self.hidden_dim * 3)
     
     def forward(self, x: torch.Tensor, kv_cache: OptimizedKVCache, request_id: str, layer_idx: int, cache_pos: int) -> torch.Tensor:

--- a/code/ch13/optimized_precisionfp8_te.py
+++ b/code/ch13/optimized_precisionfp8_te.py
@@ -71,6 +71,9 @@ class TEFP8MLP(nn.Module):
 class OptimizedTEFP8Benchmark(VerificationPayloadMixin, BaseBenchmark):
     """Eager FP8 path using Transformer Engine."""
 
+    signature_equivalence_group = "ch13_precisionfp8_te_precision"
+    signature_equivalence_ignore_fields = ("precision_flags",)
+
     def __init__(self):
         super().__init__()
         self.model: Optional[nn.Module] = None
@@ -224,9 +227,6 @@ class OptimizedTEFP8Benchmark(VerificationPayloadMixin, BaseBenchmark):
             reduced_precision_time_ms=getattr(self, "_last_elapsed_ms", None),
             precision_type="fp8",
         )
-
-    def get_output_for_verification(self) -> Optional[torch.Tensor]:
-        return self._verify_input
 
     def validate_result(self) -> Optional[str]:
         if self.model is None:

--- a/code/ch13/optimized_regional_compile.py
+++ b/code/ch13/optimized_regional_compile.py
@@ -149,7 +149,7 @@ class OptimizedRegionalCompileBenchmark(VerificationPayloadMixin, BaseBenchmark)
             )
         self._verify_output_buffer = torch.empty(
             self.batch_size,
-            min(128, max(self.sequence_schedule)),
+            max(self.sequence_schedule),
             self.hidden,
             device=self.device,
             dtype=torch.float32,
@@ -181,9 +181,9 @@ class OptimizedRegionalCompileBenchmark(VerificationPayloadMixin, BaseBenchmark)
             self.output = self.model(x)
         if self.output is None:
             raise RuntimeError("benchmark_fn() must produce output for verification")
-        if self._verify_x is None:
-            self._verify_x = x
-            self._verify_output = self.output
+        # Match the output to the latest bucket, including after warmup.
+        self._verify_x = x
+        self._verify_output = self.output
 
     def capture_verification_payload(self) -> None:
         if self._verify_x is None or self._verify_output is None or self._verify_output_buffer is None:
@@ -191,11 +191,10 @@ class OptimizedRegionalCompileBenchmark(VerificationPayloadMixin, BaseBenchmark)
         x = self._verify_x
         verify_output = self._verify_output_buffer[
             : self._verify_output.shape[0],
-            : min(self._verify_output.shape[1], self._verify_output_buffer.shape[1]),
+            : self._verify_output.shape[1],
             :,
         ]
-        output_slice = self._verify_output[:, : verify_output.shape[1], :]
-        verify_output.copy_(output_slice)
+        verify_output.copy_(self._verify_output)
         self._set_verification_payload(
             inputs={"input": x},
             output=verify_output,
@@ -222,6 +221,7 @@ class OptimizedRegionalCompileBenchmark(VerificationPayloadMixin, BaseBenchmark)
         # NOTE: warmup=10 is REQUIRED to ensure torch.compile JIT overhead is NOT
         # included in measurements. The first few calls trigger compilation.
         return BenchmarkConfig(
+            adaptive_iterations=False,
             iterations=8,
             warmup=10,  # Required for torch.compile - excludes JIT overhead from timing
             enable_memory_tracking=False,

--- a/code/ch16/optimized_dense_attention_flash.py
+++ b/code/ch16/optimized_dense_attention_flash.py
@@ -168,7 +168,7 @@ class OptimizedDenseAttentionFlashBenchmark(VerificationPayloadMixin, BaseBenchm
         )
         
         # Output projection
-        self._attn_merge_buffer.copy_(output.transpose(1, 2))
+        self._attn_merge_buffer.view(B, S, self.num_heads, self.head_dim).copy_(output.transpose(1, 2))
         return torch.matmul(self._attn_merge_buffer, self._out_proj_weight_t, out=self._output_buffer)
     
     def benchmark_fn(self) -> None:

--- a/code/ch16/optimized_dense_attention_flash_blackwell_variant.py
+++ b/code/ch16/optimized_dense_attention_flash_blackwell_variant.py
@@ -166,7 +166,7 @@ class DenseAttentionFlashBlackwellVariantBenchmark(VerificationPayloadMixin, Bas
             dropout_p=0.0,
         )
         
-        self._attn_merge_buffer.copy_(output.transpose(1, 2))
+        self._attn_merge_buffer.view(B, S, self.num_heads, self.head_dim).copy_(output.transpose(1, 2))
         return torch.matmul(self._attn_merge_buffer, self._out_proj_weight_t, out=self._output_buffer)
     
     def benchmark_fn(self) -> None:

--- a/code/core/harness/run_benchmarks.py
+++ b/code/core/harness/run_benchmarks.py
@@ -1103,6 +1103,13 @@ def _resolve_min_speedup_for_success(result_entry: Dict[str, Any]) -> float:
     return configured
 
 
+def _resolve_optimization_goal(
+    benchmark_goal: Optional[str], expectation_goal: Optional[str]
+) -> str:
+    """Use the executable's declared goal ahead of historical result metadata."""
+    return str(benchmark_goal or expectation_goal or "speed").strip().lower()
+
+
 def _update_best_measured_speedup(result_entry: Dict[str, Any]) -> Optional[float]:
     """Keep regressions visible instead of treating the baseline as a candidate."""
     measured = [
@@ -6839,8 +6846,9 @@ def _test_chapter_impl(
                 try:
                     if optimized_benchmark is not None:
                         opt_goal = optimized_benchmark.get_optimization_goal()
-                        if not expectation_goal:
-                            result_entry['optimization_goal'] = opt_goal
+                        result_entry['optimization_goal'] = _resolve_optimization_goal(
+                            opt_goal, expectation_goal
+                        )
                         min_speedup = optimized_benchmark.get_min_speedup_for_success()
                         min_speedup_f = _coerce_finite_float(min_speedup)
                         if (

--- a/code/tests/test_benchmark_hygiene_regressions.py
+++ b/code/tests/test_benchmark_hygiene_regressions.py
@@ -5914,7 +5914,7 @@ def test_ch16_optimized_dense_attention_flash_reuses_projection_buffers() -> Non
         assert "self._qkv_weight_t = self.qkv_proj.weight.t()" in setup_section
         assert "self._out_proj_weight_t = self.out_proj.weight.t()" in setup_section
         assert "qkv = torch.matmul(self.inputs, self._qkv_weight_t, out=self._qkv_buffer)" in forward_section
-        assert "self._attn_merge_buffer.copy_(output.transpose(1, 2))" in forward_section
+        assert "self._attn_merge_buffer.view(B, S, self.num_heads, self.head_dim).copy_(output.transpose(1, 2))" in forward_section
         assert "return torch.matmul(self._attn_merge_buffer, self._out_proj_weight_t, out=self._output_buffer)" in forward_section
         assert "output.transpose(1, 2).contiguous().view" not in forward_section
         assert "self.qkv_proj.weight.t()" not in forward_section
@@ -22298,11 +22298,11 @@ def test_ch13_regional_compile_moves_verification_materialization_out_of_hot_loo
         assert "self._verify_output = self.output" in benchmark_section
         assert "self._verify_output_buffer: Optional[torch.Tensor] = None" in source
         assert "self._verify_output_buffer = torch.empty(" in source
-        assert "min(128, max(self.sequence_schedule))" in source
+        assert "min(128, max(self.sequence_schedule))" not in source
+        assert "if self._verify_x is None:" not in benchmark_section
         assert "verify_output = self._verify_output_buffer[" in capture_section
-        assert "min(self._verify_output.shape[1], self._verify_output_buffer.shape[1])" in capture_section
-        assert "output_slice = self._verify_output[:, : verify_output.shape[1], :]" in capture_section
-        assert "verify_output.copy_(output_slice)" in capture_section
+        assert ": self._verify_output.shape[1]" in capture_section
+        assert "verify_output.copy_(self._verify_output)" in capture_section
         assert "output=verify_output" in capture_section
         assert "output=self._verify_output.float().clone()" not in capture_section
 

--- a/code/tests/test_benchmark_hygiene_regressions.py
+++ b/code/tests/test_benchmark_hygiene_regressions.py
@@ -19187,7 +19187,10 @@ def test_ch13_token_kv_cache_attention_skips_contiguous_for_single_token_decode(
         assert "def prepare_inference(self) -> None:" in source
         assert "self._qkv_weight_t = self.qkv.weight.t()" in source
         assert "def _qkv_buffer_for(self, x: torch.Tensor) -> torch.Tensor:" in source
-        assert "torch.matmul(x_2d, self._qkv_weight_t, out=qkv_2d)" in source
+        if filename == "optimized_kv_cache_naive_pool.py":
+            assert "torch.addmm(self.qkv.bias, x_2d, self._qkv_weight_t, out=qkv_2d)" in source
+        else:
+            assert "torch.matmul(x_2d, self._qkv_weight_t, out=qkv_2d)" in source
         assert "qkv = self._project_qkv(x)" in forward_section
         assert "qkv = self.qkv(x)" not in forward_section
 

--- a/code/tests/test_ch13_breadth_regressions.py
+++ b/code/tests/test_ch13_breadth_regressions.py
@@ -1,0 +1,69 @@
+"""Controls for Chapter 13 failures found by the direct B200 sweep."""
+import pytest
+import torch
+
+from ch13.baseline_memory_profiling import BaselineMemoryProfilingBenchmark, SimpleModel
+from ch13.optimized_memory_profiling import OptimizedMemoryProfilingBenchmark, OptimizedModel
+from ch13.optimized_kv_cache_naive_pool import SimpleAttentionLayer
+from core.harness.run_benchmarks import _resolve_optimization_goal
+
+
+def test_declared_memory_goal_takes_precedence_over_historical_speed_metadata():
+    benchmark = object.__new__(OptimizedMemoryProfilingBenchmark)
+    assert _resolve_optimization_goal(benchmark.get_optimization_goal(), "speed") == "memory"
+    assert _resolve_optimization_goal(None, "memory") == "memory"
+    assert _resolve_optimization_goal(None, None) == "speed"
+
+
+def test_memory_pair_matches_all_gradients_on_repeated_iterations():
+    class CpuBaseline(BaselineMemoryProfilingBenchmark):
+        allow_cpu = True
+
+    class CpuOptimized(OptimizedMemoryProfilingBenchmark):
+        allow_cpu = True
+
+    torch.manual_seed(42)
+    baseline = CpuBaseline()
+    optimized = CpuOptimized()
+    baseline.model = SimpleModel(hidden_dim=16)
+    optimized.model = OptimizedModel(hidden_dim=16)
+    optimized.model.load_state_dict(baseline.model.state_dict())
+    for benchmark in (baseline, optimized):
+        benchmark.inputs = torch.randn(4, 16)
+        benchmark.targets = torch.randn(4, 16)
+        benchmark.criterion = torch.nn.MSELoss()
+        benchmark.output = None
+    optimized.inputs = baseline.inputs.clone()
+    optimized.targets = baseline.targets.clone()
+    first = None
+    for _ in range(3):
+        baseline.benchmark_fn()
+        optimized.benchmark_fn()
+        torch.testing.assert_close(baseline.output, optimized.output)
+        gradients = torch.cat([p.grad.flatten() for p in baseline.model.parameters()])
+        candidate = torch.cat([p.grad.flatten() for p in optimized.model.parameters()])
+        torch.testing.assert_close(gradients, candidate)
+        if first is None:
+            first = gradients.clone()
+        else:
+            torch.testing.assert_close(gradients, first, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("with_bias", [True, False])
+def test_pool_projection_fuses_bias_and_reuses_full_output_storage(with_bias):
+    torch.manual_seed(13)
+    layer = SimpleAttentionLayer(16, 4, 4, dtype=torch.float32).eval()
+    if not with_bias:
+        layer.qkv.bias = None
+    layer.prepare_inference()
+    inputs = torch.randn(2, 1, 16)
+    with torch.inference_mode():
+        expected = layer.qkv(inputs)
+        actual = layer._project_qkv(inputs)
+        torch.testing.assert_close(actual, expected)
+        pointer = actual.data_ptr()
+        next_input = inputs * 2
+        next_expected = layer.qkv(next_input)
+        next_actual = layer._project_qkv(next_input)
+        torch.testing.assert_close(next_actual, next_expected)
+        assert next_actual.data_ptr() == pointer

--- a/code/tests/test_ch13_breadth_regressions.py
+++ b/code/tests/test_ch13_breadth_regressions.py
@@ -67,3 +67,63 @@ def test_pool_projection_fuses_bias_and_reuses_full_output_storage(with_bias):
         next_actual = layer._project_qkv(next_input)
         torch.testing.assert_close(next_actual, next_expected)
         assert next_actual.data_ptr() == pointer
+
+
+def test_regional_pair_verifies_latest_bucket_and_every_output_token():
+    from ch13.baseline_regional_compile import (
+        BaselineFullGraphCompileBenchmark,
+        TinyTransformerBlock as FullBlock,
+    )
+    from ch13.optimized_regional_compile import (
+        OptimizedRegionalCompileBenchmark,
+        TinyTransformerBlock as RegionalBlock,
+    )
+
+    class CpuBaseline(BaselineFullGraphCompileBenchmark):
+        allow_cpu = True
+
+    class CpuOptimized(OptimizedRegionalCompileBenchmark):
+        allow_cpu = True
+
+    torch.manual_seed(42)
+    baseline, optimized = CpuBaseline(), CpuOptimized()
+    baseline.model = FullBlock(hidden=16, num_heads=4, mlp_hidden=32).eval()
+    baseline.compiled_model = baseline.model
+    optimized.model = RegionalBlock(hidden=16, num_heads=4, mlp_hidden=32).eval()
+    optimized.model.load_state_dict(baseline.model.state_dict())
+    inputs = {seq: torch.randn(2, seq, 16) for seq in (4, 129)}
+    for benchmark in (baseline, optimized):
+        benchmark.device = torch.device("cpu")
+        benchmark.batch_size = 2
+        benchmark.sequence_schedule = [4, 129]
+        benchmark.inputs = {seq: x.clone() for seq, x in inputs.items()}
+        benchmark._verify_output_buffer = torch.empty(2, 129, 16)
+        assert benchmark.get_config().adaptive_iterations is False
+
+    # Exercise the real model and benchmark/payload lifecycle at two bucket
+    # sizes. CUDA compilation and speed remain separate GPU validation gates.
+    for seq in (4, 129, 4, 129):
+        for benchmark in (baseline, optimized):
+            benchmark.benchmark_fn()
+            benchmark.capture_verification_payload()
+            torch.testing.assert_close(benchmark.get_verify_inputs()["input"], inputs[seq])
+            actual = benchmark.get_verify_output()
+            assert actual.shape == (2, seq, 16)
+            torch.testing.assert_close(actual, benchmark.output)
+        torch.testing.assert_close(baseline.get_verify_output(), optimized.get_verify_output())
+
+
+def test_te_pair_declares_only_precision_signature_equivalence():
+    from ch13.baseline_precisionfp8_te import BaselineTEFP8Benchmark
+    from ch13.optimized_precisionfp8_te import OptimizedTEFP8Benchmark
+    from core.benchmark.verification import get_signature_equivalence_spec
+
+    baseline = get_signature_equivalence_spec(BaselineTEFP8Benchmark)
+    optimized = get_signature_equivalence_spec(OptimizedTEFP8Benchmark)
+    assert baseline == optimized
+    assert baseline.group == "ch13_precisionfp8_te_precision"
+    assert baseline.ignore_fields == ("precision_flags",)
+    # Real output capture comes from VerificationPayloadMixin, never a legacy
+    # accessor that returned the input unchanged.
+    assert "get_output_for_verification" not in BaselineTEFP8Benchmark.__dict__
+    assert "get_output_for_verification" not in OptimizedTEFP8Benchmark.__dict__

--- a/code/tests/test_ch16_dense_attention_regressions.py
+++ b/code/tests/test_ch16_dense_attention_regressions.py
@@ -1,0 +1,44 @@
+"""Execute attention tensor paths on CPU; full CUDA setup is tested on B200."""
+
+import pytest
+import torch
+
+from ch16.baseline_dense_attention_flash import BaselineDenseAttentionFlashBenchmark
+from ch16.optimized_dense_attention_flash import OptimizedDenseAttentionFlashBenchmark
+from ch16.optimized_dense_attention_flash_blackwell_variant import DenseAttentionFlashBlackwellVariantBenchmark
+
+
+@pytest.mark.parametrize("benchmark_class", [
+    OptimizedDenseAttentionFlashBenchmark,
+    DenseAttentionFlashBlackwellVariantBenchmark,
+])
+def test_flash_head_merge_matches_full_naive_attention_and_reuses_storage(benchmark_class):
+    torch.manual_seed(16)
+    # Exercise the production tensor method without its CUDA-only constructor.
+    baseline = object.__new__(BaselineDenseAttentionFlashBenchmark)
+    optimized = object.__new__(benchmark_class)
+    batch, seq, hidden, heads = 2, 17, 16, 4
+    qkv = torch.nn.Linear(hidden, hidden * 3, bias=False)
+    out = torch.nn.Linear(hidden, hidden, bias=False)
+    for benchmark in (baseline, optimized):
+        benchmark.hidden_dim = hidden
+        benchmark.num_heads = heads
+        benchmark.head_dim = hidden // heads
+        benchmark.qkv_proj = qkv
+        benchmark.out_proj = out
+    baseline._causal_mask = torch.ones(seq, seq, dtype=torch.bool).triu(1)
+    optimized._qkv_weight_t = qkv.weight.t()
+    optimized._out_proj_weight_t = out.weight.t()
+    optimized._qkv_buffer = torch.empty(batch, seq, hidden * 3)
+    optimized._attn_merge_buffer = torch.empty(batch, seq, hidden)
+    optimized._output_buffer = torch.empty(batch, seq, hidden)
+    output_pointer = optimized._output_buffer.data_ptr()
+    with torch.inference_mode():
+        for _ in range(3):
+            baseline.inputs = torch.randn(batch, seq, hidden)
+            optimized.inputs = baseline.inputs.clone()
+            expected = baseline._forward_naive()
+            actual = optimized._forward_flash()
+            assert actual.shape == (batch, seq, hidden)
+            assert actual.data_ptr() == output_pointer
+            torch.testing.assert_close(actual, expected)

--- a/docs/reviews/2026-09-06-codebase-repair-checkpoint.md
+++ b/docs/reviews/2026-09-06-codebase-repair-checkpoint.md
@@ -837,6 +837,43 @@ expected workload ranges. The harness now uses that path; 38 profiler-contract
 tests pass with one skip. Original failed receipts remain intact, and the
 remaining DDP optimized capture is still required.
 
+Wave 22 on `48ab6ff1a` passed all 87 focused B200 tests, including the four
+previous full-suite failures. Both training-patterns targets passed complete
+two-rank verification, with initial ratios of 1.512702 and 1.413125. Every
+stage drained. Wave 23 then passed all 16 interleaved timing observations and
+both Nsys captures. The rank-maximum median fell from 23.785251 to 15.793236 ms
+per step (1.506040 ratio); the four block ratios were 1.506725, 1.369103,
+1.526312 and 1.508860. The slower optimized observation remains in the data.
+
+The actual 100-step Nsys ranges contain 257,000 baseline kernel launches per
+rank and 157,000 optimized launches. The optimized path uses 1,600 batched-copy
+kernels for the complete gradient packing/unpacking workload, with 200 NCCL
+barrier kernels; the baseline performs 51,200 NCCL per-parameter reductions.
+These are unlocked diagnostic measurements on the same two-B200 host, with
+full-output checks across every timing and profiler invocation.
+
+The corrected validator also passed all three retained Wave 21 reports.
+Fresh baseline and optimized DDP captures on `48ab6ff1a` passed full worker
+verification and workload-range checks. Their profiled timings are separate
+from the previously retained ABBA measurements; no DDP speed win is claimed.
+The breadth continuation then resumed automatically from the original ledger
+plus the actual Wave 22 outcomes.
+
+The next breadth segment reached Chapter 15 and exposed further failures.
+In the memory-profiling pair, stale expectation metadata labeled the study as
+a speed goal despite the executable declaring a memory goal. The harness now
+gives the executable's declaration priority. The baseline also accumulated
+gradients while the optimized variant cleared them; both now clear gradients
+before the same backward pass. Full gradient comparisons pass across repeated
+CPU iterations. Previous memory savings do not establish a fair checkpointing
+benefit under the corrected gradient lifecycle.
+
+The pooled KV-cache candidate fuses its QKV matrix multiply and bias addition
+into `addmm`, reusing the same output buffer and preserving the bias-free path.
+Complete projection-output and storage-reuse controls pass. These Chapter 13
+repairs passed 28 focused CPU tests and the 553-test hygiene lane (one skip);
+their actual B200 reruns are pending while the existing sweep continues.
+
 The cache-aware disaggregation performance miss also has a precise topology
 limit: one prefill rank plus one decode rank produces identical baseline and
 optimized locality routes. At least two decode ranks are necessary to test

--- a/docs/reviews/2026-09-06-codebase-repair-checkpoint.md
+++ b/docs/reviews/2026-09-06-codebase-repair-checkpoint.md
@@ -888,6 +888,36 @@ The IBGDA examples therefore retain their explicit runtime/hardware gate;
 Grace/GB10-specific examples still require the named hardware, and NVFP4
 TensorRT-LLM execution still requires a compatible engine asset.
 
+### Chapter 13/16 follow-up and main merge
+
+PR #18 merged as `dcd2c55d594dcacf6974b1a179c1eec69bf24153` after all
+four exact-head CI checks passed. Its tree matches the tested `48ab6ff1a`
+tree. The CPU suite passed 5,136 tests with 503 skips; the core contract lane
+passed 751 tests with one skip. Dual-architecture validation also passed.
+Runtime receipts retain their actual source commits.
+
+The continued B200 sweep exposed additional correctness defects. Both
+Chapter 13 regional-compilation arms retained the first warmup output and
+truncated verification to 128 tokens. They now capture the latest input and
+complete output and use a fixed iteration count so their rotating sequence
+buckets match. The Transformer Engine FP16/FP8 pair now explicitly declares
+precision-signature equivalence while retaining its actual precision flags
+and numerical tolerances. Obsolete accessors that returned the input as an
+output have been removed; the actual payload remains the model output.
+
+Both dense Flash Attention variants now view their preallocated merge buffer
+as `[batch, sequence, heads, head_dim]` when copying the transposed attention
+heads. Previously that four-dimensional tensor was copied into a
+three-dimensional buffer and failed at runtime. Full CPU attention-output
+comparisons and storage-reuse checks cover both variants. The focused and
+hygiene run passed 561 tests with one skip. GPU reruns of these new repairs
+are pending; the original failures remain preserved.
+
+The Chapter 14 regional Triton example also produced a native crash during
+isolated-process cleanup. Its complete stderr is retained. Cold-cache
+vanilla and repository-path reproductions are required before attributing
+that failure to the toolchain or changing a compiler mode.
+
 - Run the complete GPU test suite on the final merged revision.
 - Complete all four sweep stages and reconcile the 486-target inventory,
   including unsupported and failed cases rather than silently dropping them.


### PR DESCRIPTION
Regional compilation retained its first warmup output and verified only 128 tokens. Both arms now compare the latest complete output and use fixed iteration counts for matching sequence buckets. Transformer Engine explicitly declares its intentional FP16/FP8 signature difference, and both dense Flash Attention variants copy head tensors through a correctly shaped view of their reusable output buffer.

The memory study now clears baseline gradients on every iteration and gives its executable memory goal precedence over stale expectation metadata. Pooled KV projection uses fused addmm for its bias. Numerical tolerances and speed thresholds are unchanged.

Validation: 561 focused/hygiene CPU tests passed, one skipped; 60 focused tests passed on B200. Full B200 regional-compilation and dense-attention correctness checks passed. Transformer Engine and pooled KV also passed correctness but retained speed misses, and the corrected memory study showed no memory benefit. Those results remain explicit in the dated review checkpoint. Full CPU and dual-architecture CI run against this exact head.
