### PR TITLE
Reuse pooled KV views and remove RoPE cache copies

### DIFF
--- a/code/ch13/optimized_kv_cache_naive_pool.py
+++ b/code/ch13/optimized_kv_cache_naive_pool.py
@@ -42,6 +42,8 @@ class OptimizedKVCache:
         self.dtype = dtype
         self.device = device
         self.cache_pool = []
+        self._token_views = []
+        self._prefix_views = []
         self.allocated_caches = {}
         # The benchmark processes requests sequentially (single in-flight request),
         # so a small pool demonstrates reuse without inflating the allocator's
@@ -49,6 +51,8 @@ class OptimizedKVCache:
         pool_size = 2
         for _ in range(pool_size):
             cache_entry = []
+            token_views = []
+            prefix_views = []
             for _ in range(self.num_layers):
                 # Store in SDPA layout: [batch, heads, seq, dim] to avoid permutes.
                 k = torch.empty(
@@ -61,7 +65,14 @@ class OptimizedKVCache:
                 )
                 v = torch.empty_like(k)
                 cache_entry.append((k, v))
+                token_views.append(list(zip(k.unbind(2), v.unbind(2), strict=True)))
+                prefix_views.append([
+                    (k[:, :, :end, :], v[:, :, :end, :])
+                    for end in range(self.max_seq_len + 1)
+                ])
             self.cache_pool.append(cache_entry)
+            self._token_views.append(token_views)
+            self._prefix_views.append(prefix_views)
         self.free_indices = list(range(pool_size))
 
     def allocate(self, request_id: str) -> None:
@@ -77,12 +88,16 @@ class OptimizedKVCache:
         if request_id not in self.allocated_caches:
             self.allocate(request_id)
         cache_idx = self.allocated_caches[request_id]
-        cache_k, cache_v = self.cache_pool[cache_idx][layer_idx]
-        cache_k[:, :, pos, :].copy_(k)
-        cache_v[:, :, pos, :].copy_(v)
+        # Fixed-capacity token views are prepared once with the pool. Avoid
+        # rebuilding strided views for every layer of every decoded token.
+        cache_k, cache_v = self._token_views[cache_idx][layer_idx][pos]
+        cache_k.copy_(k)
+        cache_v.copy_(v)
 
     def get(self, request_id: str, layer_idx: int, start: int, end: int) -> tuple[torch.Tensor, torch.Tensor]:
         cache_idx = self.allocated_caches[request_id]
+        if start == 0 and 0 <= end <= self.max_seq_len:
+            return self._prefix_views[cache_idx][layer_idx][end]
         cache_k, cache_v = self.cache_pool[cache_idx][layer_idx]
         return cache_k[:, :, start:end, :], cache_v[:, :, start:end, :]
 

--- a/code/ch18/baseline_rope_q_cache.py
+++ b/code/ch18/baseline_rope_q_cache.py
@@ -110,7 +110,7 @@ class BaselineRopeQCacheBenchmark(VerificationPayloadMixin, BaseBenchmark):
         self._cos_step_count = len(self._cos_step_views)
         self._sin_step_count = len(self._sin_step_views)
         self._step_group_count = len(self._step_groups)
-        self._output_view = self._cache_step_views[self.cfg.steps - 1]
+        self._output_view = self.cache[:, :, : self.cfg.steps, :]
         torch.cuda.synchronize(self.device)
 
     def benchmark_fn(self) -> None:
