### PR TITLE
Add Colfax FlashAttention-4 decode and backward lab pairs

### DIFF
--- a/code/ch10/README.md
+++ b/code/ch10/README.md
@@ -49,6 +49,7 @@ python -m cli.aisp bench run --targets ch10 --profile minimal
 - Prototype persistent matmuls that amortize launch overhead across iterations.
 - Exercise thread-block clusters with and without DSMEM to understand hardware limits.
 - Combine PyTorch, Triton, and CUDA kernels while keeping expectations synchronized.
+- Study how [FA4 decode ping-pong and backward TMEM de-aliasing](../labs/flashattention4/colfax_optimization_diaries.md) change MMA issue order and synchronization scope without changing the attention math.
 
 ## Directory Layout
 | Path | Description |

--- a/code/ch11/README.md
+++ b/code/ch11/README.md
@@ -54,6 +54,7 @@ python -m cli.aisp bench run --targets ch11:streams --profile deep_dive --single
 - Control ordering constraints for KV-cache updates and stream-ordered memory pools.
 - Benchmark warp-specialized multistream kernels that share data via DSMEM.
 - Introduce adaptive policies that adjust stream usage based on runtime telemetry.
+- Connect stream-level ideas to [FA4's intra-kernel producer/consumer pipelines](../labs/flashattention4/colfax_optimization_diaries.md), where per-slot phases and warp-local signals expose otherwise serialized work.
 
 ## Directory Layout
 | Path | Description |

--- a/code/ch18/README.md
+++ b/code/ch18/README.md
@@ -70,6 +70,7 @@ python -m cli.aisp bench run --targets ch18:flexdecoding --profile deep_dive --s
 - Test tensor-core optimized attention kernels tailored for Blackwell tmem limits.
 - Validate integration points with serving frameworks (vLLM) using the provided runners.
 - Separate EOS polling overhead from early-exit work reduction when a batch finishes before the max decode budget.
+- Compare prefill and decode schedules through [FA4 S/P ping-pong](../labs/flashattention4/colfax_optimization_diaries.md), and keep that kernel-internal TMEM experiment distinct from FlexAttention masking and score-mod sweeps.
 
 ## Directory Layout
 | Path | Description |

--- a/code/labs/README.md
+++ b/code/labs/README.md
@@ -27,7 +27,7 @@ If a lab cannot answer those questions yet, the doc should say so directly inste
 ## Directory Layout
 | Path | Description |
 | --- | --- |
-| `labs/block_scaling`, `labs/blackwell_matmul`, `labs/blackwell_gemm_optimizations`, `labs/flashattention4`, `labs/memory_bandwidth_patterns`, `labs/nccl_nixl_nvshmem`, `labs/persistent_decode`, `labs/parameterized_cuda_graphs`, `labs/training_hotpath` | Benchmark-pair labs with strong kernel/perf narratives and artifact-backed measured deltas, including narrow bandwidth-pattern, communication-stack tradeoff, and CUDA-graph replay labs. |
+| `labs/block_scaling`, `labs/blackwell_matmul`, `labs/blackwell_gemm_optimizations`, `labs/flashattention4`, `labs/memory_bandwidth_patterns`, `labs/nccl_nixl_nvshmem`, `labs/persistent_decode`, `labs/parameterized_cuda_graphs`, `labs/training_hotpath` | Benchmark-pair labs with strong kernel/perf narratives. Measured claims require retained artifacts; the FlashAttention-4 Colfax diary pairs are source-grounded studies whose local target-GPU qualification is pending. |
 | `labs/decode_optimization`, `labs/kv_optimization`, `labs/moe_cuda`, `labs/moe_optimization_journey` | Serving-path and MoE labs where the benchmark pair is part of a broader optimization story. |
 | `labs/moe_decode_blackwell_matrix`, `labs/nanochat_fullstack`, `labs/python_concurrency`, `labs/vllm-deepseek-tuning` | Larger workflow-oriented and matrix/playbook labs that need a richer doc model than a simple pair benchmark. |
 | `labs/nvfp4_*` | Low-precision kernel labs where verification discipline matters as much as the timing win. |
@@ -66,7 +66,7 @@ python -m cli.aisp bench list-targets --chapter labs/moe_cuda
 | `labs/cutlass_profiler_kernel_selector/` | CUTLASS profiler-based kernel selection | ch06, ch09 |
 | `labs/decode_optimization/` | Decoder hot-path optimization | ch18, ch19 |
 | `labs/dynamic_router/` | Dynamic prefill/decode routing | ch17, ch19 |
-| `labs/flashattention4/` | FlashAttention-4 pipeline co-design | ch10, ch18 |
+| `labs/flashattention4/` | FlashAttention-4 pipeline co-design, including a [Colfax diary guide](flashattention4/colfax_optimization_diaries.md) to decode S/P ping-pong and backward hdim-64 TMEM de-aliasing | ch10, ch11, ch18 |
 | `labs/flashattention_gluon/` | FlashAttention experimentation | ch18 |
 | `labs/flashinfer_attention/` | FlashInfer block-sparse attention lab | ch16 |
 | `labs/flexattention/` | FlexAttention harness and sweeps | ch18 |

--- a/code/labs/flashattention4/README.md
+++ b/code/labs/flashattention4/README.md
@@ -1,5 +1,60 @@
 # Lab - FlashAttention-4 Pipeline Co-Design
 
+## Colfax decode and backward kernel ablations
+
+The [Colfax optimization diaries guide](colfax_optimization_diaries.md) extends
+this lab with two direct upstream FA4 comparisons, linked from Chapters 10, 11,
+and 18. These use separate, pinned PR revisions and do not use the provider
+selection path described in the older forward experiments below.
+
+| Harness target | `baseline_` path | `optimized_` path |
+| --- | --- | --- |
+| `flashattention4_decode` | Single S/P TMEM slot | Two-slot S/P ping-pong, overlapping next-tile QK with softmax |
+| `flashattention4_backward` | Aliased P/S and dS/dP; compute-wide barriers | Dedicated P/dS storage plus warp-local synchronization at head dimension 64 |
+
+Both arms replay one captured CUDA graph per iteration. JIT compilation, warmup,
+and capture are setup costs. Backward times preprocessing, gradient kernels, and
+postprocessing; its common forward output/LSE are prepared outside the timer.
+Verification consumes the full replay output, including **all of dQ, dK, and dV**
+for backward. Deterministic backward requires exact gradient equality between
+arms; the GPU test also checks an independent high-precision reference.
+`optimized_` identifies the candidate, not a measured speedup.
+
+Use **two separate CUDA 13 / SM100 environments** with the repository harness
+dependencies available. These experiments need CUTLASS DSL 4.6.2, whereas the
+repository's default stack pins 4.5.2. Install one recipe per environment; installing
+both in one environment replaces the first FA4 revision. From `code/`:
+
+```bash
+# In the dedicated decode environment:
+python -m pip install -r labs/flashattention4/requirements_colfax_decode.txt
+python -m cli.aisp bench run --targets labs/flashattention4:flashattention4_decode --profile deep_dive --single-gpu
+AISP_TEST_COLFAX_KIND=decode python -m pytest -q tests/test_flashattention4_colfax.py
+
+# In the dedicated backward environment:
+python -m pip install -r labs/flashattention4/requirements_colfax_backward.txt
+python -m cli.aisp bench run --targets labs/flashattention4:flashattention4_backward --profile deep_dive --single-gpu
+AISP_TEST_COLFAX_KIND=backward python -m pytest -q tests/test_flashattention4_colfax.py
+```
+
+Missing CUDA, a non-SM100 GPU, or mismatched pinned kernel/interface files produces
+an explicit `SKIPPED:` diagnostic. There is no substitute backend. The source
+pins are in [colfax_upstream.json](colfax_upstream.json); benchmark workloads and
+the performance hypothesis are in [colfax_workload_spec.yaml](colfax_workload_spec.yaml)
+and [colfax_performance_intake.yaml](colfax_performance_intake.yaml).
+
+These new pairs have **no local GPU measurements or expectations yet**. Run the
+opt-in correctness tests and retain harness clock/provenance, interleaved repeat,
+Nsight Systems, and Nsight Compute evidence before claiming a win. The older
+results below apply only to their named forward/provider targets.
+
+Local validation on 2026-09-07 (macOS, Python 3.12, CPU PyTorch 2.14.0):
+
+- `python -m pytest -q tests/test_flashattention4_colfax.py`: **28 passed, 1 skipped**; the opt-in SM100 test was not enabled.
+- `python scripts/linting/check_benchmarks.py labs/flashattention4/baseline_flashattention4_decode.py labs/flashattention4/optimized_flashattention4_decode.py labs/flashattention4/baseline_flashattention4_backward.py labs/flashattention4/optimized_flashattention4_backward.py`: **0 errors, 0 warnings**.
+- `python -m cli.aisp bench list-targets --chapter labs/flashattention4`: both new targets discovered.
+- Ruff, syntax, documentation links, requirement/manifest consistency, and SHA256 checks against the pinned upstream sources passed. Direct setup returned the expected CUDA-required `SKIPPED:` diagnostic.
+
 ## Summary
 Recreates the practical shape of the FlashAttention-4 article: eager FlexAttention as the scalar-heavy baseline, then a compiled Blackwell-friendly path that tries the FLASH backend and falls back to FlexAttention+TMA when needed. The default benchmark uses ALiBi because it is stable on the local stack and still exercises the FA4 score-mod path.
 

--- a/code/labs/flashattention4/baseline_flashattention4_backward.py
+++ b/code/labs/flashattention4/baseline_flashattention4_backward.py
@@ -1,0 +1,13 @@
+"""Colfax PR #2804 control: aliased TMEM and compute-wide synchronization."""
+
+from core.harness.benchmark_harness import BaseBenchmark
+from labs.flashattention4.colfax_benchmarks import ColfaxBenchmark
+
+
+class BaselineFlashAttention4BackwardBenchmark(ColfaxBenchmark):
+    def __init__(self):
+        super().__init__("backward", optimized=False)
+
+
+def get_benchmark() -> BaseBenchmark:
+    return BaselineFlashAttention4BackwardBenchmark()

--- a/code/labs/flashattention4/baseline_flashattention4_decode.py
+++ b/code/labs/flashattention4/baseline_flashattention4_decode.py
@@ -1,0 +1,13 @@
+"""Colfax PR #2817 control: single S/P TMEM slot during decode."""
+
+from core.harness.benchmark_harness import BaseBenchmark
+from labs.flashattention4.colfax_benchmarks import ColfaxBenchmark
+
+
+class BaselineFlashAttention4DecodeBenchmark(ColfaxBenchmark):
+    def __init__(self):
+        super().__init__("decode", optimized=False)
+
+
+def get_benchmark() -> BaseBenchmark:
+    return BaselineFlashAttention4DecodeBenchmark()

--- a/code/labs/flashattention4/colfax_benchmarks.py
+++ b/code/labs/flashattention4/colfax_benchmarks.py
@@ -1,0 +1,339 @@
+"""Pinned Colfax FA4 kernel ablations, measured as steady-state CUDA graph replay.
+
+The optional upstream packages are experiment-specific; see
+``colfax_optimization_diaries.md``. Neither pair uses FlexAttention as a proxy.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import importlib.util
+import json
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+
+from core.benchmark.verification_mixin import VerificationPayloadMixin
+from core.harness.benchmark_harness import BaseBenchmark, BenchmarkConfig, WorkloadMetadata
+
+
+@dataclass(frozen=True)
+class ColfaxConfig:
+    kind: str
+    batch_size: int
+    seqlen_q: int
+    seqlen_k: int
+    query_heads: int
+    kv_heads: int
+    head_dim: int
+    causal: bool = False
+
+    def validate(self) -> None:
+        if self.kind not in ("decode", "backward"):
+            raise ValueError("kind must be decode or backward")
+        for name in ("batch_size", "seqlen_q", "seqlen_k", "query_heads", "kv_heads", "head_dim"):
+            value = getattr(self, name)
+            if type(value) is not int or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if self.query_heads % self.kv_heads:
+            raise ValueError("query_heads must be divisible by kv_heads")
+        if self.seqlen_q > self.seqlen_k:
+            raise ValueError("seqlen_q must not exceed seqlen_k")
+        if self.kind == "decode":
+            if self.head_dim not in (64, 128):
+                raise ValueError("decode ping-pong requires head_dim 64 or 128")
+            if self.seqlen_q * (self.query_heads // self.kv_heads) > 128:
+                raise ValueError("packed decode queries must fit one 128-row Q stage")
+            if self.seqlen_k < 256:
+                raise ValueError("decode needs at least two 128-token KV tiles to overlap")
+        else:
+            if self.head_dim != 64:
+                raise ValueError("backward de-aliasing requires head_dim 64")
+            if self.seqlen_q != self.seqlen_k:
+                raise ValueError("this backward lab uses equal Q and KV sequence lengths")
+
+
+def default_config(kind: str) -> ColfaxConfig:
+    if kind == "decode":
+        return ColfaxConfig(kind, 32, 1, 131072, 16, 1, 64)
+    if kind == "backward":
+        return ColfaxConfig(kind, 4, 16384, 16384, 32, 32, 64)
+    raise ValueError("kind must be decode or backward")
+
+
+def build_inputs(config: ColfaxConfig, device: torch.device) -> dict[str, torch.Tensor]:
+    """Use the caller's RNG; both arms consume identical random draws."""
+    config.validate()
+    b, q, k = config.batch_size, config.seqlen_q, config.seqlen_k
+    hq, hkv, d = config.query_heads, config.kv_heads, config.head_dim
+    tensors = {
+        "q": torch.randn(b, q, hq, d, device=device, dtype=torch.bfloat16),
+        "k": torch.randn(b, k, hkv, d, device=device, dtype=torch.bfloat16),
+        "v": torch.randn(b, k, hkv, d, device=device, dtype=torch.bfloat16),
+    }
+    if config.kind == "backward":
+        tensors["dout"] = torch.randn(b, q, hq, d, device=device, dtype=torch.bfloat16)
+    return tensors
+
+
+def reference_attention(q, k, v, causal: bool = False):
+    """Small-shape independent oracle with FA's bottom-right causal alignment.
+
+    This materializes scores and is only for correctness tests, never timing.
+    Preserve double inputs for gradient checks; otherwise accumulate in FP32.
+    """
+    dtype = torch.float64 if q.dtype == torch.float64 else torch.float32
+    group = q.shape[2] // k.shape[2]
+    qh = q.to(dtype).transpose(1, 2)
+    kh = k.to(dtype).repeat_interleave(group, dim=2).transpose(1, 2)
+    vh = v.to(dtype).repeat_interleave(group, dim=2).transpose(1, 2)
+    scores = (qh @ kh.transpose(-1, -2)) * q.shape[-1] ** -0.5
+    if causal:
+        rows = torch.arange(q.shape[1], device=q.device)[:, None]
+        cols = torch.arange(k.shape[1], device=q.device)[None, :]
+        scores = scores.masked_fill(cols > rows + k.shape[1] - q.shape[1], float("-inf"))
+    return (scores.softmax(dim=-1) @ vh).transpose(1, 2)
+
+
+def source_manifest(kind: str) -> dict:
+    if kind not in ("decode", "backward"):
+        raise ValueError("kind must be decode or backward")
+    return json.loads(Path(__file__).with_name("colfax_upstream.json").read_text())[kind]
+
+
+def verify_source_files(root: Path, kind: str) -> dict:
+    """Reject drift in the interface, controls and kernels before importing CUDA code."""
+    manifest = source_manifest(kind)
+    for name, expected in manifest["files"].items():
+        path = root / name
+        if not path.is_file() or hashlib.sha256(path.read_bytes()).hexdigest() != expected:
+            raise RuntimeError(
+                f"SKIPPED: Colfax {kind} requires unmodified FA4 {manifest['commit']}; "
+                f"source mismatch: {name}. See requirements_colfax_{kind}.txt."
+            )
+    return manifest
+
+
+def load_upstream(kind: str):
+    try:
+        spec = importlib.util.find_spec("flash_attn.cute")
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            f"SKIPPED: install requirements_colfax_{kind}.txt in a dedicated environment"
+        ) from exc
+    if spec is None or not spec.submodule_search_locations:
+        raise RuntimeError(
+            f"SKIPPED: install requirements_colfax_{kind}.txt in a dedicated environment"
+        )
+    root = Path(next(iter(spec.submodule_search_locations)))
+    verify_source_files(root, kind)
+    # Missing dependencies and compiler failures must retain their actual errors.
+    interface = importlib.import_module("flash_attn.cute.interface")
+    if Path(interface.__file__).resolve() != (root / "interface.py").resolve():
+        raise RuntimeError("SKIPPED: loaded FA4 interface does not match verified source")
+    return interface
+
+
+@contextmanager
+def decode_control(interface, optimized: bool):
+    """Bridge the pinned import-time env switch to a scoped capture-time control.
+
+    FA_DISABLE_S_PING_PONG is read only when upstream utils is imported. Setting
+    os.environ per arm would silently reuse the first arm's setting. The pinned
+    boolean is read by _flash_attn_fwd and enters its JIT key as use_s_ping_pong.
+    Restore it even if compilation fails. Replays no longer read this global.
+    """
+    previous = interface.utils._fa_disable_s_ping_pong_enabled
+    interface.utils._fa_disable_s_ping_pong_enabled = not optimized
+    try:
+        yield
+    finally:
+        interface.utils._fa_disable_s_ping_pong_enabled = previous
+
+
+class ColfaxBenchmark(VerificationPayloadMixin, BaseBenchmark):
+    """One real FA4 invocation per replay; full timed outputs are verified."""
+
+    def __init__(self, kind: str, optimized: bool, config: ColfaxConfig | None = None):
+        super().__init__()
+        self.spec = config or default_config(kind)
+        self.spec.validate()
+        if self.spec.kind != kind:
+            raise ValueError("config kind must match benchmark kind")
+        self.kind = kind
+        self.optimized = optimized
+        self.inputs = None
+        self.output = None
+        self.graph = None
+        self._ran = False
+        self._forward_state = None
+
+    def setup(self) -> None:
+        if not torch.cuda.is_available():
+            raise RuntimeError("SKIPPED: Colfax FA4 labs require a CUDA Blackwell SM100 GPU")
+        if torch.cuda.get_device_capability(self.device) != (10, 0):
+            raise RuntimeError(
+                "SKIPPED: Colfax FA4 labs are scoped to Blackwell SM100 (B200/GB200)"
+            )
+        if torch.version.cuda is None or int(torch.version.cuda.split(".")[0]) < 13:
+            raise RuntimeError(
+                "SKIPPED: the Colfax experiment recipes require a CUDA 13+ PyTorch build"
+            )
+        interface = load_upstream(self.kind)
+        if interface.is_fake_mode():
+            raise RuntimeError("SKIPPED: FA4 fake-tensor mode cannot produce benchmark evidence")
+        if interface._get_device_arch() != 100:
+            raise RuntimeError("SKIPPED: FA4 architecture override must resolve to SM100")
+        self.inputs = build_inputs(self.spec, self.device)
+        self._ran = False
+        cfg, x = self.spec, self.inputs
+        fwd_kwargs = {
+            "causal": cfg.causal,
+            "tile_mn": (128, 128),
+            "num_splits": 1,
+            "pack_gqa": True,
+        }
+
+        if self.kind == "decode":
+            dispatch = interface._get_fwd_config(
+                arch=100,
+                head_dim=cfg.head_dim,
+                head_dim_v=cfg.head_dim,
+                max_seqlen_q=cfg.seqlen_q,
+                max_seqlen_k=cfg.seqlen_k,
+                num_head_kv=cfg.kv_heads,
+                qhead_per_kvhead=cfg.query_heads // cfg.kv_heads,
+                pack_gqa=True,
+                batch_size=cfg.batch_size,
+                causal=cfg.causal,
+                local=False,
+                window_size_left=None,
+                window_size_right=None,
+                num_splits=1,
+                device=self.device,
+                tile_mn=(128, 128),
+            )
+            if (
+                dispatch.m_block_size,
+                dispatch.n_block_size,
+                dispatch.q_stage,
+                dispatch.num_splits,
+            ) != (128, 128, 1, 1):
+                raise RuntimeError(
+                    "SKIPPED: upstream dispatch is not eligible for the decode ping-pong ablation"
+                )
+
+            def run():
+                return interface._flash_attn_fwd(x["q"], x["k"], x["v"], **fwd_kwargs)[0]
+
+            # All dispatch predicates are fixed: SM100, Q stage 1, 128x128,
+            # D=64/128, no 2CTA, no modifiers/sparsity, unsplit contiguous KV.
+            with decode_control(interface, self.optimized):
+                self._capture(run)
+        else:
+            # Backward-only contract: forward output/LSE are common setup state.
+            out, lse, _, _ = interface._flash_attn_fwd(
+                x["q"], x["k"], x["v"], return_lse=True, **fwd_kwargs
+            )
+            self._forward_state = (out, lse)
+            self.inputs.update(out=out, lse=lse)
+
+            def run():
+                return interface._flash_attn_bwd(
+                    x["q"],
+                    x["k"],
+                    x["v"],
+                    out,
+                    x["dout"],
+                    lse,
+                    causal=cfg.causal,
+                    deterministic=True,
+                    split_P_dS=self.optimized,
+                    warp_sync=self.optimized,
+                )[:3]
+
+            self._capture(run)
+
+    def _capture(self, run) -> None:
+        """JIT/warmup/capture are setup costs, identical lifecycle for both arms."""
+        stream = torch.cuda.Stream(device=self.device)
+        stream.wait_stream(torch.cuda.current_stream(self.device))
+        with torch.cuda.stream(stream):
+            for _ in range(3):
+                run()
+        torch.cuda.current_stream(self.device).wait_stream(stream)
+        stream.synchronize()
+        self.graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(self.graph, stream=stream):
+            self.output = run()
+        torch.cuda.current_stream(self.device).wait_stream(stream)
+
+    def benchmark_fn(self) -> None:
+        if self.graph is None:
+            raise RuntimeError("setup() must complete before benchmark_fn()")
+        with self._nvtx_range(
+            f"colfax_{self.kind}_{'optimized' if self.optimized else 'baseline'}"
+        ):
+            self.graph.replay()
+        self._ran = True
+
+    def capture_verification_payload(self) -> None:
+        if not self._ran or self.inputs is None or self.output is None:
+            raise RuntimeError(
+                "benchmark_fn() must replay before verification; setup outputs are not evidence"
+            )
+        # Concatenation is post-timing. Verify every gradient, not a checksum or slice.
+        output = (
+            self.output
+            if self.kind == "decode"
+            else torch.cat([t.reshape(-1) for t in self.output])
+        )
+        self._set_verification_payload(
+            inputs=self.inputs,
+            output=output,
+            batch_size=self.spec.batch_size,
+            parameter_count=0,
+            precision_flags={"bf16": True, "fp16": False, "tf32": False},
+            # PR2804 reports bit-identical gradients with deterministic=True.
+            output_tolerance=(0.0, 0.0) if self.kind == "backward" else (2e-2, 2e-2),
+            signature_overrides={"graph_capture_enabled": True},
+        )
+
+    def get_config(self) -> BenchmarkConfig:
+        return BenchmarkConfig(
+            iterations=20, warmup=5, enable_cuda_graph=False, measurement_timeout_seconds=180
+        )
+
+    def get_workload_metadata(self) -> WorkloadMetadata:
+        return WorkloadMetadata(
+            requests_per_iteration=float(self.spec.batch_size),
+            tokens_per_iteration=float(self.spec.batch_size * self.spec.seqlen_q),
+        )
+
+    def get_custom_metrics(self) -> dict[str, float]:
+        return {
+            "colfax.pr": 2817.0 if self.kind == "decode" else 2804.0,
+            "colfax.optimization_enabled": float(self.optimized),
+            "colfax.head_dim": float(self.spec.head_dim),
+            "colfax.seqlen_q": float(self.spec.seqlen_q),
+            "colfax.seqlen_k": float(self.spec.seqlen_k),
+            "colfax.query_heads": float(self.spec.query_heads),
+            "colfax.kv_heads": float(self.spec.kv_heads),
+            "colfax.causal": float(self.spec.causal),
+            "colfax.deterministic_backward": float(self.kind == "backward"),
+            "colfax.cuda_graph_replay": 1.0,
+        }
+
+    def validate_result(self) -> str | None:
+        return None if self._ran and self.output is not None else "No timed graph replay output"
+
+    def teardown(self) -> None:
+        self.graph = None
+        self.output = None
+        self.inputs = None
+        self._forward_state = None
+        self._verification_payload = None
+        self._ran = False