@@ -145,7 +145,7 @@ class BaselineRopeQCacheBenchmark(VerificationPayloadMixin, BaseBenchmark):
         if self.inputs is None or self.output is None:
             raise RuntimeError("benchmark_fn() must run before capture_verification_payload()")
         self._set_verification_payload(
-            inputs={"inputs": self.inputs[:1].detach()},
+            inputs={"inputs": self.inputs.detach()},
             output=self.output.detach(),
             batch_size=self.cfg.batch_size,
             parameter_count=0,

--- a/code/ch18/optimized_rope_q_cache.py
+++ b/code/ch18/optimized_rope_q_cache.py
@@ -1,4 +1,4 @@
-"""Optimized RoPE + Q projection + KV cache update (vectorized)."""
+"""Optimized RoPE + Q projection, writing rotations directly into the KV cache."""
 
 from __future__ import annotations
 
@@ -8,11 +8,11 @@ import torch
 
 from core.harness.benchmark_harness import BaseBenchmark, BenchmarkConfig, WorkloadMetadata
 from core.benchmark.verification_mixin import VerificationPayloadMixin
-from ch18.rope_q_cache_common import RopeQCacheConfig, apply_rope_inplace, build_rope_tables
+from ch18.rope_q_cache_common import RopeQCacheConfig, apply_rope_out, build_rope_tables
 
 
 class OptimizedRopeQCacheBenchmark(VerificationPayloadMixin, BaseBenchmark):
-    """Optimized: vectorized RoPE + single cache write per step."""
+    """Optimized: vectorized RoPE writes directly to the cache at each step."""
 
     def __init__(self, cfg: Optional[RopeQCacheConfig] = None) -> None:
         super().__init__()
@@ -22,7 +22,6 @@ class OptimizedRopeQCacheBenchmark(VerificationPayloadMixin, BaseBenchmark):
         self.cos: Optional[torch.Tensor] = None
         self.sin: Optional[torch.Tensor] = None
         self.cache: Optional[torch.Tensor] = None
-        self.rope_scratch: Optional[torch.Tensor] = None
         self.q_buffer: Optional[torch.Tensor] = None
         self.q_heads: Optional[torch.Tensor] = None
         self._input_step_views: list[torch.Tensor] = []
@@ -78,13 +77,6 @@ class OptimizedRopeQCacheBenchmark(VerificationPayloadMixin, BaseBenchmark):
             device=self.device,
             dtype=self.cfg.dtype,
         )
-        self.rope_scratch = torch.empty(
-            self.cfg.batch_size,
-            self.cfg.heads,
-            self.cfg.head_dim // 2,
-            device=self.device,
-            dtype=self.cfg.dtype,
-        )
         self.q_buffer = torch.empty(
             self.cfg.batch_size,
             self.cfg.hidden_size,
@@ -116,7 +108,7 @@ class OptimizedRopeQCacheBenchmark(VerificationPayloadMixin, BaseBenchmark):
         self._cos_step_count = len(self._cos_step_views)
         self._sin_step_count = len(self._sin_step_views)
         self._step_group_count = len(self._step_groups)
-        self._output_view = self._cache_step_views[self.cfg.steps - 1]
+        self._output_view = self.cache[:, :, : self.cfg.steps, :]
         torch.cuda.synchronize(self.device)
 
     def benchmark_fn(self) -> None:
@@ -126,7 +118,6 @@ class OptimizedRopeQCacheBenchmark(VerificationPayloadMixin, BaseBenchmark):
             or self.cos is None
             or self.sin is None
             or self.cache is None
-            or self.rope_scratch is None
             or self.q_buffer is None
             or self.q_heads is None
             or self._output_view is None
@@ -140,8 +131,7 @@ class OptimizedRopeQCacheBenchmark(VerificationPayloadMixin, BaseBenchmark):
         with torch.inference_mode():
             for x, cache_step, cos_t, sin_t in self._step_groups:
                 torch.mm(x, self.q_weight, out=self.q_buffer)
-                q = apply_rope_inplace(self.q_heads, cos_t, sin_t, self.rope_scratch)
-                cache_step.copy_(q)
+                apply_rope_out(self.q_heads, cos_t, sin_t, cache_step)
             self.output = self._output_view
         if self.output is None:
             raise RuntimeError("benchmark_fn() did not produce output")
@@ -150,7 +140,7 @@ class OptimizedRopeQCacheBenchmark(VerificationPayloadMixin, BaseBenchmark):
         if self.inputs is None or self.output is None:
             raise RuntimeError("benchmark_fn() must run before capture_verification_payload()")
         self._set_verification_payload(
-            inputs={"inputs": self.inputs[:1].detach()},
+            inputs={"inputs": self.inputs.detach()},
             output=self.output.detach(),
             batch_size=self.cfg.batch_size,
             parameter_count=0,
@@ -169,7 +159,6 @@ class OptimizedRopeQCacheBenchmark(VerificationPayloadMixin, BaseBenchmark):
         self.cos = None
         self.sin = None
         self.cache = None
-        self.rope_scratch = None
         self.q_buffer = None
         self.q_heads = None
         self._input_step_views = []

--- a/code/tests/test_benchmark_hygiene_regressions.py
+++ b/code/tests/test_benchmark_hygiene_regressions.py
@@ -10727,7 +10727,7 @@ def test_ch18_paged_vllm_cache_reset_is_metadata_only() -> None:
     assert "self.page_faults = 0" in cache_section
 
 
-def test_ch18_optimized_rope_q_cache_uses_inplace_rope_scratch() -> None:
+def test_ch18_optimized_rope_q_cache_writes_rope_directly_to_cache() -> None:
     from ch18.rope_q_cache_common import apply_rope, apply_rope_inplace, apply_rope_out, build_rope_tables
 
     common_source = (REPO_ROOT / "ch18" / "rope_q_cache_common.py").read_text(encoding="utf-8")
@@ -10777,7 +10777,7 @@ def test_ch18_optimized_rope_q_cache_uses_inplace_rope_scratch() -> None:
     assert "self._cos_step_count = len(self._cos_step_views)" in baseline_setup
     assert "self._sin_step_count = len(self._sin_step_views)" in baseline_setup
     assert "self._step_group_count = len(self._step_groups)" in baseline_setup
-    assert "self._output_view = self._cache_step_views[self.cfg.steps - 1]" in baseline_setup
+    assert "self._output_view = self.cache[:, :, : self.cfg.steps, :]" in baseline_setup
     assert "emb = torch.cat([freqs, freqs], dim=-1)" not in common_source
     assert "cos[:, :half].copy_(cos_half)" in common_source
     assert "sin[:, half:].copy_(sin_half)" in common_source
@@ -10824,7 +10824,7 @@ def test_ch18_optimized_rope_q_cache_uses_inplace_rope_scratch() -> None:
     assert "q[:, h, :]" not in baseline_benchmark
     assert "self.cache = torch.empty(" in setup_section
     assert "self.cache = torch.zeros(" not in setup_section
-    assert "self.rope_scratch = torch.empty(" in setup_section
+    assert "self.rope_scratch" not in source
     assert "self.q_buffer: Optional[torch.Tensor] = None" in source
     assert "self.q_heads: Optional[torch.Tensor] = None" in source
     assert "self._input_step_views: list[torch.Tensor] = []" in source
@@ -10847,7 +10847,7 @@ def test_ch18_optimized_rope_q_cache_uses_inplace_rope_scratch() -> None:
     assert "self._cos_step_count = len(self._cos_step_views)" in setup_section
     assert "self._sin_step_count = len(self._sin_step_views)" in setup_section
     assert "self._step_group_count = len(self._step_groups)" in setup_section
-    assert "self._output_view = self._cache_step_views[self.cfg.steps - 1]" in setup_section
+    assert "self._output_view = self.cache[:, :, : self.cfg.steps, :]" in setup_section
     assert "for x, cache_step, cos_t, sin_t in self._step_groups:" in benchmark_section
     assert "self._input_step_count != self.cfg.steps" in benchmark_section
     assert "self._cache_step_count != self.cfg.steps" in benchmark_section
@@ -10861,7 +10861,8 @@ def test_ch18_optimized_rope_q_cache_uses_inplace_rope_scratch() -> None:
     assert "len(self._step_groups)" not in benchmark_section
     assert "zip(" not in benchmark_section
     assert "torch.mm(x, self.q_weight, out=self.q_buffer)" in benchmark_section
-    assert "apply_rope_inplace(self.q_heads, cos_t, sin_t, self.rope_scratch)" in benchmark_section
+    assert "apply_rope_out(self.q_heads, cos_t, sin_t, cache_step)" in benchmark_section
+    assert "cache_step.copy_(q)" not in benchmark_section
     assert "apply_rope(q, cos_t, sin_t)" not in benchmark_section
     assert "q = x @ self.q_weight" not in benchmark_section
     assert "self.cache[:, :, step, :] = q" not in benchmark_section

--- a/code/tests/test_ch13_breadth_regressions.py
+++ b/code/tests/test_ch13_breadth_regressions.py
@@ -127,3 +127,31 @@ def test_te_pair_declares_only_precision_signature_equivalence():
     # accessor that returned the input unchanged.
     assert "get_output_for_verification" not in BaselineTEFP8Benchmark.__dict__
     assert "get_output_for_verification" not in OptimizedTEFP8Benchmark.__dict__
+
+
+def test_pool_reuses_views_and_matches_every_prefix_across_requests():
+    from ch13.optimized_kv_cache_naive_pool import OptimizedKVCache
+
+    cache = OptimizedKVCache(23, 2, 2, 3, 4, torch.float32, torch.device("cpu"))
+    torch.manual_seed(13)
+    for request_number, length in enumerate((23, 7, 19)):
+        request = str(request_number)
+        cache.allocate(request)
+        keys, values = [[], []], [[], []]
+        for pos in range(length):
+            for layer in range(2):
+                k, v = torch.randn(2, 3, 4), torch.randn(2, 3, 4)
+                keys[layer].append(k)
+                values[layer].append(v)
+                cache.append(request, layer, k, v, pos)
+                actual = cache.get(request, layer, 0, pos + 1)
+                expected_k = torch.stack(keys[layer], dim=2)
+                expected_v = torch.stack(values[layer], dim=2)
+                torch.testing.assert_close(actual[0], expected_k, rtol=0, atol=0)
+                torch.testing.assert_close(actual[1], expected_v, rtol=0, atol=0)
+                assert cache.get(request, layer, 0, pos + 1) is actual
+                tail_k, tail_v = cache.get(request, layer, 1, pos + 1)
+                torch.testing.assert_close(tail_k, expected_k[:, :, 1:, :], rtol=0, atol=0)
+                torch.testing.assert_close(tail_v, expected_v[:, :, 1:, :], rtol=0, atol=0)
+        cache.free(request)
+    assert len(cache.free_indices) == 2

--- a/code/tests/test_ch18_rope_cache_regressions.py
+++ b/code/tests/test_ch18_rope_cache_regressions.py
@@ -1,0 +1,55 @@
+"""Full cache controls for the production sequential RoPE benchmark loop."""
+
+import torch
+
+from ch18.baseline_rope_q_cache import BaselineRopeQCacheBenchmark
+from ch18.optimized_rope_q_cache import OptimizedRopeQCacheBenchmark
+from ch18.rope_q_cache_common import RopeQCacheConfig, build_rope_tables
+
+
+def test_rope_direct_cache_writes_match_every_step_and_preserve_unused_tail():
+    class CpuBaseline(BaselineRopeQCacheBenchmark):
+        allow_cpu = True
+
+    class CpuOptimized(OptimizedRopeQCacheBenchmark):
+        allow_cpu = True
+
+    cfg = RopeQCacheConfig(batch_size=2, heads=3, head_dim=8, steps=5, max_seq_len=7, dtype=torch.float32)
+    torch.manual_seed(18)
+    baseline, optimized = CpuBaseline(cfg), CpuOptimized(cfg)
+    inputs = torch.randn(cfg.steps, cfg.batch_size, cfg.hidden_size)
+    weight = torch.randn(cfg.hidden_size, cfg.hidden_size)
+    cos, sin = build_rope_tables(cfg.max_seq_len, cfg.head_dim, torch.device('cpu'), cfg.dtype)
+    for benchmark in (baseline, optimized):
+        benchmark.device = torch.device('cpu')
+        benchmark.inputs = inputs.clone()
+        benchmark.q_weight = weight.clone()
+        benchmark.cos, benchmark.sin = cos.clone(), sin.clone()
+        benchmark.cache = torch.full((cfg.batch_size, cfg.heads, cfg.max_seq_len, cfg.head_dim), float('nan'))
+        benchmark.q_buffer = torch.empty(cfg.batch_size, cfg.hidden_size)
+        benchmark.q_heads = benchmark.q_buffer.view(cfg.batch_size, cfg.heads, cfg.head_dim)
+        benchmark._input_step_views = list(benchmark.inputs.unbind(0))
+        benchmark._cache_step_views = [benchmark.cache[:, :, step, :] for step in range(cfg.steps)]
+        benchmark._cos_step_views = [cos[step].view(1, 1, cfg.head_dim) for step in range(cfg.steps)]
+        benchmark._sin_step_views = [sin[step].view(1, 1, cfg.head_dim) for step in range(cfg.steps)]
+        benchmark._step_groups = list(zip(benchmark._input_step_views, benchmark._cache_step_views, benchmark._cos_step_views, benchmark._sin_step_views, strict=True))
+        benchmark._input_step_count = benchmark._cache_step_count = cfg.steps
+        benchmark._cos_step_count = benchmark._sin_step_count = benchmark._step_group_count = cfg.steps
+        benchmark._output_view = benchmark.cache[:, :, :cfg.steps, :]
+    baseline.rope_out = torch.empty(cfg.batch_size, cfg.heads, cfg.head_dim)
+    for repetition in range(3):
+        changed_inputs = inputs + repetition
+        expected = []
+        for step, x in enumerate(changed_inputs):
+            q = (x @ weight).view(cfg.batch_size, cfg.heads, cfg.head_dim)
+            half = cfg.head_dim // 2
+            rotated = torch.cat((-q[..., half:], q[..., :half]), dim=-1)
+            expected.append(q * cos[step] + rotated * sin[step])
+        expected = torch.stack(expected, dim=2)
+        for benchmark in (baseline, optimized):
+            benchmark.inputs.copy_(changed_inputs)
+            benchmark.benchmark_fn()
+            benchmark.capture_verification_payload()
+            torch.testing.assert_close(benchmark.get_verify_output(), expected)
+            torch.testing.assert_close(benchmark.get_verify_inputs()['inputs'], changed_inputs)
+            assert torch.isnan(benchmark.cache[:, :, cfg.steps:, :]).all()

--- a/docs/reviews/2026-09-06-codebase-repair-checkpoint.md
+++ b/docs/reviews/2026-09-06-codebase-repair-checkpoint.md
@@ -918,6 +918,38 @@ isolated-process cleanup. Its complete stderr is retained. Cold-cache
 vanilla and repository-path reproductions are required before attributing
 that failure to the toolchain or changing a compiler mode.
 
+### Wave 24: Chapter 13/16 B200 reruns
+
+All nine stages on `5a59db088` drained their owned processes. The focused GPU
+lane passed 60 tests. Regional compilation now verifies the complete latest
+output, with maximum difference `0.03125`, and its diagnostic speed ratio was
+`1.0931`. Dense Flash Attention passes full verification with maximum
+difference `0.00048828125`; its diagnostic ratio was `12.9137`.
+
+The corrected memory-goal study passes execution and correctness, but does
+**not** show a memory benefit: baseline peak was `287.2974 MiB`, candidate
+peak `288.2974 MiB`, and the candidate was slower. The pooled KV-cache and
+Transformer Engine examples now pass correctness while retaining speed
+failures (`0.9478` and `0.6819` respectively). Passing a correctness gate does
+not turn these observations into optimization wins.
+
+Chapter 14 regional Triton passed a fresh cold-cache harness run. Separate
+cold-cache vanilla main-thread and worker-thread probes used the unchanged
+model definitions without importing repository modules. Both compared all
+outputs for 18 invocations and exited cleanly, with maximum difference
+`0.03125`. The original native crash remains an unreproduced failure; no
+compiler downgrade or toolchain attribution was added.
+
+Two further candidates are ready for measurement. The pooled KV cache now
+prepares token and prefix views when allocating the pool, avoiding repeated
+view construction in the decoding loop. RoPE writes its rotations directly
+into each cache slot, removing the scratch copy and final cache copy without
+batching future decoding steps. Both RoPE arms now verify every written
+cache slot and all step inputs. Full-prefix/cache CPU controls, including
+reused requests and untouched cache tails, pass; the focused/hygiene lane
+passed 561 tests with one skip. These candidates still require B200 timing
+and profiler evidence.
+
 - Run the complete GPU test suite on the final merged revision.
 - Complete all four sweep stages and reconcile the 486-target inventory,
   including unsupported and failed cases rather than silently dropping them.


### PR DESCRIPTION
The pooled KV cache now reuses token and prefix views prepared with its storage pool. RoPE writes each rotation directly to its cache slot, avoiding two copies while retaining sequential decoding. Both RoPE arms verify every written cache slot and all input steps.

Validation: 561 focused and hygiene CPU tests passed, one skipped. B200 reruns and interleaved timing/profiler measurements are in progress. Existing speed misses remain preserved and are not reported as wins. This change depends on PR #19.