--- a/code/labs/flashattention4/colfax_optimization_diaries.md
+++ b/code/labs/flashattention4/colfax_optimization_diaries.md
@@ -1,0 +1,91 @@
+# Colfax Optimization Diaries: FlashAttention-4 TMEM Scheduling
+
+This guide turns two Colfax Research optimization diaries into comparable `baseline_*` / `optimized_*` lab targets. The pairs hold the attention workload fixed and isolate a Blackwell TMEM scheduling change. They complement the existing FlashAttention-4 lab; they do not replace its eager-versus-compiled FlexAttention comparison.
+
+## Source material
+
+- [S/P Ping-Pong for FlashAttention-4 Decode](https://research.colfax-intl.com/optimization-diaries-s-p-ping-pong-for-flashattention-4-decode/)
+- [Improving FlashAttention-4 Backward for Head Dimension 64](https://research.colfax-intl.com/optimization-diaries-improving-flashattention-4-backward-for-head-dimension-64/)
+
+The performance figures below are results reported by Colfax for its B200 environment. They are study targets, not measurements from this repository or the current host.
+
+## Experiment contract
+
+| Harness target | Baseline | Optimized | Invariant |
+| --- | --- | --- | --- |
+| `flashattention4_decode` | One TMEM S/P slot keeps `QK(i+1)` behind `softmax(S(i))` and `PV(i)` | Two TMEM slots alternate S and P so the next QK can issue during the current softmax | Same decode inputs, attention math, outputs, and KV-block work |
+| `flashattention4_backward` | At head dimension 64, P aliases S and dS aliases dP, requiring compute-wide alias guards | Spare TMEM gives P and dS dedicated slots, enabling earlier S release and warp-local signaling | Same backward inputs, gradients, mode, dtype, and attention shape |
+
+The corresponding modules follow the repository convention: `baseline_flashattention4_decode.py` with `optimized_flashattention4_decode.py`, and `baseline_flashattention4_backward.py` with `optimized_flashattention4_backward.py`. A valid comparison must fail clearly if the requested upstream FA4 path or Blackwell capability is unavailable. A different attention provider is not an equivalent fallback for either pair.
+
+The default decode workload is non-causal BF16 with batch 32, one query token, 131,072 KV tokens, 16 query heads, 1 KV head, and head dimension 64, matching a representative cell in the upstream decode PR. The default backward workload is non-causal BF16 with batch 4, sequence length 16,384, 32 query and KV heads, head dimension 64, and deterministic backward enabled, matching the article's 64k-token deterministic dense row. These are representative performance workloads; the opt-in correctness tests use smaller tensors.
+
+Both pairs measure steady-state CUDA Graph replay after JIT, warmup, and capture in setup. One decode replay contains one FA4 forward invocation. One backward replay contains FA4 backward preprocessing, mainloop, and postprocessing and returns dQ, dK, and dV; the common forward pass that prepares O and LSE runs once in setup and is outside the backward timing boundary. The baseline and optimized arms use the same lifecycle.
+
+The two experiments intentionally pin separate upstream FA4 source identities and environments; follow this lab's README and experiment-specific requirement files rather than mixing them. Decode controls an upstream private ping-pong boolean during graph capture because the corresponding environment switch is read only once at import. Backward selects the source ablation explicitly: both `split_P_dS` and `warp_sync` are false for baseline and true for optimized.
+
+## Decode: true S/P ping-pong
+
+FA4 prefill assigns two 128-row Q tiles to a CTA and overlaps the low tile's QK work with softmax for the high tile. Single- and multi-token decode usually has only one padded Q tile, so that prefill schedule leaves TMEM columns 128-255 idle and serializes:
+
+```text
+QK(i) -> softmax(S(i)) -> PV(i) -> QK(i+1)
+```
+
+The optimized decode path uses TMEM columns 0-127 as slot 0 and 128-255 as slot 1. S and P alternate between them across KV blocks. The MMA warp can write `S(i+1)` into one slot while the softmax warps read `S(i)` and write `P(i)` in the other. `QK` therefore runs one block ahead of `PV`.
+
+This is more than ordinary double buffering. Correct ping-pong requires all of the following:
+
+- Alternate the TMEM destination for both S and P by KV-block parity.
+- Track a barrier per slot. The slot is selected by the low bit of the global PV count, while the next bit tracks the phase when that slot is reused.
+- Change the load order from `K0, V0, K1, V1, ...` to `K0, K1, V0, K2, V1, ...`, with the final V appended, so `QK(i+1)` is ready before `PV(i)`.
+- Keep the single O accumulator safe while correction warps may rescale it. Slot acquisition must wait for both P production and any correction use to finish.
+
+A host-side buffer toggle or alternate SMEM staging without these TMEM destinations, phases, and dependencies does not reproduce the optimization.
+
+Colfax reports up to a 16% improvement for supported single- and multi-token decode shapes on B200. Because decode is memory-bound, the article reports achieved bandwidth and shows larger gains at longer KV lengths, where the steady-state overlap covers more iterations.
+
+## Backward hdim-64: de-alias before relaxing synchronization
+
+The head-dimension-64 backward kernel uses less tensor-core work per tile than the hdim-128 kernel, while its pointwise softmax and dS work remains. In the baseline TMEM layout, fp32 accumulators occupy columns 0-383 and columns 384-511 are unused. BF16 P overwrites S and BF16 dS overwrites dP.
+
+Those aliases create a real cross-warp hazard. The eight compute warps span two warpgroups, and paired warps share 32-lane TMEM sectors. One warp can otherwise store P into a sector while its partner is still reading S. The baseline therefore needs alias guards: a P-over-S guard once per tile and a dS-over-dP guard in each stage of the two-stage dS loop. Along with signal barriers, the article counts five compute-wide barriers per mainloop iteration.
+
+The optimized layout uses the spare 128 columns for packed BF16 tiles: P in columns 384-447 and dS in 448-511. Once P and dS no longer overwrite S and dP, the kernel can:
+
+1. Remove the two kinds of cross-warp alias guard while retaining the required TMEM fences.
+2. Release S as soon as each compute warp has copied it into registers, before softmax.
+3. Split the old fused `S read and P written` signal into an early S-read pipeline and a separate P-written/P-consumed pipeline.
+4. Issue the next tile's QK before the current tile's `P dO`, moving useful tensor-core work under softmax.
+5. Replace the remaining compute-wide signal barriers with warp-local synchronization, allowing the eight compute warps to drift instead of waiting for the slowest warp.
+
+Colfax reports 6-15% improvements across the highlighted B200 BF16 cases, including deterministic cases, and up to 903 TFLOP/s. The wider source sweep covers more modes and dtypes. These figures describe the source environment; this lab must establish its own correctness and performance evidence.
+
+## What the profiler should test
+
+Run each pair as a hypothesis test rather than assuming the upstream mechanism is active.
+
+For decode, look for `QK(i+1)` overlapping the current softmax instead of following `PV(i)`, correct alternation and reuse of the two TMEM slots, and a gain that becomes clearer as KV length increases. Colfax demonstrates the overlap with in-kernel event tracing; a local deep-dive artifact should retain whatever equivalent timeline and counter evidence the installed profiler can capture.
+
+For backward, look for the next QK moving under softmax, removal of the five compute-wide barrier rendezvous per tile, and compute warps progressing independently through softmax and dS. Confirm that the run used head dimension 64 and the de-aliased upstream path. Lower latency without those mechanism checks could come from a different dispatch or workload.
+
+For both targets, compare equivalent work, preserve numerical verification, record the selected kernel/API identity, and reject unsupported or fallback execution. The source's trace and benchmark results explain what to seek; they do not qualify a local run.
+
+## Chapter connections
+
+- [Chapter 10](../../ch10/README.md): warp specialization, `tcgen05.mma`, TMEM allocation, TMA-fed operand pipelines, and choosing synchronization scope inside a tensor-core kernel.
+- [Chapter 11](../../ch11/README.md): producer/consumer overlap, barrier phase tracking, and removing unnecessary ordering. This is intra-kernel concurrency rather than CUDA-stream concurrency.
+- [Chapter 18](../../ch18/README.md): decode-specific attention shapes, KV-block iteration, GQA, and the difference between prefill and decode schedules.
+
+The existing `flashattention4` target compares eager score materialization with a compiled provider-aware fused path. The separate `labs/flexattention` lab studies programmable masks, score modifications, and FlexAttention sweeps. Each Colfax pair uses one pinned upstream revision with its optimization disabled or enabled, isolating TMEM allocation and scheduling.
+
+## Run and qualify
+
+From `code/`:
+
+```bash
+python -m cli.aisp bench run --targets labs/flashattention4:flashattention4_decode --profile deep_dive --single-gpu
+python -m cli.aisp bench run --targets labs/flashattention4:flashattention4_backward --profile deep_dive --single-gpu
+```
+
+Current-host CPU/static checks can verify discovery, imports, metadata, pair structure, and unsupported-hardware diagnostics. They cannot show that a Blackwell TMEM path executed or establish a speedup. Target-GPU qualification requires successful baseline and optimized execution on the intended Blackwell GPU, output or gradient parity, retained provenance, repeated comparable timings, and profiler evidence for the scheduling mechanism.

--- a/code/labs/flashattention4/colfax_performance_intake.yaml
+++ b/code/labs/flashattention4/colfax_performance_intake.yaml
@@ -1,0 +1,38 @@
+objective:
+  primary_kpi: latency_ms
+  secondary_kpis: [kv_bytes_per_second, backward_tflops]
+benchmark:
+  layer: component
+  grade: realism
+  variable_under_test: kernel_tmem_layout_and_synchronization
+workload:
+  decode: {batch: 32, seqlen_q: 1, seqlen_k: 131072, heads_q: 16, heads_kv: 1, head_dim: 64, dtype: bf16}
+  backward: {batch: 4, seqlen_q: 16384, seqlen_k: 16384, heads_q: 32, heads_kv: 32, head_dim: 64, dtype: bf16}
+  constraints: [same_inputs_per_pair, same_upstream_revision_per_pair, full_output_verification]
+hot_path_model:
+  path: labs.flashattention4.colfax_benchmarks.ColfaxBenchmark.benchmark_fn
+  phase: steady_state
+  invocation_frequency: per_batch
+  invocations_per_primary_unit: 1
+  estimated_costs:
+    decode_minimum_kv_bytes_read: 1073741824
+    decode_output_bytes_written: 65536
+    host_device_bytes: 0
+    graph_launches: 1
+    storage_or_network_operations: 0
+  operation_cost_source: tensor shapes; no local measured operation costs
+  expected_dominant_cost: decode KV traffic and QK/softmax serialization; backward MMA/synchronization and deterministic dQ accumulation
+  best_case_primary_kpi_improvement_pct: null
+evidence:
+  baseline_artifact: null
+  profile_artifacts: []
+  hardware_counter_artifacts: []
+  static_review_findings:
+    - Decode has spare TMEM for S/P ping-pong; eligibility is fixed by the lab shape and dispatch options.
+    - Backward hd64 can separate P/dS storage to remove alias guards and enable warp-local signaling.
+candidate_optimizations:
+  - Decode PR2817 S/P ping-pong on versus off, all other arguments fixed.
+  - Backward PR2804 split_P_dS and warp_sync together on versus off, deterministic mode fixed.
+risk_guardrails:
+  correctness_tests: [tests/test_flashattention4_colfax.py, harness_full_output_verification]
+  publication_boundary: source and CPU tests do not establish GPU correctness or performance

--- a/code/labs/flashattention4/colfax_upstream.json
+++ b/code/labs/flashattention4/colfax_upstream.json
@@ -1,0 +1,23 @@
+{
+  "decode": {
+    "repository": "https://github.com/Dao-AILab/flash-attention",
+    "pr": 2817,
+    "commit": "a93c9a8fb95516a08e0974743bd5723122613377",
+    "article": "https://research.colfax-intl.com/optimization-diaries-s-p-ping-pong-for-flashattention-4-decode/",
+    "files": {
+      "interface.py": "ad66e664523002b769a24bd2df076e8b96bb4005c8a5eb8f60da94e0bb823aae",
+      "flash_fwd_sm100.py": "ccae92a1d287fb1745b413170d984a7b4d6aa90cf91f67f32baacab92d2db779",
+      "utils.py": "a48f62478027f84d2573fdc4eb75967cd27f99741f14b33cc0a843fb547a0591"
+    }
+  },
+  "backward": {
+    "repository": "https://github.com/Dao-AILab/flash-attention",
+    "pr": 2804,
+    "commit": "c33d03d9f3edc850ecb5e21466d5dd31331ca7b6",
+    "article": "https://research.colfax-intl.com/optimization-diaries-improving-flashattention-4-backward-for-head-dimension-64/",
+    "files": {
+      "interface.py": "de3b6d986101de5142e877c27395e70f79c6a16c4a43f0c11bfe736d91b389c9",
+      "flash_bwd_sm100.py": "4301340010d097fa44817b2ed70aad6e972458cb66ce8689546c7cdf3c1fe6fe"
+    }
+  }
+}

--- a/code/labs/flashattention4/colfax_workload_spec.yaml
+++ b/code/labs/flashattention4/colfax_workload_spec.yaml
@@ -1,0 +1,38 @@
+run_metadata:
+  benchmark_layer: component
+  benchmark_grade: realism
+  use_case: engineering_debug
+comparison_axis:
+  variable_under_test: kernel_tmem_layout_and_synchronization
+  control: decode ping-pong disabled; backward split_P_dS=False and warp_sync=False
+  candidate: decode ping-pong enabled; backward split_P_dS=True and warp_sync=True
+  constants_locked: [source_revision_within_pair, shape, bf16, input_seed, causal_mask, split_count, graph_replay, deterministic_backward]
+workload:
+  decode: {batch: 32, seqlen_q: 1, seqlen_k: 131072, heads_q: 16, heads_kv: 1, head_dim: 64, causal: false}
+  backward: {batch: 4, seqlen_q: 16384, seqlen_k: 16384, heads_q: 32, heads_kv: 32, head_dim: 64, causal: false, deterministic: true}
+  precision: bf16
+  input_distribution: caller-seeded standard normal Q/K/V and backward dO
+  forward_options: {tile_m: 128, tile_n: 128, pack_gqa: true, num_splits: 1}
+  excluded_from_timing: [input_allocation, jit_compilation, warmup, graph_capture, backward_common_forward, verification]
+  included_in_backward_timing: [preprocess_and_accumulator_initialization, main_backward, postprocess]
+  verification: full decode output or concatenated dQ/dK/dV from the timed replay
+  tolerances: {decode_rtol: 0.02, decode_atol: 0.02, deterministic_backward_rtol: 0.0, deterministic_backward_atol: 0.0}
+execution:
+  hardware_tier: {gpu_architecture: SM100, gpu_models: [B200, GB200], gpu_count: 1}
+  source_pins: colfax_upstream.json
+  optional_dependencies: requirements_colfax_decode.txt or requirements_colfax_backward.txt, separately
+measurement_policy:
+  iterations: 20
+  warmup_iterations: 5
+  publication_trials: 5
+  publication_order: repeated interleaved baseline/candidate
+  report_statistics: [median, mean, stddev, cv_pct]
+  environment_controls: {gpu_clocks_locked: true, app_clocks_recorded: true, background_load_recorded: true}
+  outlier_policy: retain raw samples and report rejected runs with reasons
+diagnosis_policy:
+  required_signals: [nsys_trace, ncu_counters, kernel_identity, correctness]
+  scheduling_detail: IKET or equivalent in-kernel tracing is needed to directly establish warp overlap
+artifacts:
+  baseline: null
+  candidate: null
+  status: GPU execution pending; no local speedup claim or expectation update

--- a/code/labs/flashattention4/optimized_flashattention4_backward.py
+++ b/code/labs/flashattention4/optimized_flashattention4_backward.py
@@ -1,0 +1,13 @@
+"""Colfax PR #2804 candidate: separate P/dS TMEM and warp-local signaling."""
+
+from core.harness.benchmark_harness import BaseBenchmark
+from labs.flashattention4.colfax_benchmarks import ColfaxBenchmark
+
+
+class OptimizedFlashAttention4BackwardBenchmark(ColfaxBenchmark):
+    def __init__(self):
+        super().__init__("backward", optimized=True)
+
+
+def get_benchmark() -> BaseBenchmark:
+    return OptimizedFlashAttention4BackwardBenchmark()

--- a/code/labs/flashattention4/optimized_flashattention4_decode.py
+++ b/code/labs/flashattention4/optimized_flashattention4_decode.py
@@ -1,0 +1,13 @@
+"""Colfax PR #2817 candidate: ping-pong S/P across two TMEM slots."""
+
+from core.harness.benchmark_harness import BaseBenchmark
+from labs.flashattention4.colfax_benchmarks import ColfaxBenchmark
+
+
+class OptimizedFlashAttention4DecodeBenchmark(ColfaxBenchmark):
+    def __init__(self):
+        super().__init__("decode", optimized=True)
+
+
+def get_benchmark() -> BaseBenchmark:
+    return OptimizedFlashAttention4DecodeBenchmark()

--- a/code/labs/flashattention4/requirements_colfax_backward.txt
+++ b/code/labs/flashattention4/requirements_colfax_backward.txt
@@ -1,0 +1,3 @@
+# Optional experiment environment; use separately from the decode PR environment.
+nvidia-cutlass-dsl[cu13]==4.6.2
+flash-attn-4[cu13] @ git+https://github.com/Dao-AILab/flash-attention.git@c33d03d9f3edc850ecb5e21466d5dd31331ca7b6#subdirectory=flash_attn/cute

--- a/code/labs/flashattention4/requirements_colfax_decode.txt
+++ b/code/labs/flashattention4/requirements_colfax_decode.txt
@@ -1,0 +1,3 @@
+# Optional experiment environment; do not overlay the repo's CUTLASS 4.5.2 stack.
+nvidia-cutlass-dsl[cu13]==4.6.2
+flash-attn-4[cu13] @ git+https://github.com/Dao-AILab/flash-attention.git@a93c9a8fb95516a08e0974743bd5723122613377#subdirectory=flash_attn/cute

--- a/code/tests/test_flashattention4_colfax.py
+++ b/code/tests/test_flashattention4_colfax.py
@@ -1,0 +1,433 @@
+"""Correctness and discovery coverage for the pinned Colfax FA4 lab pairs."""
+
+from __future__ import annotations
+
+import importlib
+import math
+import os
+import re
+from dataclasses import FrozenInstanceError, replace
+from pathlib import Path
+
+import pytest
+import torch
+
+from core.discovery import discover_benchmarks
+from core.harness.benchmark_harness import BaseBenchmark
+from labs.flashattention4.colfax_benchmarks import (
+    ColfaxBenchmark,
+    ColfaxConfig,
+    build_inputs,
+    default_config,
+    load_upstream,
+    reference_attention,
+    source_manifest,
+    verify_source_files,
+)
+from tests.protection_test_utils import preserve_rng_state
+
+LAB_DIR = Path(__file__).resolve().parents[1] / "labs" / "flashattention4"
+EXPECTED_PINS = {
+    "decode": {
+        "pr": 2817,
+        "commit": "a93c9a8fb95516a08e0974743bd5723122613377",
+        "files": {
+            "interface.py": "ad66e664523002b769a24bd2df076e8b96bb4005c8a5eb8f60da94e0bb823aae",
+            "flash_fwd_sm100.py": "ccae92a1d287fb1745b413170d984a7b4d6aa90cf91f67f32baacab92d2db779",
+            "utils.py": "a48f62478027f84d2573fdc4eb75967cd27f99741f14b33cc0a843fb547a0591",
+        },
+    },
+    "backward": {
+        "pr": 2804,
+        "commit": "c33d03d9f3edc850ecb5e21466d5dd31331ca7b6",
+        "files": {
+            "interface.py": "de3b6d986101de5142e877c27395e70f79c6a16c4a43f0c11bfe736d91b389c9",
+            "flash_bwd_sm100.py": "4301340010d097fa44817b2ed70aad6e972458cb66ce8689546c7cdf3c1fe6fe",
+        },
+    },
+}
+
+
+def _manual_attention(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+    """Deliberately scalar CPU oracle, independent of the module implementation."""
+    batch, query_tokens, query_heads, head_dim = q.shape
+    key_tokens, kv_heads = k.shape[1:3]
+    group_size = query_heads // kv_heads
+    output = torch.empty_like(q, dtype=torch.float64)
+    scale = head_dim**-0.5
+
+    for batch_index in range(batch):
+        for query_index in range(query_tokens):
+            for query_head in range(query_heads):
+                kv_head = query_head // group_size
+                scores = [
+                    sum(
+                        float(q[batch_index, query_index, query_head, dim])
+                        * float(k[batch_index, key_index, kv_head, dim])
+                        for dim in range(head_dim)
+                    )
+                    * scale
+                    for key_index in range(key_tokens)
+                ]
+                score_max = max(scores)
+                unnormalized = [math.exp(score - score_max) for score in scores]
+                normalizer = sum(unnormalized)
+                for dim in range(head_dim):
+                    output[batch_index, query_index, query_head, dim] = (
+                        sum(
+                            weight * float(v[batch_index, key_index, kv_head, dim])
+                            for key_index, weight in enumerate(unnormalized)
+                        )
+                        / normalizer
+                    )
+    return output
+
+
+def _torch_attention_oracle(
+    inputs: dict[str, torch.Tensor],
+    *,
+    causal: bool,
+) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None]:
+    """Independent CPU FP64 PyTorch oracle, including autograd for backward."""
+    requires_grad = "dout" in inputs
+    q = inputs["q"].detach().cpu().double().requires_grad_(requires_grad)
+    k = inputs["k"].detach().cpu().double().requires_grad_(requires_grad)
+    v = inputs["v"].detach().cpu().double().requires_grad_(requires_grad)
+    group_size = q.shape[2] // k.shape[2]
+    expanded_k = k.repeat_interleave(group_size, dim=2)
+    expanded_v = v.repeat_interleave(group_size, dim=2)
+    scores = torch.einsum("bqhd,bkhd->bhqk", q, expanded_k) * q.shape[-1] ** -0.5
+    if causal:
+        query_positions = torch.arange(q.shape[1], device=q.device)[:, None]
+        key_positions = torch.arange(k.shape[1], device=q.device)[None, :]
+        bottom_right = query_positions + k.shape[1] - q.shape[1]
+        scores = scores.masked_fill(key_positions > bottom_right, float("-inf"))
+    probabilities = scores.softmax(dim=-1)
+    output = torch.einsum("bhqk,bkhd->bqhd", probabilities, expanded_v)
+    if not requires_grad:
+        return output, None
+    gradients = torch.autograd.grad(
+        output,
+        (q, k, v),
+        grad_outputs=inputs["dout"].detach().cpu().double(),
+    )
+    return output, gradients
+
+
+def test_default_configs_are_frozen_and_match_the_two_colfax_workloads() -> None:
+    decode = default_config("decode")
+    backward = default_config("backward")
+
+    assert decode == ColfaxConfig("decode", 32, 1, 131072, 16, 1, 64)
+    assert backward == ColfaxConfig("backward", 4, 16384, 16384, 32, 32, 64)
+    decode.validate()
+    backward.validate()
+    with pytest.raises(FrozenInstanceError):
+        decode.head_dim = 128  # type: ignore[misc]
+    with pytest.raises(ValueError, match="kind must be decode or backward"):
+        default_config("prefill")
+
+
+@pytest.mark.parametrize(
+    ("config", "message"),
+    [
+        (replace(default_config("decode"), kind="prefill"), "kind must be"),
+        (replace(default_config("decode"), batch_size=0), "batch_size must be"),
+        (replace(default_config("decode"), seqlen_q=True), "seqlen_q must be"),
+        (replace(default_config("decode"), seqlen_k=-1), "seqlen_k must be"),
+        (replace(default_config("decode"), query_heads=0), "query_heads must be"),
+        (replace(default_config("decode"), kv_heads=0), "kv_heads must be"),
+        (replace(default_config("decode"), head_dim=0), "head_dim must be"),
+        (replace(default_config("decode"), query_heads=15, kv_heads=2), "divisible"),
+        (replace(default_config("decode"), seqlen_q=257, seqlen_k=256), "must not exceed"),
+        (replace(default_config("decode"), head_dim=32), "head_dim 64 or 128"),
+        (
+            replace(default_config("decode"), seqlen_q=17, seqlen_k=256),
+            "packed decode queries",
+        ),
+        (replace(default_config("decode"), seqlen_k=128), "at least two"),
+        (replace(default_config("backward"), head_dim=128), "head_dim 64"),
+        (replace(default_config("backward"), seqlen_q=1024), "equal Q and KV"),
+    ],
+)
+def test_config_validation_rejects_invalid_or_unsupported_shapes(
+    config: ColfaxConfig,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        config.validate()
+
+
+def test_benchmark_constructor_rejects_a_mismatched_config_kind() -> None:
+    with pytest.raises(ValueError, match="config kind must match benchmark kind"):
+        ColfaxBenchmark("decode", optimized=False, config=default_config("backward"))
+
+
+def test_build_inputs_uses_the_callers_cpu_rng_stream() -> None:
+    config = ColfaxConfig("backward", 1, 2, 2, 2, 2, 64)
+    shapes = {
+        "q": (1, 2, 2, 64),
+        "k": (1, 2, 2, 64),
+        "v": (1, 2, 2, 64),
+        "dout": (1, 2, 2, 64),
+    }
+
+    with preserve_rng_state():
+        snapshots = []
+        for seed in (20260907, 20260907, 20260908):
+            torch.manual_seed(seed)
+            tensors = build_inputs(config, torch.device("cpu"))
+            assert torch.initial_seed() == seed
+            assert {name: tuple(tensor.shape) for name, tensor in tensors.items()} == shapes
+            assert all(tensor.dtype == torch.bfloat16 for tensor in tensors.values())
+            snapshots.append({name: tensor.clone() for name, tensor in tensors.items()})
+
+    assert all(torch.equal(snapshots[0][name], snapshots[1][name]) for name in shapes)
+    assert any(not torch.equal(snapshots[0][name], snapshots[2][name]) for name in shapes)
+
+    with preserve_rng_state():
+        torch.manual_seed(4242)
+        _ = torch.randn(11)
+        build_inputs(config, torch.device("cpu"))
+        actual_tail = torch.randn(8)
+
+        torch.manual_seed(4242)
+        _ = torch.randn(11)
+        for shape in shapes.values():
+            _ = torch.randn(shape, dtype=torch.bfloat16)
+        expected_tail = torch.randn(8)
+
+    torch.testing.assert_close(actual_tail, expected_tail, rtol=0, atol=0)
+
+
+def test_build_inputs_only_adds_dout_for_backward() -> None:
+    decode = ColfaxConfig("decode", 1, 1, 256, 2, 1, 64)
+    backward = ColfaxConfig("backward", 1, 2, 2, 2, 2, 64)
+
+    with preserve_rng_state():
+        torch.manual_seed(7)
+        decode_inputs = build_inputs(decode, torch.device("cpu"))
+        torch.manual_seed(7)
+        backward_inputs = build_inputs(backward, torch.device("cpu"))
+
+    assert set(decode_inputs) == {"q", "k", "v"}
+    assert set(backward_inputs) == {"q", "k", "v", "dout"}
+
+
+def test_reference_attention_expands_gqa_heads_against_a_scalar_oracle() -> None:
+    q = torch.tensor(
+        [
+            [
+                [[0.2, -0.1], [0.5, 0.3], [-0.4, 0.7], [0.1, -0.8]],
+                [[-0.3, 0.9], [0.4, -0.2], [0.8, 0.1], [-0.5, 0.6]],
+            ]
+        ],
+        dtype=torch.float64,
+    )
+    k = torch.tensor(
+        [[[[0.3, 0.1], [-0.2, 0.4]], [[0.7, -0.5], [0.6, 0.2]], [[-0.1, 0.8], [0.5, -0.7]]]],
+        dtype=torch.float64,
+    )
+    v = torch.tensor(
+        [[[[1.0, -1.0], [0.5, 0.2]], [[0.0, 2.0], [-0.5, 1.5]], [[3.0, 0.5], [2.0, -2.0]]]],
+        dtype=torch.float64,
+    )
+
+    actual = reference_attention(q, k, v)
+    expected = _manual_attention(q, k, v)
+
+    assert actual.dtype == torch.float64
+    torch.testing.assert_close(actual, expected, rtol=1e-12, atol=1e-12)
+
+
+def test_reference_attention_uses_bottom_right_causal_alignment() -> None:
+    q = torch.zeros((1, 2, 1, 1), dtype=torch.float32)
+    k = torch.zeros((1, 4, 1, 1), dtype=torch.float32)
+    v = torch.tensor([1.0, 2.0, 3.0, 4.0]).reshape(1, 4, 1, 1)
+
+    actual = reference_attention(q, k, v, causal=True)
+
+    # Q row 0 aligns with K row 2 and can see K[0:3]; Q row 1 can see all K.
+    expected = torch.tensor([2.0, 2.5]).reshape(1, 2, 1, 1)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_source_manifests_and_requirement_files_pin_distinct_exact_revisions() -> None:
+    manifests = {kind: source_manifest(kind) for kind in EXPECTED_PINS}
+
+    for kind, expected in EXPECTED_PINS.items():
+        manifest = manifests[kind]
+        assert manifest["pr"] == expected["pr"]
+        assert manifest["commit"] == expected["commit"]
+        assert manifest["files"] == expected["files"]
+        assert all(re.fullmatch(r"[0-9a-f]{64}", digest) for digest in manifest["files"].values())
+        requirement = (LAB_DIR / f"requirements_colfax_{kind}.txt").read_text(encoding="utf-8")
+        assert (
+            f"flash-attention.git@{expected['commit']}#subdirectory=flash_attn/cute" in requirement
+        )
+
+    assert manifests["decode"]["commit"] != manifests["backward"]["commit"]
+
+
+@pytest.mark.parametrize("kind", ["decode", "backward"])
+def test_source_verification_rejects_a_real_directory_with_mismatched_files(
+    tmp_path: Path,
+    kind: str,
+) -> None:
+    manifest = source_manifest(kind)
+    for filename in manifest["files"]:
+        path = tmp_path / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(f"not Colfax {kind}\n".encode())
+
+    with pytest.raises(RuntimeError, match=rf"SKIPPED: Colfax {kind}.*source mismatch"):
+        verify_source_files(tmp_path, kind)
+
+
+def test_real_discovery_finds_both_colfax_pairs() -> None:
+    pairs = {
+        example: (baseline.name, [path.name for path in optimized])
+        for baseline, optimized, example in discover_benchmarks(LAB_DIR, warn_missing=False)
+        if example.startswith("flashattention4_")
+    }
+
+    assert pairs["flashattention4_decode"] == (
+        "baseline_flashattention4_decode.py",
+        ["optimized_flashattention4_decode.py"],
+    )
+    assert pairs["flashattention4_backward"] == (
+        "baseline_flashattention4_backward.py",
+        ["optimized_flashattention4_backward.py"],
+    )
+
+
+@pytest.mark.parametrize(
+    ("module_name", "kind", "optimized"),
+    [
+        ("baseline_flashattention4_decode", "decode", False),
+        ("optimized_flashattention4_decode", "decode", True),
+        ("baseline_flashattention4_backward", "backward", False),
+        ("optimized_flashattention4_backward", "backward", True),
+    ],
+)
+def test_wrapper_factories_construct_without_resolving_a_device(
+    module_name: str,
+    kind: str,
+    optimized: bool,
+) -> None:
+    module = importlib.import_module(f"labs.flashattention4.{module_name}")
+
+    benchmark = module.get_benchmark()
+
+    assert isinstance(benchmark, BaseBenchmark)
+    assert isinstance(benchmark, ColfaxBenchmark)
+    assert benchmark.kind == kind
+    assert benchmark.optimized is optimized
+    assert benchmark.spec == default_config(kind)
+    assert benchmark._device is None
+
+
+def test_opt_in_real_colfax_sm100_lifecycle_and_full_outputs() -> None:
+    kind = os.environ.get("AISP_TEST_COLFAX_KIND")
+    if kind is None:
+        pytest.skip("set AISP_TEST_COLFAX_KIND=decode or backward for the real Colfax FA4 test")
+    if kind not in EXPECTED_PINS:
+        pytest.fail("AISP_TEST_COLFAX_KIND must be exactly decode or backward")
+    if not torch.cuda.is_available():
+        pytest.fail(f"AISP_TEST_COLFAX_KIND={kind} requested, but CUDA is unavailable")
+    capability = torch.cuda.get_device_capability()
+    if capability != (10, 0):
+        pytest.fail(f"AISP_TEST_COLFAX_KIND={kind} requires exact SM100; detected {capability}")
+
+    interface = load_upstream(kind)
+    verified = verify_source_files(Path(interface.__file__).resolve().parent, kind)
+    assert verified["commit"] == EXPECTED_PINS[kind]["commit"]
+    assert interface._get_device_arch() == 100
+
+    config = (
+        ColfaxConfig("decode", 1, 2, 256, 16, 2, 64)
+        if kind == "decode"
+        else ColfaxConfig("backward", 1, 256, 256, 4, 4, 64)
+    )
+    arm_results = []
+    for optimized in (False, True):
+        benchmark = ColfaxBenchmark(kind, optimized=optimized, config=config)
+        try:
+            torch.manual_seed(20260907)
+            decode_switch = (
+                interface.utils._fa_disable_s_ping_pong_enabled if kind == "decode" else None
+            )
+            benchmark.setup()
+            if kind == "decode":
+                assert interface.utils._fa_disable_s_ping_pong_enabled is decode_switch
+            with pytest.raises(RuntimeError, match=r"benchmark_fn\(\) must replay"):
+                benchmark.capture_verification_payload()
+
+            for _ in range(2):
+                captured_outputs = (
+                    (benchmark.output,)
+                    if isinstance(benchmark.output, torch.Tensor)
+                    else benchmark.output
+                )
+                assert captured_outputs is not None
+                for tensor in captured_outputs:
+                    tensor.fill_(float("nan"))
+                benchmark.benchmark_fn()
+                assert all(torch.isfinite(tensor).all() for tensor in captured_outputs)
+
+            benchmark.capture_verification_payload()
+            assert benchmark.inputs is not None
+            inputs = {name: tensor.detach().clone() for name, tensor in benchmark.inputs.items()}
+            if kind == "decode":
+                assert isinstance(benchmark.output, torch.Tensor)
+                outputs = (benchmark.output.detach().clone(),)
+            else:
+                assert isinstance(benchmark.output, tuple) and len(benchmark.output) == 3
+                outputs = tuple(tensor.detach().clone() for tensor in benchmark.output)
+            payload = benchmark.get_verify_output()
+            expected_payload = (
+                outputs[0]
+                if kind == "decode"
+                else torch.cat([tensor.reshape(-1) for tensor in outputs])
+            )
+            torch.testing.assert_close(payload, expected_payload, rtol=0, atol=0)
+            assert benchmark.get_output_tolerance() == (
+                (2e-2, 2e-2) if kind == "decode" else (0.0, 0.0)
+            )
+            assert benchmark.validate_result() is None
+            arm_results.append((inputs, outputs))
+        finally:
+            benchmark.teardown()
+
+    baseline_inputs, baseline_outputs = arm_results[0]
+    candidate_inputs, candidate_outputs = arm_results[1]
+    assert baseline_inputs.keys() == candidate_inputs.keys()
+    for name in baseline_inputs:
+        torch.testing.assert_close(baseline_inputs[name], candidate_inputs[name], rtol=0, atol=0)
+
+    reference_output, reference_gradients = _torch_attention_oracle(
+        baseline_inputs,
+        causal=config.causal,
+    )
+    if kind == "decode":
+        for outputs in (baseline_outputs, candidate_outputs):
+            torch.testing.assert_close(
+                outputs[0].detach().cpu().double(), reference_output, rtol=3e-2, atol=3e-2
+            )
+    else:
+        assert reference_gradients is not None
+        for outputs in (baseline_outputs, candidate_outputs):
+            assert len(outputs) == len(reference_gradients) == 3
+            for actual, expected in zip(outputs, reference_gradients, strict=True):
+                torch.testing.assert_close(
+                    actual.detach().cpu().double(), expected, rtol=3e-2, atol=3e-2
+                )
+
+    pair_tolerance = (2e-2, 2e-2) if kind == "decode" else (0.0, 0.0)
+    for baseline, candidate in zip(baseline_outputs, candidate_outputs, strict=True):
+        torch.testing.assert_close(
+            baseline,
+            candidate,
+            rtol=pair_tolerance[0],
+            atol=pair_tolerance[1],
+        )


### PR DESCRIPTION
The existing FlashAttention-4 lab now includes direct kernel ablations for the two Colfax optimization diaries: S/P ping-pong during decode and head-dimension-64 backward TMEM de-aliasing with warp-local synchronization. Each baseline/optimized pair holds the workload and upstream revision fixed and switches the corresponding kernel controls off/on.

The new targets use separate pinned FA4 environments, reject unsupported CUDA/SM100 or mismatched source files, and time steady-state CUDA graph replay. Backward includes preprocessing, gradient computation and postprocessing; its common forward state is setup work. Verification checks full outputs and all three gradients, with exact arm equality for deterministic backward. The guide and workload contracts are linked from Chapters 10, 11 and 18.

Validation: 28 CPU tests passed; the opt-in B200 test was skipped on macOS. Ruff, formatting, syntax, benchmark-contract lint and target discovery passed. Critical upstream file hashes match the pinned revisions. The GPU test includes an independent high-precision oracle and repeated poisoned-output replay checks. B200 correctness, profiling and performance remain pending; no new GPU speedup or expectations are claimed.
