### PR TITLE
Verify executed worker outputs and repair B200 distributed benchmarks

### DIFF
--- a/code/ch04/baseline_pipeline_parallel.py
+++ b/code/ch04/baseline_pipeline_parallel.py
@@ -6,22 +6,19 @@ Sequential micro-batches (all forward, then all backward). Launched via torchrun
 
 from __future__ import annotations
 
-
 import argparse
 import os
-
-from core.common.device_utils import resolve_local_rank
 import time
 from collections import deque
 from typing import Optional
 
 import torch
-import torch.nn as nn
 import torch.distributed as dist
-
+import torch.nn as nn
 from core.benchmark.gpu_requirements import require_min_gpus
 from core.benchmark.verification import PrecisionFlags
 from core.benchmark.verification_mixin import VerificationPayloadMixin
+from core.common.device_utils import resolve_local_rank
 from core.harness.benchmark_harness import (
     BaseBenchmark,
     BenchmarkConfig,
@@ -32,9 +29,22 @@ from core.profiling.nvtx_helper import nvtx_range
 from core.utils.logger import get_logger
 from core.utils.worker_seed import apply_worker_seed
 
+from ch04.pipeline_parallel_common import (
+    PIPELINE_RESULT_CALLBACK,
+    PipelineIterationCapture,
+    PipelineParallelChildResultMixin,
+    pipeline_child_result_requested,
+    run_gpipe_iteration,
+    verify_and_concatenate_pipeline_capture,
+    write_pipeline_child_result,
+)
+
 logger = get_logger(__name__)
 
 PROFILE_NVTX_RANGE = "compute_kernel:pipeline_parallel_gpipe"
+PIPELINE_SOURCE = "ch04.baseline_pipeline_parallel"
+PIPELINE_VARIANT = "baseline"
+PIPELINE_SCHEDULE = "gpipe"
 
 _DEFAULT_BATCH = 32
 _DEFAULT_SEQ = 2048
@@ -187,65 +197,61 @@ def _run_worker(
         inputs = torch.randn(batch_size, seq_length, hidden, device=device, dtype=torch.bfloat16)
     else:
         inputs = None
+    recv_micro_batches: list[torch.Tensor] = []
     recv_micro_batch: Optional[torch.Tensor] = None
     if rank > 0:
-        recv_micro_batch = torch.empty(
-            micro_batch_size,
-            seq_length,
-            hidden,
-            device=device,
-            dtype=torch.bfloat16,
-        )
+        for _ in range(num_micro_batches):
+            recv_micro_batch = torch.empty(
+                micro_batch_size,
+                seq_length,
+                hidden,
+                device=device,
+                dtype=torch.bfloat16,
+            )
+            recv_micro_batches.append(recv_micro_batch)
+    recv_grads: list[torch.Tensor] = []
     recv_grad: Optional[torch.Tensor] = None
     if rank < world_size - 1:
-        recv_grad = torch.empty(
-            micro_batch_size,
-            seq_length,
-            hidden,
-            device=device,
-            dtype=torch.bfloat16,
-        )
+        for _ in range(num_micro_batches):
+            recv_grad = torch.empty(
+                micro_batch_size,
+                seq_length,
+                hidden,
+                device=device,
+                dtype=torch.bfloat16,
+            )
+            recv_grads.append(recv_grad)
 
     def _forward(micro_batch: torch.Tensor) -> torch.Tensor:
         return _run_rank_stage(fwd_layers, rank, micro_batch)
 
-    def _backward(grad_in: torch.Tensor) -> torch.Tensor:
+    def _backward(_activation: torch.Tensor, grad_in: torch.Tensor) -> torch.Tensor:
         return _run_rank_stage(bwd_layers, rank, grad_in)
 
-    def _run_iteration() -> None:
-        activations: deque[torch.Tensor] = deque()
+    if rank == 0 and inputs is None:
+        raise RuntimeError("rank zero pipeline input is missing")
 
-        for micro_idx in range(num_micro_batches):
-            if rank == 0:
-                start_idx = micro_idx * micro_batch_size
-                end_idx = start_idx + micro_batch_size
-                micro_batch = inputs[start_idx:end_idx]
-            else:
-                if recv_micro_batch is None:
-                    raise RuntimeError("recv microbatch buffer missing")
-                micro_batch = recv_micro_batch
-                dist.recv(micro_batch, src=rank - 1)
+    def _get_rank0_microbatch(micro_idx: int) -> torch.Tensor:
+        if inputs is None:
+            raise RuntimeError("Only rank zero owns pipeline input microbatches")
+        start_idx = micro_idx * micro_batch_size
+        return inputs.narrow(0, start_idx, micro_batch_size)
 
-            out = _forward(micro_batch)
-            activations.append(out)
+    def _run_iteration(capture: Optional[PipelineIterationCapture] = None) -> None:
+        run_gpipe_iteration(
+            rank=rank,
+            world_size=world_size,
+            num_micro_batches=num_micro_batches,
+            get_rank0_microbatch=_get_rank0_microbatch,
+            recv_forward_buffers=recv_micro_batches,
+            recv_backward_buffers=recv_grads,
+            forward_step=_forward,
+            backward_step=_backward,
+            capture=capture,
+        )
 
-            if rank < world_size - 1:
-                dist.send(out, dst=rank + 1)
-
-        for _ in range(num_micro_batches):
-            activation = activations.pop()
-            if rank < world_size - 1:
-                if recv_grad is None:
-                    raise RuntimeError("recv grad buffer missing")
-                grad_in = recv_grad
-                dist.recv(grad_in, src=rank + 1)
-            else:
-                grad_in = activation
-
-            grad = _backward(grad_in)
-            if rank > 0:
-                dist.send(grad, dst=rank - 1)
-
+    result_requested = pipeline_child_result_requested()
+    captured_iteration: Optional[PipelineIterationCapture] = None
     with torch.inference_mode():
         for _ in range(max(warmup, 0)):
             _run_iteration()
@@ -253,13 +259,47 @@ def _run_worker(
 
         with nvtx_range(PROFILE_NVTX_RANGE, enable=True):
             start = time.perf_counter()
-            for _ in range(max(iters, 1)):
-                _run_iteration()
+            measured_iterations = max(iters, 1)
+            for iteration in range(max(iters, 1)):
+                capture = (
+                    PipelineIterationCapture.create(num_micro_batches)
+                    if result_requested and iteration == measured_iterations - 1
+                    else None
+                )
+                _run_iteration(capture)
+                if capture is not None:
+                    captured_iteration = capture
             torch.cuda.synchronize(device)
             elapsed = time.perf_counter() - start
 
+        time_per_iter_ms = (elapsed / measured_iterations) * 1000.0
+        if result_requested:
+            if captured_iteration is None:
+                raise RuntimeError("Pipeline timed iteration did not retain its actual outputs")
+            forward_stages = [
+                (lambda value, stage=stage: _run_stage(stage, value))
+                for stage in fwd_layers
+            ]
+            backward_stages = [
+                (lambda value, stage=stage: _run_stage(stage, value))
+                for stage in bwd_layers
+            ]
+            verify_input, verify_output = verify_and_concatenate_pipeline_capture(
+                rank=rank,
+                capture=captured_iteration,
+                forward_stages=forward_stages,
+                backward_stages=backward_stages,
+            )
+            if not write_pipeline_child_result(
+                verify_input=verify_input,
+                verify_output=verify_output,
+                completed_iterations=measured_iterations,
+                time_per_iter_ms=time_per_iter_ms,
+                reference_verified=True,
+            ):
+                raise RuntimeError("Pipeline child-result request disappeared before publication")
+
     if rank == 0:
-        time_per_iter_ms = (elapsed / max(iters, 1)) * 1000.0
         print(f"rank0 time_per_iter_ms: {time_per_iter_ms:.9f}", flush=True)
 
     dist.barrier()
@@ -304,7 +344,11 @@ def main() -> None:
     )
 
 
-class BaselinePipelineParallelBenchmark(VerificationPayloadMixin, BaseBenchmark):
+class BaselinePipelineParallelBenchmark(
+    PipelineParallelChildResultMixin,
+    VerificationPayloadMixin,
+    BaseBenchmark,
+):
     preferred_ncu_replay_mode = "app-range"
 
     """Harness entry that launches this module via torchrun."""
@@ -376,30 +420,13 @@ class BaselinePipelineParallelBenchmark(VerificationPayloadMixin, BaseBenchmark)
             },
         )
 
-    def _prepare_verification_payload(self) -> None:
-        if hasattr(self, "_subprocess_verify_output"):
-            return
-        self.setup()
-        try:
-            self.benchmark_fn()
-            self.capture_verification_payload()
-            self._subprocess_verify_output = self.get_verify_output()
-            self._subprocess_output_tolerance = self.get_output_tolerance()
-            self._subprocess_input_signature = self.get_input_signature()
-        finally:
-            self.teardown()
-
     def teardown(self) -> None:
+        self.retain_failed_pipeline_child_result()
         self._fwd_layers = None
         self._bwd_layers = None
         self._input = None
         self._output = None
         torch.cuda.empty_cache()
-
-    def validate_result(self) -> Optional[str]:
-        if self._output is None:
-            return "No output captured"
-        return None
 
     def get_config(self) -> BenchmarkConfig:
         return BenchmarkConfig(
@@ -415,13 +442,27 @@ class BaselinePipelineParallelBenchmark(VerificationPayloadMixin, BaseBenchmark)
         )
 
     def get_torchrun_spec(self, config: Optional[BenchmarkConfig] = None) -> TorchrunLaunchSpec:
-        self._prepare_verification_payload()
         effective_config = config or self.get_config()
+        world_size = int(effective_config.nproc_per_node or max(torch.cuda.device_count(), 1))
+        num_layers = _resolve_num_layers(None, world_size)
+        result_env = self.prepare_pipeline_child_result(
+            source=PIPELINE_SOURCE,
+            variant=PIPELINE_VARIANT,
+            schedule=PIPELINE_SCHEDULE,
+            world_size=world_size,
+            iterations=int(effective_config.iterations),
+            batch_size=_DEFAULT_BATCH,
+            seq_length=_DEFAULT_SEQ,
+            hidden=_DEFAULT_HIDDEN,
+            num_layers=num_layers,
+        )
         return TorchrunLaunchSpec(
             module_name="core.harness.benchmark_worker",
             script_args=["--module", "ch04.baseline_pipeline_parallel", "--callable", "main", "--"],
+            env=result_env,
             multi_gpu_required=True,
             name="baseline_pipeline_parallel",
+            result_callback=PIPELINE_RESULT_CALLBACK,
             config_arg_map={
                 "iterations": "--iters",
                 "warmup": "--warmup",

--- a/code/ch04/baseline_tensor_parallel_allgather_multigpu.py
+++ b/code/ch04/baseline_tensor_parallel_allgather_multigpu.py
@@ -194,8 +194,6 @@ def main() -> None:
 
 
 class BaselineTensorParallelAllGatherBenchmark(VerificationPayloadMixin, BaseBenchmark):
-    preferred_ncu_replay_mode = "app-range"
-
     """Harness entry that launches this module via torchrun."""
     multi_gpu_required = True
     preferred_ncu_replay_mode = "kernel"  # Application replay is unstable for torchrun collectives.

--- a/code/ch04/baseline_tensor_parallel_multigpu.py
+++ b/code/ch04/baseline_tensor_parallel_multigpu.py
@@ -198,8 +198,6 @@ def main() -> None:
 
 
 class BaselineTensorParallelBenchmark(VerificationPayloadMixin, BaseBenchmark):
-    preferred_ncu_replay_mode = "app-range"
-
     """Harness entry that launches this module via torchrun."""
     multi_gpu_required = True
     preferred_ncu_replay_mode = "kernel"  # Application replay is unstable for torchrun collectives.

--- a/code/ch04/optimized_pipeline_parallel_1f1b.py
+++ b/code/ch04/optimized_pipeline_parallel_1f1b.py
@@ -7,21 +7,18 @@ Launched via torchrun.
 
 from __future__ import annotations
 
-
 import argparse
 import os
-
-from core.common.device_utils import resolve_local_rank
 import time
 from typing import Optional
 
 import torch
-import torch.nn as nn
 import torch.distributed as dist
-
+import torch.nn as nn
 from core.benchmark.gpu_requirements import require_min_gpus
 from core.benchmark.verification import PrecisionFlags
 from core.benchmark.verification_mixin import VerificationPayloadMixin
+from core.common.device_utils import resolve_local_rank
 from core.harness.benchmark_harness import (
     BaseBenchmark,
     BenchmarkConfig,
@@ -32,9 +29,22 @@ from core.profiling.nvtx_helper import nvtx_range
 from core.utils.logger import get_logger
 from core.utils.worker_seed import apply_worker_seed
 
+from ch04.pipeline_parallel_common import (
+    PIPELINE_RESULT_CALLBACK,
+    PipelineIterationCapture,
+    PipelineParallelChildResultMixin,
+    pipeline_child_result_requested,
+    run_1f1b_iteration,
+    verify_and_concatenate_pipeline_capture,
+    write_pipeline_child_result,
+)
+
 logger = get_logger(__name__)
 
 PROFILE_NVTX_RANGE = "compute_kernel:pipeline_parallel_1f1b"
+PIPELINE_SOURCE = "ch04.optimized_pipeline_parallel_1f1b"
+PIPELINE_VARIANT = "optimized"
+PIPELINE_SCHEDULE = "1f1b-paired-p2p"
 
 _DEFAULT_BATCH = 32
 _DEFAULT_SEQ = 2048
@@ -154,109 +164,67 @@ def _run_worker(
         inputs = torch.randn(batch_size, seq_length, hidden, device=device, dtype=torch.bfloat16)
     else:
         inputs = None
+    recv_micro_batches: list[torch.Tensor] = []
     recv_micro_batch: Optional[torch.Tensor] = None
     if rank > 0:
-        recv_micro_batch = torch.empty(
-            micro_batch_size,
-            seq_length,
-            hidden,
-            device=device,
-            dtype=torch.bfloat16,
-        )
+        for _ in range(num_micro_batches):
+            recv_micro_batch = torch.empty(
+                micro_batch_size,
+                seq_length,
+                hidden,
+                device=device,
+                dtype=torch.bfloat16,
+            )
+            recv_micro_batches.append(recv_micro_batch)
+    recv_grads: list[torch.Tensor] = []
     recv_grad: Optional[torch.Tensor] = None
     if rank < world_size - 1:
-        recv_grad = torch.empty(
-            micro_batch_size,
-            seq_length,
-            hidden,
-            device=device,
-            dtype=torch.bfloat16,
-        )
+        for _ in range(num_micro_batches):
+            recv_grad = torch.empty(
+                micro_batch_size,
+                seq_length,
+                hidden,
+                device=device,
+                dtype=torch.bfloat16,
+            )
+            recv_grads.append(recv_grad)
 
     def _forward(micro_batch: torch.Tensor) -> torch.Tensor:
         return _run_rank_stage_inplace(fwd_layers, rank, micro_batch)
 
-    def _backward(grad_in: torch.Tensor) -> torch.Tensor:
+    def _backward(_activation: torch.Tensor, grad_in: torch.Tensor) -> torch.Tensor:
         return _run_rank_stage_inplace(bwd_layers, rank, grad_in)
 
-    warmup_steps = min(world_size, num_micro_batches)
-    activation_slots: list[Optional[torch.Tensor]] = [None] * warmup_steps
+    if rank == 0 and inputs is None:
+        raise RuntimeError("rank zero pipeline input is missing")
 
-    def _run_iteration() -> None:
-        activation_head = 0
-        activation_count = 0
+    def _get_rank0_microbatch(micro_idx: int) -> torch.Tensor:
+        if inputs is None:
+            raise RuntimeError("Only rank zero owns pipeline input microbatches")
+        start_idx = micro_idx * micro_batch_size
+        return inputs.narrow(0, start_idx, micro_batch_size)
 
-        for micro_idx in range(warmup_steps):
-            if rank == 0:
-                start_idx = micro_idx * micro_batch_size
-                end_idx = start_idx + micro_batch_size
-                micro_batch = inputs[start_idx:end_idx]
-            else:
-                if recv_micro_batch is None:
-                    raise RuntimeError("recv microbatch buffer missing")
-                micro_batch = recv_micro_batch
-                dist.recv(micro_batch, src=rank - 1)
+    warmup_steps = min(world_size - rank - 1, num_micro_batches)
+    activation_slots: list[Optional[tuple[int, torch.Tensor]]] = [None] * max(
+        warmup_steps, 1
+    )
 
-            out = _forward(micro_batch)
-            activation_slots[(activation_head + activation_count) % warmup_steps] = out
-            activation_count += 1
-            if rank < world_size - 1:
-                dist.send(out, dst=rank + 1)
+    def _run_iteration(capture: Optional[PipelineIterationCapture] = None) -> None:
+        run_1f1b_iteration(
+            rank=rank,
+            world_size=world_size,
+            num_micro_batches=num_micro_batches,
+            get_rank0_microbatch=_get_rank0_microbatch,
+            recv_forward_buffers=recv_micro_batches,
+            recv_backward_buffers=recv_grads,
+            forward_step=_forward,
+            backward_step=_backward,
+            activation_slots=activation_slots,
+            capture=capture,
+        )
 
-        for micro_idx in range(warmup_steps, num_micro_batches):
-            activation = activation_slots[activation_head]
-            if activation is None:
-                raise RuntimeError("activation slot missing")
-            activation_slots[activation_head] = None
-            activation_head = (activation_head + 1) % warmup_steps
-            activation_count -= 1
-            if rank < world_size - 1:
-                if recv_grad is None:
-                    raise RuntimeError("recv grad buffer missing")
-                grad_in = recv_grad
-                dist.recv(grad_in, src=rank + 1)
-            else:
-                grad_in = activation
-
-            grad = _backward(grad_in)
-            if rank > 0:
-                dist.send(grad, dst=rank - 1)
-
-            if rank == 0:
-                start_idx = micro_idx * micro_batch_size
-                end_idx = start_idx + micro_batch_size
-                micro_batch = inputs[start_idx:end_idx]
-            else:
-                if recv_micro_batch is None:
-                    raise RuntimeError("recv microbatch buffer missing")
-                micro_batch = recv_micro_batch
-                dist.recv(micro_batch, src=rank - 1)
-
-            out = _forward(micro_batch)
-            activation_slots[(activation_head + activation_count) % warmup_steps] = out
-            activation_count += 1
-            if rank < world_size - 1:
-                dist.send(out, dst=rank + 1)
-
-        while activation_count:
-            activation = activation_slots[activation_head]
-            if activation is None:
-                raise RuntimeError("activation slot missing")
-            activation_slots[activation_head] = None
-            activation_head = (activation_head + 1) % warmup_steps
-            activation_count -= 1
-            if rank < world_size - 1:
-                if recv_grad is None:
-                    raise RuntimeError("recv grad buffer missing")
-                grad_in = recv_grad
-                dist.recv(grad_in, src=rank + 1)
-            else:
-                grad_in = activation
-
-            grad = _backward(grad_in)
-            if rank > 0:
-                dist.send(grad, dst=rank - 1)
-
+    result_requested = pipeline_child_result_requested()
+    captured_iteration: Optional[PipelineIterationCapture] = None
     with torch.inference_mode():
         for _ in range(max(warmup, 0)):
             _run_iteration()
@@ -264,13 +232,47 @@ def _run_worker(
 
         with nvtx_range(PROFILE_NVTX_RANGE, enable=True):
             start = time.perf_counter()
-            for _ in range(max(iters, 1)):
-                _run_iteration()
+            measured_iterations = max(iters, 1)
+            for iteration in range(max(iters, 1)):
+                capture = (
+                    PipelineIterationCapture.create(num_micro_batches)
+                    if result_requested and iteration == measured_iterations - 1
+                    else None
+                )
+                _run_iteration(capture)
+                if capture is not None:
+                    captured_iteration = capture
             torch.cuda.synchronize(device)
             elapsed = time.perf_counter() - start
 
+        time_per_iter_ms = (elapsed / measured_iterations) * 1000.0
+        if result_requested:
+            if captured_iteration is None:
+                raise RuntimeError("Pipeline timed iteration did not retain its actual outputs")
+            forward_stages = [
+                (lambda value, stage=stage: _run_stage_inplace(stage, value))
+                for stage in fwd_layers
+            ]
+            backward_stages = [
+                (lambda value, stage=stage: _run_stage_inplace(stage, value))
+                for stage in bwd_layers
+            ]
+            verify_input, verify_output = verify_and_concatenate_pipeline_capture(
+                rank=rank,
+                capture=captured_iteration,
+                forward_stages=forward_stages,
+                backward_stages=backward_stages,
+            )
+            if not write_pipeline_child_result(
+                verify_input=verify_input,
+                verify_output=verify_output,
+                completed_iterations=measured_iterations,
+                time_per_iter_ms=time_per_iter_ms,
+                reference_verified=True,
+            ):
+                raise RuntimeError("Pipeline child-result request disappeared before publication")
+
     if rank == 0:
-        time_per_iter_ms = (elapsed / max(iters, 1)) * 1000.0
         print(f"rank0 time_per_iter_ms: {time_per_iter_ms:.9f}", flush=True)
 
     dist.barrier()
@@ -315,7 +317,11 @@ def main() -> None:
     )
 
 
-class OptimizedPipelineParallelBenchmark(VerificationPayloadMixin, BaseBenchmark):
+class OptimizedPipelineParallelBenchmark(
+    PipelineParallelChildResultMixin,
+    VerificationPayloadMixin,
+    BaseBenchmark,
+):
     preferred_ncu_replay_mode = "app-range"
 
     """Harness entry that launches this module via torchrun."""
@@ -400,31 +406,14 @@ class OptimizedPipelineParallelBenchmark(VerificationPayloadMixin, BaseBenchmark
             },
         )
 
-    def _prepare_verification_payload(self) -> None:
-        if hasattr(self, "_subprocess_verify_output"):
-            return
-        self.setup()
-        try:
-            self.benchmark_fn()
-            self.capture_verification_payload()
-            self._subprocess_verify_output = self.get_verify_output()
-            self._subprocess_output_tolerance = self.get_output_tolerance()
-            self._subprocess_input_signature = self.get_input_signature()
-        finally:
-            self.teardown()
-
     def teardown(self) -> None:
+        self.retain_failed_pipeline_child_result()
         self._fwd_layers = None
         self._bwd_layers = None
         self._input = None
         self._micro_batch = None
         self._output = None
         torch.cuda.empty_cache()
-
-    def validate_result(self) -> Optional[str]:
-        if self._output is None:
-            return "No output captured"
-        return None
 
     def get_config(self) -> BenchmarkConfig:
         return BenchmarkConfig(
@@ -440,13 +429,27 @@ class OptimizedPipelineParallelBenchmark(VerificationPayloadMixin, BaseBenchmark
         )
 
     def get_torchrun_spec(self, config: Optional[BenchmarkConfig] = None) -> TorchrunLaunchSpec:
-        self._prepare_verification_payload()
         effective_config = config or self.get_config()
+        world_size = int(effective_config.nproc_per_node or max(torch.cuda.device_count(), 1))
+        num_layers = _resolve_num_layers(None, world_size)
+        result_env = self.prepare_pipeline_child_result(
+            source=PIPELINE_SOURCE,
+            variant=PIPELINE_VARIANT,
+            schedule=PIPELINE_SCHEDULE,
+            world_size=world_size,
+            iterations=int(effective_config.iterations),
+            batch_size=_DEFAULT_BATCH,
+            seq_length=_DEFAULT_SEQ,
+            hidden=_DEFAULT_HIDDEN,
+            num_layers=num_layers,
+        )
         return TorchrunLaunchSpec(
             module_name="core.harness.benchmark_worker",
             script_args=["--module", "ch04.optimized_pipeline_parallel_1f1b", "--callable", "main", "--"],
+            env=result_env,
             multi_gpu_required=True,
             name="optimized_pipeline_parallel_1f1b",
+            result_callback=PIPELINE_RESULT_CALLBACK,
             config_arg_map={
                 "iterations": "--iters",
                 "warmup": "--warmup",

--- a/code/ch04/optimized_tensor_parallel_allgather_multigpu.py
+++ b/code/ch04/optimized_tensor_parallel_allgather_multigpu.py
@@ -194,8 +194,6 @@ def main() -> None:
 
 
 class OptimizedTensorParallelAllGatherBenchmark(VerificationPayloadMixin, BaseBenchmark):
-    preferred_ncu_replay_mode = "app-range"
-
     """Harness entry that launches this module via torchrun."""
     multi_gpu_required = True
     preferred_ncu_replay_mode = "kernel"  # Application replay is unstable for torchrun collectives.

--- a/code/ch04/optimized_tensor_parallel_multigpu.py
+++ b/code/ch04/optimized_tensor_parallel_multigpu.py
@@ -217,8 +217,6 @@ def main() -> None:
 
 
 class OptimizedTensorParallelBenchmark(VerificationPayloadMixin, BaseBenchmark):
-    preferred_ncu_replay_mode = "app-range"
-
     """Harness entry that launches this module via torchrun."""
     multi_gpu_required = True
     preferred_ncu_replay_mode = "kernel"  # Application replay is unstable for torchrun collectives.

--- a/code/ch04/pipeline_parallel_common.py
+++ b/code/ch04/pipeline_parallel_common.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import torch
 import torch.distributed as dist
+
 from core.benchmark.verification import InputSignature, PrecisionFlags
 from labs.train_distributed.training_utils.child_result import (
     CONTRACT_ENV,
@@ -41,7 +42,9 @@ PIPELINE_RESULT_VARIANT_ENV = "AISP_PIPELINE_RESULT_VARIANT"
 PIPELINE_RESULT_SCHEDULE_ENV = "AISP_PIPELINE_RESULT_SCHEDULE"
 PIPELINE_RESULT_SHAPE_ENV = "AISP_PIPELINE_RESULT_SHAPE"
 PIPELINE_RESULT_LAYERS_ENV = "AISP_PIPELINE_RESULT_LAYERS"
-PIPELINE_OUTPUT_TOLERANCE = (0.1, 1.0)
+# Both schedules perform the same per-microbatch BF16 operations. Full-shape
+# two-B200 repeats across four seeds produced bitwise-equal worker outputs.
+PIPELINE_OUTPUT_TOLERANCE = (0.0, 0.0)
 
 _MAX_RAW_RANK_BYTES = 1024 * 1024 * 1024
 _SERIALIZATION_OVERHEAD_BYTES = 1024 * 1024

--- a/code/ch04/pipeline_parallel_common.py
+++ b/code/ch04/pipeline_parallel_common.py
@@ -1,0 +1,1027 @@
+"""Shared scheduling and child-result support for the Chapter 4 pipeline pair."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import shutil
+import tempfile
+import time
+import uuid
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import torch
+import torch.distributed as dist
+from core.benchmark.verification import InputSignature, PrecisionFlags
+from labs.train_distributed.training_utils.child_result import (
+    CONTRACT_ENV,
+    ITERATIONS_ENV,
+    LAUNCH_MONOTONIC_NS_ENV,
+    LAUNCH_WALL_NS_ENV,
+    RESULT_DIR_ENV,
+    RUN_ID_ENV,
+    WORLD_SIZE_ENV,
+    TorchrunChildResultContract,
+)
+
+if TYPE_CHECKING:
+    from core.harness.benchmark_harness import BenchmarkConfig, TorchrunLaunchSpec
+
+
+PIPELINE_RESULT_CALLBACK = "consume_pipeline_child_results"
+PIPELINE_RESULT_SCHEMA = "aisp.ch04.pipeline.child-result.v1"
+PIPELINE_RESULT_RECEIPT_SCHEMA = "aisp.ch04.pipeline.child-result-receipt.v1"
+PIPELINE_RESULT_RECEIPT_PREFIX = "AISP_PIPELINE_RESULT_RECEIPT:"
+PIPELINE_RESULT_SOURCE_ENV = "AISP_PIPELINE_RESULT_SOURCE"
+PIPELINE_RESULT_VARIANT_ENV = "AISP_PIPELINE_RESULT_VARIANT"
+PIPELINE_RESULT_SCHEDULE_ENV = "AISP_PIPELINE_RESULT_SCHEDULE"
+PIPELINE_RESULT_SHAPE_ENV = "AISP_PIPELINE_RESULT_SHAPE"
+PIPELINE_RESULT_LAYERS_ENV = "AISP_PIPELINE_RESULT_LAYERS"
+PIPELINE_OUTPUT_TOLERANCE = (0.1, 1.0)
+
+_MAX_RAW_RANK_BYTES = 1024 * 1024 * 1024
+_SERIALIZATION_OVERHEAD_BYTES = 1024 * 1024
+_FINITE_CHUNK_ELEMENTS = 16 * 1024 * 1024
+
+
+TensorStep = Callable[[torch.Tensor], torch.Tensor]
+BackwardStep = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+MicrobatchGetter = Callable[[int], torch.Tensor]
+
+
+@dataclass
+class PipelineIterationCapture:
+    """References to one measured iteration, indexed by original microbatch."""
+
+    forward_inputs: list[torch.Tensor | None]
+    backward_inputs: list[torch.Tensor | None]
+    backward_outputs: list[torch.Tensor | None]
+
+    @classmethod
+    def create(cls, num_micro_batches: int) -> PipelineIterationCapture:
+        if num_micro_batches <= 0:
+            raise ValueError("num_micro_batches must be positive")
+        return cls(
+            forward_inputs=[None] * num_micro_batches,
+            backward_inputs=[None] * num_micro_batches,
+            backward_outputs=[None] * num_micro_batches,
+        )
+
+    def concatenate(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Concatenate only after the measured interval has closed."""
+
+        ordered: list[list[torch.Tensor]] = []
+        for label, values in (
+            ("forward_inputs", self.forward_inputs),
+            ("backward_inputs", self.backward_inputs),
+            ("backward_outputs", self.backward_outputs),
+        ):
+            if any(value is None for value in values):
+                raise RuntimeError(f"Pipeline capture is incomplete: {label}")
+            ordered.append([cast(torch.Tensor, value) for value in values])
+        return tuple(torch.cat(values, dim=0) for values in ordered)  # type: ignore[return-value]
+
+
+def _validate_schedule_inputs(
+    *,
+    rank: int,
+    world_size: int,
+    num_micro_batches: int,
+    recv_forward_buffers: Sequence[torch.Tensor],
+    recv_backward_buffers: Sequence[torch.Tensor],
+) -> None:
+    if world_size < 2 or rank < 0 or rank >= world_size:
+        raise ValueError("Pipeline schedule requires a valid multi-rank topology")
+    if num_micro_batches < world_size:
+        raise ValueError("Pipeline schedule requires at least one microbatch per stage")
+    if rank > 0 and len(recv_forward_buffers) != num_micro_batches:
+        raise ValueError("Every non-first stage needs one forward receive buffer per microbatch")
+    if rank < world_size - 1 and len(recv_backward_buffers) != num_micro_batches:
+        raise ValueError("Every non-last stage needs one backward receive buffer per microbatch")
+
+
+def _record(
+    capture: PipelineIterationCapture | None,
+    collection: str,
+    microbatch_index: int,
+    tensor: torch.Tensor,
+) -> None:
+    if capture is not None:
+        getattr(capture, collection)[microbatch_index] = tensor
+
+
+def _exchange_neighbor(
+    *,
+    rank: int,
+    peer: int,
+    send_tensor: torch.Tensor,
+    recv_tensor: torch.Tensor,
+) -> None:
+    """Pair opposite-direction transfers and wait before either buffer is reused."""
+
+    if rank < peer:
+        operations = [
+            dist.P2POp(dist.isend, send_tensor, peer),
+            dist.P2POp(dist.irecv, recv_tensor, peer),
+        ]
+    else:
+        operations = [
+            dist.P2POp(dist.irecv, recv_tensor, peer),
+            dist.P2POp(dist.isend, send_tensor, peer),
+        ]
+    requests = dist.batch_isend_irecv(operations)
+    for request in requests:
+        request.wait()
+
+
+def run_gpipe_iteration(
+    *,
+    rank: int,
+    world_size: int,
+    num_micro_batches: int,
+    get_rank0_microbatch: MicrobatchGetter,
+    recv_forward_buffers: Sequence[torch.Tensor],
+    recv_backward_buffers: Sequence[torch.Tensor],
+    forward_step: TensorStep,
+    backward_step: BackwardStep,
+    capture: PipelineIterationCapture | None = None,
+) -> None:
+    """Run the existing all-forward/all-backward reference schedule."""
+
+    _validate_schedule_inputs(
+        rank=rank,
+        world_size=world_size,
+        num_micro_batches=num_micro_batches,
+        recv_forward_buffers=recv_forward_buffers,
+        recv_backward_buffers=recv_backward_buffers,
+    )
+    activations: list[tuple[int, torch.Tensor]] = []
+    for microbatch_index in range(num_micro_batches):
+        if rank == 0:
+            microbatch = get_rank0_microbatch(microbatch_index)
+        else:
+            microbatch = recv_forward_buffers[microbatch_index]
+            dist.recv(microbatch, src=rank - 1)
+        _record(capture, "forward_inputs", microbatch_index, microbatch)
+        output = forward_step(microbatch)
+        activations.append((microbatch_index, output))
+        if rank < world_size - 1:
+            dist.send(output, dst=rank + 1)
+
+    while activations:
+        microbatch_index, activation = activations.pop()
+        if rank < world_size - 1:
+            backward_input = recv_backward_buffers[microbatch_index]
+            dist.recv(backward_input, src=rank + 1)
+        else:
+            backward_input = activation
+        _record(capture, "backward_inputs", microbatch_index, backward_input)
+        output = backward_step(activation, backward_input)
+        _record(capture, "backward_outputs", microbatch_index, output)
+        if rank > 0:
+            dist.send(output, dst=rank - 1)
+
+
+def run_1f1b_iteration(
+    *,
+    rank: int,
+    world_size: int,
+    num_micro_batches: int,
+    get_rank0_microbatch: MicrobatchGetter,
+    recv_forward_buffers: Sequence[torch.Tensor],
+    recv_backward_buffers: Sequence[torch.Tensor],
+    forward_step: TensorStep,
+    backward_step: BackwardStep,
+    activation_slots: list[tuple[int, torch.Tensor] | None],
+    capture: PipelineIterationCapture | None = None,
+) -> None:
+    """Run rank-staggered 1F1B with paired bidirectional P2P transitions."""
+
+    _validate_schedule_inputs(
+        rank=rank,
+        world_size=world_size,
+        num_micro_batches=num_micro_batches,
+        recv_forward_buffers=recv_forward_buffers,
+        recv_backward_buffers=recv_backward_buffers,
+    )
+    warmup_steps = min(world_size - rank - 1, num_micro_batches)
+    required_slots = max(warmup_steps, 1)
+    if len(activation_slots) != required_slots:
+        raise ValueError(
+            f"Pipeline activation slot count mismatch: expected {required_slots}, "
+            f"got {len(activation_slots)}"
+        )
+    for index in range(len(activation_slots)):
+        activation_slots[index] = None
+    activation_head = 0
+    activation_count = 0
+
+    def push(microbatch_index: int, tensor: torch.Tensor) -> None:
+        nonlocal activation_count
+        if activation_count >= warmup_steps:
+            raise RuntimeError("Pipeline activation ring overflow")
+        slot = (activation_head + activation_count) % required_slots
+        activation_slots[slot] = (microbatch_index, tensor)
+        activation_count += 1
+
+    def pop() -> tuple[int, torch.Tensor]:
+        nonlocal activation_head, activation_count
+        if activation_count <= 0:
+            raise RuntimeError("Pipeline activation ring underflow")
+        entry = activation_slots[activation_head]
+        if entry is None:
+            raise RuntimeError("Pipeline activation slot is empty")
+        activation_slots[activation_head] = None
+        activation_head = (activation_head + 1) % required_slots
+        activation_count -= 1
+        return entry
+
+    def receive_forward(microbatch_index: int) -> torch.Tensor:
+        if rank == 0:
+            return get_rank0_microbatch(microbatch_index)
+        tensor = recv_forward_buffers[microbatch_index]
+        dist.recv(tensor, src=rank - 1)
+        return tensor
+
+    for microbatch_index in range(warmup_steps):
+        microbatch = receive_forward(microbatch_index)
+        _record(capture, "forward_inputs", microbatch_index, microbatch)
+        output = forward_step(microbatch)
+        push(microbatch_index, output)
+        dist.send(output, dst=rank + 1)
+
+    remaining_steps = num_micro_batches - warmup_steps
+    current_input = receive_forward(warmup_steps) if remaining_steps else None
+    for steady_index in range(remaining_steps):
+        current_microbatch = warmup_steps + steady_index
+        if current_input is None:
+            raise RuntimeError("Pipeline steady state is missing its forward input")
+        _record(capture, "forward_inputs", current_microbatch, current_input)
+        current_output = forward_step(current_input)
+
+        if rank == world_size - 1:
+            backward_microbatch = current_microbatch
+            activation = current_output
+            backward_input = current_output
+        else:
+            backward_microbatch, activation = pop()
+            backward_input = recv_backward_buffers[backward_microbatch]
+            _exchange_neighbor(
+                rank=rank,
+                peer=rank + 1,
+                send_tensor=current_output,
+                recv_tensor=backward_input,
+            )
+        _record(capture, "backward_inputs", backward_microbatch, backward_input)
+        backward_output = backward_step(activation, backward_input)
+        _record(capture, "backward_outputs", backward_microbatch, backward_output)
+        if rank < world_size - 1:
+            push(current_microbatch, current_output)
+
+        has_next_forward = steady_index + 1 < remaining_steps
+        if rank == 0:
+            current_input = (
+                get_rank0_microbatch(current_microbatch + 1)
+                if has_next_forward
+                else None
+            )
+        elif has_next_forward:
+            current_input = recv_forward_buffers[current_microbatch + 1]
+            _exchange_neighbor(
+                rank=rank,
+                peer=rank - 1,
+                send_tensor=backward_output,
+                recv_tensor=current_input,
+            )
+        else:
+            dist.send(backward_output, dst=rank - 1)
+            current_input = None
+
+    while activation_count:
+        microbatch_index, activation = pop()
+        if rank >= world_size - 1:
+            raise RuntimeError("Last pipeline stage retained an unexpected activation")
+        backward_input = recv_backward_buffers[microbatch_index]
+        dist.recv(backward_input, src=rank + 1)
+        _record(capture, "backward_inputs", microbatch_index, backward_input)
+        backward_output = backward_step(activation, backward_input)
+        _record(capture, "backward_outputs", microbatch_index, backward_output)
+        if rank > 0:
+            dist.send(backward_output, dst=rank - 1)
+
+
+def verify_and_concatenate_pipeline_capture(
+    *,
+    rank: int,
+    capture: PipelineIterationCapture,
+    forward_stages: Sequence[Callable[[torch.Tensor], torch.Tensor]],
+    backward_stages: Sequence[Callable[[torch.Tensor], torch.Tensor]],
+    tolerance: tuple[float, float] = PIPELINE_OUTPUT_TOLERANCE,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Check an independent post-timing reference, then form full tensors."""
+
+    if not forward_stages or len(forward_stages) != len(backward_stages):
+        raise ValueError("Pipeline reference requires equal non-empty stage lists")
+    if rank < 0 or rank >= len(forward_stages):
+        raise ValueError("Pipeline reference rank is outside the stage list")
+    for microbatch_index, actual_value in enumerate(capture.backward_outputs):
+        actual = cast(torch.Tensor, actual_value)
+        if rank == 0:
+            reference = cast(torch.Tensor, capture.forward_inputs[microbatch_index])
+            for stage in forward_stages:
+                reference = stage(reference)
+            for stage in reversed(backward_stages):
+                reference = stage(reference)
+        else:
+            reference = backward_stages[rank](
+                cast(torch.Tensor, capture.backward_inputs[microbatch_index])
+            )
+        torch.testing.assert_close(
+            actual,
+            reference,
+            rtol=tolerance[0],
+            atol=tolerance[1],
+        )
+    full_input, _, full_output = capture.concatenate()
+    return full_input, full_output
+
+
+def make_pipeline_child_result_contract(
+    *,
+    batch_size: int,
+    parameter_count: int,
+) -> TorchrunChildResultContract:
+    contract = TorchrunChildResultContract(
+        profile="ch04.pipeline-parallel-toy-v1",
+        input_names=("pipeline_input",),
+        output_names=("pipeline_output",),
+        per_rank_batch_size=batch_size,
+        parameter_count=parameter_count,
+        precision_flags=PrecisionFlags(bf16=True, tf32=False),
+        output_tolerance=PIPELINE_OUTPUT_TOLERANCE,
+        independent_reference="post-timing sequential pipeline replay",
+        collective_type="send_recv",
+        collective_algorithm="ordered-point-to-point-pipeline",
+        max_rank_payload_bytes=_MAX_RAW_RANK_BYTES,
+    )
+    contract.validate()
+    return contract
+
+
+def pipeline_child_result_requested() -> bool:
+    """Return whether the harness requested actual timed-worker tensors."""
+
+    return bool(os.environ.get(RESULT_DIR_ENV))
+
+
+def _tensor_nbytes(tensor: torch.Tensor) -> int:
+    return tensor.numel() * tensor.element_size()
+
+
+def _require_finite_tensor(
+    tensor: Any,
+    *,
+    label: str,
+    shape: tuple[int, ...],
+) -> torch.Tensor:
+    if not isinstance(tensor, torch.Tensor):
+        raise RuntimeError(f"Pipeline {label} is not a tensor")
+    if tensor.shape != shape or tensor.dtype != torch.bfloat16:
+        raise RuntimeError(
+            f"Pipeline {label} shape/dtype mismatch: expected {shape}/torch.bfloat16, "
+            f"got {tuple(tensor.shape)}/{tensor.dtype}"
+        )
+    flat = tensor.reshape(-1)
+    for start in range(0, flat.numel(), _FINITE_CHUNK_ELEMENTS):
+        if not bool(torch.isfinite(flat[start : start + _FINITE_CHUNK_ELEMENTS]).all()):
+            raise RuntimeError(f"Pipeline {label} contains non-finite values")
+    return tensor
+
+
+def _atomic_save_tensor(tensor: torch.Tensor, destination: Path) -> int:
+    raw_bytes = _tensor_nbytes(tensor)
+    cpu_tensor = tensor.detach().to(device="cpu").contiguous()
+    temporary = destination.with_name(f".{destination.name}.{os.getpid()}.tmp")
+    with temporary.open("xb") as handle:
+        torch.save(cpu_tensor, handle)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, destination)
+    return raw_bytes
+
+
+def _atomic_write_json(payload: dict[str, Any], destination: Path) -> None:
+    temporary = destination.with_name(f".{destination.name}.{os.getpid()}.tmp")
+    with temporary.open("x", encoding="utf-8") as handle:
+        json.dump(payload, handle, sort_keys=True, separators=(",", ":"))
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, destination)
+
+
+def write_pipeline_child_result(
+    *,
+    verify_input: torch.Tensor,
+    verify_output: torch.Tensor,
+    completed_iterations: int,
+    time_per_iter_ms: float,
+    reference_verified: bool,
+) -> bool:
+    """Publish each full actual tensor once; metadata is the atomic commit marker."""
+
+    result_dir_value = os.environ.get(RESULT_DIR_ENV)
+    if not result_dir_value:
+        return False
+    required_names = (
+        RUN_ID_ENV,
+        CONTRACT_ENV,
+        WORLD_SIZE_ENV,
+        ITERATIONS_ENV,
+        LAUNCH_WALL_NS_ENV,
+        LAUNCH_MONOTONIC_NS_ENV,
+        PIPELINE_RESULT_SOURCE_ENV,
+        PIPELINE_RESULT_VARIANT_ENV,
+        PIPELINE_RESULT_SCHEDULE_ENV,
+        PIPELINE_RESULT_SHAPE_ENV,
+        PIPELINE_RESULT_LAYERS_ENV,
+    )
+    missing = [name for name in required_names if not os.environ.get(name)]
+    if missing:
+        raise RuntimeError(f"Pipeline child-result environment is incomplete: {missing}")
+    contract = TorchrunChildResultContract.from_dict(
+        json.loads(os.environ[CONTRACT_ENV])
+    )
+    rank = int(os.environ.get("RANK", "-1"))
+    world_size = int(os.environ.get("WORLD_SIZE", "-1"))
+    expected_world_size = int(os.environ[WORLD_SIZE_ENV])
+    requested_iterations = int(os.environ[ITERATIONS_ENV])
+    shape = tuple(int(value) for value in json.loads(os.environ[PIPELINE_RESULT_SHAPE_ENV]))
+    if rank < 0 or rank >= world_size or world_size != expected_world_size:
+        raise RuntimeError("Pipeline child rank topology differs from its contract")
+    if completed_iterations != requested_iterations or completed_iterations <= 0:
+        raise RuntimeError("Pipeline child completed iteration count differs from its contract")
+    if not math.isfinite(time_per_iter_ms) or time_per_iter_ms <= 0:
+        raise RuntimeError("Pipeline child timing must be finite and positive")
+    if reference_verified is not True:
+        raise RuntimeError("Pipeline child result requires its independent post-timing reference")
+    verified_input = _require_finite_tensor(verify_input, label="input", shape=shape)
+    verified_output = _require_finite_tensor(verify_output, label="output", shape=shape)
+    input_bytes = _tensor_nbytes(verified_input)
+    output_bytes = _tensor_nbytes(verified_output)
+    if input_bytes + output_bytes > contract.max_rank_payload_bytes:
+        raise RuntimeError("Pipeline raw rank payload exceeds its declared byte limit")
+
+    result_dir = Path(result_dir_value)
+    if result_dir.is_symlink() or not result_dir.is_dir():
+        raise RuntimeError("Pipeline result directory must be the prepared regular directory")
+    input_path = result_dir / f"rank-{rank}.input.pt"
+    output_path = result_dir / f"rank-{rank}.output.pt"
+    metadata_path = result_dir / f"rank-{rank}.meta.json"
+    if any(path.exists() for path in (input_path, output_path, metadata_path)):
+        raise RuntimeError(f"Refusing to overwrite pipeline child result for rank {rank}")
+    stored_input_bytes = _atomic_save_tensor(verified_input, input_path)
+    stored_output_bytes = _atomic_save_tensor(verified_output, output_path)
+    metadata = {
+        "schema": PIPELINE_RESULT_SCHEMA,
+        "run_id": os.environ[RUN_ID_ENV],
+        "contract": contract.to_dict(),
+        "source": os.environ[PIPELINE_RESULT_SOURCE_ENV],
+        "variant": os.environ[PIPELINE_RESULT_VARIANT_ENV],
+        "schedule": os.environ[PIPELINE_RESULT_SCHEDULE_ENV],
+        "rank": rank,
+        "world_size": world_size,
+        "pid": os.getpid(),
+        "completed_iterations": completed_iterations,
+        "time_per_iter_ms": time_per_iter_ms,
+        "num_layers": int(os.environ[PIPELINE_RESULT_LAYERS_ENV]),
+        "shape": list(shape),
+        "dtype": str(torch.bfloat16),
+        "input_bytes": stored_input_bytes,
+        "output_bytes": stored_output_bytes,
+        "reference_verified": True,
+        "launch_wall_ns": int(os.environ[LAUNCH_WALL_NS_ENV]),
+        "launch_monotonic_ns": int(os.environ[LAUNCH_MONOTONIC_NS_ENV]),
+        "created_wall_ns": time.time_ns(),
+        "created_monotonic_ns": time.monotonic_ns(),
+    }
+    _atomic_write_json(metadata, metadata_path)
+    receipt = {
+        "schema": PIPELINE_RESULT_RECEIPT_SCHEMA,
+        "run_id": metadata["run_id"],
+        "source": metadata["source"],
+        "variant": metadata["variant"],
+        "schedule": metadata["schedule"],
+        "rank": rank,
+        "world_size": world_size,
+        "pid": metadata["pid"],
+        "completed_iterations": completed_iterations,
+        "time_per_iter_ms": time_per_iter_ms,
+    }
+    print(
+        f"{PIPELINE_RESULT_RECEIPT_PREFIX}"
+        f"{json.dumps(receipt, sort_keys=True, separators=(',', ':'))}",
+        flush=True,
+    )
+    return True
+
+
+def _load_tensor_file(path: Path, *, raw_bytes: int) -> torch.Tensor:
+    if path.is_symlink() or not path.is_file():
+        raise RuntimeError(f"Pipeline tensor artifact must be a regular file: {path}")
+    if path.stat().st_size > raw_bytes + _SERIALIZATION_OVERHEAD_BYTES:
+        raise RuntimeError(f"Pipeline tensor artifact exceeds its expected byte bound: {path}")
+    loaded = torch.load(path, map_location="cpu", weights_only=True)
+    if not isinstance(loaded, torch.Tensor):
+        raise RuntimeError(f"Pipeline tensor artifact did not contain one tensor: {path}")
+    return loaded
+
+
+def _parse_pipeline_result_receipts(
+    stdout: str,
+    *,
+    run_id: str,
+    source: str,
+    variant: str,
+    schedule: str,
+    world_size: int,
+    requested_iterations: int,
+) -> dict[int, dict[str, Any]]:
+    if not isinstance(stdout, str):
+        raise TypeError("Pipeline child stdout must be text")
+    expected_fields = {
+        "schema",
+        "run_id",
+        "source",
+        "variant",
+        "schedule",
+        "rank",
+        "world_size",
+        "pid",
+        "completed_iterations",
+        "time_per_iter_ms",
+    }
+    receipts: dict[int, dict[str, Any]] = {}
+    for line_number, line in enumerate(stdout.splitlines(), start=1):
+        if PIPELINE_RESULT_RECEIPT_PREFIX not in line:
+            continue
+        if not line.startswith(PIPELINE_RESULT_RECEIPT_PREFIX):
+            raise RuntimeError(
+                "Pipeline child-result receipt prefix is misplaced on stdout "
+                f"line {line_number}"
+            )
+        try:
+            receipt = json.loads(line[len(PIPELINE_RESULT_RECEIPT_PREFIX) :])
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"Pipeline child-result receipt is malformed on stdout line {line_number}"
+            ) from exc
+        if not isinstance(receipt, dict) or set(receipt) != expected_fields:
+            raise RuntimeError(
+                f"Pipeline child-result receipt fields are invalid on stdout line {line_number}"
+            )
+        rank = receipt["rank"]
+        pid = receipt["pid"]
+        observed_time = receipt["time_per_iter_ms"]
+        if (
+            isinstance(rank, bool)
+            or not isinstance(rank, int)
+            or rank < 0
+            or rank >= world_size
+            or rank in receipts
+        ):
+            raise RuntimeError("Pipeline child-result receipt rank is invalid or duplicated")
+        if isinstance(pid, bool) or not isinstance(pid, int) or pid <= 0:
+            raise RuntimeError(f"Pipeline child-result receipt PID is invalid for rank {rank}")
+        if (
+            isinstance(observed_time, bool)
+            or not isinstance(observed_time, int | float)
+            or not math.isfinite(observed_time)
+            or observed_time <= 0
+        ):
+            raise RuntimeError(f"Pipeline child-result receipt timing is invalid for rank {rank}")
+        if (
+            receipt["schema"] != PIPELINE_RESULT_RECEIPT_SCHEMA
+            or receipt["run_id"] != run_id
+            or receipt["source"] != source
+            or receipt["variant"] != variant
+            or receipt["schedule"] != schedule
+            or receipt["world_size"] != world_size
+            or receipt["completed_iterations"] != requested_iterations
+        ):
+            raise RuntimeError(f"Pipeline child-result receipt identity mismatch for rank {rank}")
+        receipts[rank] = receipt
+    if set(receipts) != set(range(world_size)):
+        raise RuntimeError("Pipeline child-result stdout receipt rank quorum is incomplete")
+
+    rank_zero_timings: list[float] = []
+    timing_prefix = "rank0 time_per_iter_ms:"
+    for line in stdout.splitlines():
+        if not line.strip().startswith(timing_prefix):
+            continue
+        try:
+            rank_zero_timings.append(float(line.strip()[len(timing_prefix) :].strip()))
+        except ValueError as exc:
+            raise RuntimeError("Pipeline rank-zero stdout timing is malformed") from exc
+    if len(rank_zero_timings) != 1:
+        raise RuntimeError("Pipeline child stdout requires exactly one rank-zero timing")
+    if not math.isclose(
+        rank_zero_timings[0],
+        float(receipts[0]["time_per_iter_ms"]),
+        rel_tol=1e-12,
+        abs_tol=5.1e-10,
+    ):
+        raise RuntimeError("Pipeline rank-zero stdout timing differs from its worker receipt")
+    return receipts
+
+
+def validate_pipeline_child_result_bundle(
+    result_dir: Path,
+    *,
+    contract: TorchrunChildResultContract,
+    run_id: str,
+    source: str,
+    variant: str,
+    schedule: str,
+    world_size: int,
+    requested_iterations: int,
+    shape: tuple[int, ...],
+    num_layers: int,
+    launch_wall_ns: int,
+    launch_monotonic_ns: int,
+    finish_wall_ns: int,
+    finish_monotonic_ns: int,
+    stdout: str,
+) -> dict[str, Any]:
+    """Fail closed unless a fresh, exact rank quorum carries the full tensors."""
+
+    contract.validate()
+    receipts_by_rank = _parse_pipeline_result_receipts(
+        stdout,
+        run_id=run_id,
+        source=source,
+        variant=variant,
+        schedule=schedule,
+        world_size=world_size,
+        requested_iterations=requested_iterations,
+    )
+    expected_names = {
+        f"rank-{rank}.{suffix}"
+        for rank in range(world_size)
+        for suffix in ("input.pt", "output.pt", "meta.json")
+    }
+    entries = {path.name for path in result_dir.iterdir()}
+    if entries != expected_names:
+        raise RuntimeError(
+            "Pipeline child-result rank quorum is incomplete or contains unexpected artifacts"
+        )
+    expected_raw_bytes = math.prod(shape) * torch.empty((), dtype=torch.bfloat16).element_size()
+    if expected_raw_bytes * 2 > contract.max_rank_payload_bytes:
+        raise RuntimeError("Pipeline expected raw rank payload exceeds its contract")
+    verify_inputs: dict[str, torch.Tensor] = {}
+    verify_outputs: dict[str, torch.Tensor] = {}
+    metadata_by_rank: dict[int, dict[str, Any]] = {}
+    seen_pids: set[int] = set()
+    for rank in range(world_size):
+        metadata_path = result_dir / f"rank-{rank}.meta.json"
+        if metadata_path.is_symlink() or not metadata_path.is_file():
+            raise RuntimeError(f"Pipeline metadata must be a regular file: {metadata_path}")
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        expected_metadata_fields = {
+            "schema", "run_id", "contract", "source", "variant", "schedule",
+            "rank", "world_size", "pid", "completed_iterations", "time_per_iter_ms",
+            "num_layers", "shape", "dtype", "input_bytes", "output_bytes",
+            "reference_verified", "launch_wall_ns", "launch_monotonic_ns",
+            "created_wall_ns", "created_monotonic_ns",
+        }
+        if not isinstance(metadata, dict) or set(metadata) != expected_metadata_fields:
+            raise RuntimeError(f"Pipeline metadata fields are invalid for rank {rank}")
+        if metadata["schema"] != PIPELINE_RESULT_SCHEMA:
+            raise RuntimeError(f"Pipeline result schema mismatch for rank {rank}")
+        if metadata["run_id"] != run_id:
+            raise RuntimeError(f"Pipeline result run mismatch for rank {rank}")
+        if metadata["source"] != source or metadata["variant"] != variant:
+            raise RuntimeError(f"Pipeline result source/variant mismatch for rank {rank}")
+        if metadata["schedule"] != schedule:
+            raise RuntimeError(f"Pipeline result schedule mismatch for rank {rank}")
+        if TorchrunChildResultContract.from_dict(metadata["contract"]) != contract:
+            raise RuntimeError(f"Pipeline result contract mismatch for rank {rank}")
+        if metadata["rank"] != rank or metadata["world_size"] != world_size:
+            raise RuntimeError(f"Pipeline result rank topology mismatch for rank {rank}")
+        pid = metadata["pid"]
+        if isinstance(pid, bool) or not isinstance(pid, int) or pid <= 0 or pid in seen_pids:
+            raise RuntimeError(f"Pipeline result PID is invalid or duplicated for rank {rank}")
+        seen_pids.add(pid)
+        if metadata["completed_iterations"] != requested_iterations:
+            raise RuntimeError(f"Pipeline result iteration count mismatch for rank {rank}")
+        observed_time = metadata["time_per_iter_ms"]
+        if not isinstance(observed_time, int | float) or not math.isfinite(observed_time) or observed_time <= 0:
+            raise RuntimeError(f"Pipeline result timing is invalid for rank {rank}")
+        receipt = receipts_by_rank[rank]
+        if (
+            receipt["pid"] != pid
+            or receipt["completed_iterations"] != metadata["completed_iterations"]
+            or receipt["time_per_iter_ms"] != observed_time
+        ):
+            raise RuntimeError(
+                f"Pipeline result metadata differs from its worker stdout receipt for rank {rank}"
+            )
+        if metadata["num_layers"] != num_layers:
+            raise RuntimeError(f"Pipeline result layer count mismatch for rank {rank}")
+        if tuple(metadata["shape"]) != shape or metadata["dtype"] != str(torch.bfloat16):
+            raise RuntimeError(f"Pipeline result tensor metadata mismatch for rank {rank}")
+        if metadata["input_bytes"] != expected_raw_bytes or metadata["output_bytes"] != expected_raw_bytes:
+            raise RuntimeError(f"Pipeline result byte count mismatch for rank {rank}")
+        if metadata["reference_verified"] is not True:
+            raise RuntimeError(f"Pipeline independent reference is missing for rank {rank}")
+        if (
+            metadata["launch_wall_ns"] != launch_wall_ns
+            or metadata["launch_monotonic_ns"] != launch_monotonic_ns
+        ):
+            raise RuntimeError(f"Pipeline result launch identity mismatch for rank {rank}")
+        if not launch_wall_ns <= metadata["created_wall_ns"] <= finish_wall_ns:
+            raise RuntimeError(f"Pipeline result wall-clock freshness failed for rank {rank}")
+        if not launch_monotonic_ns <= metadata["created_monotonic_ns"] <= finish_monotonic_ns:
+            raise RuntimeError(f"Pipeline result monotonic freshness failed for rank {rank}")
+
+        input_tensor = _require_finite_tensor(
+            _load_tensor_file(result_dir / f"rank-{rank}.input.pt", raw_bytes=expected_raw_bytes),
+            label=f"rank {rank} input",
+            shape=shape,
+        )
+        output_tensor = _require_finite_tensor(
+            _load_tensor_file(result_dir / f"rank-{rank}.output.pt", raw_bytes=expected_raw_bytes),
+            label=f"rank {rank} output",
+            shape=shape,
+        )
+        verify_inputs[f"rank-{rank}:pipeline_input"] = input_tensor
+        verify_outputs[f"rank-{rank}:pipeline_output"] = output_tensor
+        metadata_by_rank[rank] = metadata
+
+    verify_outputs["completed_iterations"] = torch.ones(
+        requested_iterations, dtype=torch.float32
+    )
+    signature = InputSignature(
+        shapes={name: tuple(tensor.shape) for name, tensor in verify_inputs.items()},
+        dtypes={name: str(tensor.dtype) for name, tensor in verify_inputs.items()},
+        batch_size=contract.per_rank_batch_size,
+        parameter_count=cast(int, contract.parameter_count),
+        precision_flags=PrecisionFlags.from_dict(contract.precision_flags.to_dict()),
+        world_size=world_size,
+        ranks=list(range(world_size)),
+        pipeline_stages=world_size,
+        pipeline_stage_boundaries=[
+            (stage * (num_layers // world_size), (stage + 1) * (num_layers // world_size) - 1)
+            for stage in range(world_size)
+        ],
+        per_rank_batch_size=contract.per_rank_batch_size,
+        collective_type=contract.collective_type,
+        collective_algorithm=contract.collective_algorithm,
+        async_completion_policy="wait_for_async_before_timed_close",
+    )
+    signature_errors = signature.validate(strict=True)
+    if signature_errors:
+        raise RuntimeError(f"Pipeline child-result signature is invalid: {signature_errors[0]}")
+    return {
+        "contract": contract,
+        "verify_inputs": verify_inputs,
+        "verify_output": verify_outputs,
+        "input_signature": signature,
+        "output_tolerance": contract.output_tolerance,
+        "metadata_by_rank": metadata_by_rank,
+        "completed_iterations": requested_iterations,
+    }
+
+
+class PipelineParallelChildResultMixin:
+    """Prepare and consume an exact child-produced pipeline result bundle."""
+
+    _pipeline_result_context: dict[str, Any] | None = None
+    _pipeline_result_bundle: dict[str, Any] | None = None
+
+    def get_profile_torchrun_spec(
+        self,
+        *,
+        profiler: str,
+        config: BenchmarkConfig | None = None,
+        output_path: Path | None = None,
+    ) -> TorchrunLaunchSpec | None:
+        if profiler not in {"ncu", "nsys", "torch"}:
+            return None
+        spec = self.get_torchrun_spec(config)
+        context = self._pipeline_result_context
+        if context is None:
+            raise RuntimeError("Pipeline profiling spec did not prepare a result context")
+        result_dir = cast(Path, context["result_dir"])
+        if any(result_dir.iterdir()):
+            raise RuntimeError(
+                "Refusing to discard populated pipeline child artifacts for profiling"
+            )
+        result_dir.rmdir()
+        self._pipeline_result_context = None
+        self._pipeline_result_bundle = None
+        transport_names = {
+            RESULT_DIR_ENV,
+            RUN_ID_ENV,
+            CONTRACT_ENV,
+            WORLD_SIZE_ENV,
+            ITERATIONS_ENV,
+            PIPELINE_RESULT_SOURCE_ENV,
+            PIPELINE_RESULT_VARIANT_ENV,
+            PIPELINE_RESULT_SCHEDULE_ENV,
+            PIPELINE_RESULT_SHAPE_ENV,
+            PIPELINE_RESULT_LAYERS_ENV,
+        }
+        profile_env = {
+            name: value
+            for name, value in (spec.env or {}).items()
+            if name not in transport_names
+        }
+        if profiler == "torch":
+            if output_path is None:
+                raise ValueError("Torch profiling requires an output path")
+            profile_env["AISP_TORCH_PROFILE_OUTPUT"] = str(output_path)
+        return replace(spec, env=profile_env, result_callback=None)
+
+    def prepare_pipeline_child_result(
+        self,
+        *,
+        source: str,
+        variant: str,
+        schedule: str,
+        world_size: int,
+        iterations: int,
+        batch_size: int,
+        seq_length: int,
+        hidden: int,
+        num_layers: int,
+    ) -> dict[str, str]:
+        if not source or variant not in {"baseline", "optimized"} or not schedule:
+            raise ValueError("Pipeline child-result source, variant and schedule must be explicit")
+        if world_size < 2 or num_layers <= 0 or num_layers % world_size:
+            raise ValueError("Pipeline child-result topology/layer partition is invalid")
+        if iterations <= 0 or min(batch_size, seq_length, hidden) <= 0:
+            raise ValueError("Pipeline child-result workload dimensions must be positive")
+        previous = self._pipeline_result_context
+        if previous is not None and Path(previous["result_dir"]).exists():
+            raise RuntimeError("Refusing to replace an unconsumed pipeline child-result context")
+        parameter_count = 2 * num_layers * hidden * hidden
+        contract = make_pipeline_child_result_contract(
+            batch_size=batch_size,
+            parameter_count=parameter_count,
+        )
+        result_dir = Path(tempfile.mkdtemp(prefix="aisp-pipeline-child-result-"))
+        run_id = uuid.uuid4().hex
+        shape = (batch_size, seq_length, hidden)
+        self._pipeline_result_context = {
+            "result_dir": result_dir,
+            "run_id": run_id,
+            "contract": contract,
+            "source": source,
+            "variant": variant,
+            "schedule": schedule,
+            "world_size": world_size,
+            "requested_iterations": iterations,
+            "shape": shape,
+            "num_layers": num_layers,
+            "retention": "pending-child-result",
+        }
+        self._pipeline_result_bundle = None
+        for attribute in (
+            "_subprocess_verify_inputs",
+            "_subprocess_verify_output",
+            "_subprocess_input_signature",
+            "_subprocess_output_tolerance",
+        ):
+            if hasattr(self, attribute):
+                delattr(self, attribute)
+        return {
+            RESULT_DIR_ENV: str(result_dir),
+            RUN_ID_ENV: run_id,
+            CONTRACT_ENV: json.dumps(contract.to_dict(), sort_keys=True, separators=(",", ":")),
+            WORLD_SIZE_ENV: str(world_size),
+            ITERATIONS_ENV: str(iterations),
+            PIPELINE_RESULT_SOURCE_ENV: source,
+            PIPELINE_RESULT_VARIANT_ENV: variant,
+            PIPELINE_RESULT_SCHEDULE_ENV: schedule,
+            PIPELINE_RESULT_SHAPE_ENV: json.dumps(shape, separators=(",", ":")),
+            PIPELINE_RESULT_LAYERS_ENV: str(num_layers),
+        }
+
+    def consume_pipeline_child_results(
+        self,
+        *,
+        spec: TorchrunLaunchSpec,
+        launch_wall_ns: int,
+        launch_monotonic_ns: int,
+        finish_wall_ns: int,
+        finish_monotonic_ns: int,
+        returncode: int,
+        stdout: str,
+        **_: Any,
+    ) -> None:
+        context = self._pipeline_result_context
+        if context is None:
+            raise RuntimeError("Pipeline child-result callback has no prepared launch context")
+        result_dir = cast(Path, context["result_dir"])
+        if returncode != 0:
+            context["retention"] = "retained-child-failure"
+            raise RuntimeError(
+                f"Pipeline child exited unsuccessfully; artifacts retained at {result_dir}"
+            )
+        try:
+            bundle = validate_pipeline_child_result_bundle(
+                result_dir,
+                contract=context["contract"],
+                run_id=context["run_id"],
+                source=context["source"],
+                variant=context["variant"],
+                schedule=context["schedule"],
+                world_size=context["world_size"],
+                requested_iterations=context["requested_iterations"],
+                shape=context["shape"],
+                num_layers=context["num_layers"],
+                launch_wall_ns=int(launch_wall_ns),
+                launch_monotonic_ns=int(launch_monotonic_ns),
+                finish_wall_ns=int(finish_wall_ns),
+                finish_monotonic_ns=int(finish_monotonic_ns),
+                stdout=stdout,
+            )
+        except Exception as exc:
+            context["retention"] = "retained-validation-failure"
+            raise RuntimeError(
+                f"{exc}; failed pipeline child artifacts retained at {result_dir}"
+            ) from exc
+        self._pipeline_result_bundle = bundle
+        self._subprocess_verify_inputs = bundle["verify_inputs"]
+        self._subprocess_verify_output = bundle["verify_output"]
+        self._subprocess_input_signature = bundle["input_signature"]
+        self._subprocess_output_tolerance = bundle["output_tolerance"]
+        spec.timing_iterations_per_sample = bundle["completed_iterations"]
+        try:
+            shutil.rmtree(result_dir)
+        except OSError:
+            context["retention"] = "retained-cleanup-failure"
+        else:
+            context["retention"] = "cleaned-after-success"
+
+    def require_pipeline_child_result(self) -> None:
+        if self._pipeline_result_bundle is None:
+            context = self._pipeline_result_context
+            retained = context["result_dir"] if context else "unavailable"
+            raise RuntimeError(
+                "Pipeline verification requires a fresh full-rank timed-worker result; "
+                f"retained path: {retained}"
+            )
+
+    def get_verify_inputs(self) -> dict[str, torch.Tensor]:
+        self.require_pipeline_child_result()
+        return dict(self._subprocess_verify_inputs)
+
+    def get_verify_output(self) -> dict[str, torch.Tensor]:
+        self.require_pipeline_child_result()
+        return dict(self._subprocess_verify_output)
+
+    def get_input_signature(self) -> InputSignature:
+        self.require_pipeline_child_result()
+        return self._subprocess_input_signature
+
+    def get_output_tolerance(self) -> tuple[float, float]:
+        self.require_pipeline_child_result()
+        return self._subprocess_output_tolerance
+
+    def validate_result(self) -> str | None:
+        if self._pipeline_result_bundle is None:
+            return "Fresh full-rank timed pipeline worker output is missing"
+        return None
+
+    def retain_failed_pipeline_child_result(self) -> None:
+        context = self._pipeline_result_context
+        if (
+            self._pipeline_result_bundle is None
+            and context is not None
+            and Path(context["result_dir"]).exists()
+        ):
+            print(
+                f"[pipeline-child-result] retained unsuccessful artifacts at "
+                f"{context['result_dir']}",
+                flush=True,
+            )
+
+
+__all__ = [
+    "PIPELINE_OUTPUT_TOLERANCE",
+    "PIPELINE_RESULT_CALLBACK",
+    "PipelineIterationCapture",
+    "PipelineParallelChildResultMixin",
+    "make_pipeline_child_result_contract",
+    "pipeline_child_result_requested",
+    "run_1f1b_iteration",
+    "run_gpipe_iteration",
+    "validate_pipeline_child_result_bundle",
+    "verify_and_concatenate_pipeline_capture",
+    "write_pipeline_child_result",
+]

--- a/code/ch13/README.md
+++ b/code/ch13/README.md
@@ -29,6 +29,16 @@ This chapter is one of the easiest places to fool yourself with framework overhe
 
 The prior `precisionfp8_te` number compared eager FP16 with CUDA-graph-replayed FP8, so it is retired. The pair now runs both sides eagerly to isolate Transformer Engine FP8; publish a new speed result only after a fresh B200 correctness and timing run.
 
+The TE 2.18 pair now verifies its captured prediction and every post-step parameter with a calibrated per-output policy. Previously, all outputs inherited the global `(rtol=0.5, atol=5.0)` threshold. B200 calibration of the unchanged batch-256, hidden-4096 training step selected these stricter budgets across seed 44 and fixed holdouts 45, 1044, and 1045:
+
+| Captured outputs | Calibrated `(rtol, atol)` | Largest observed absolute error |
+| --- | --- | --- |
+| Prediction | `(0.4, 1.0)` | `0.5949707` |
+| Both weight tensors | `(0.001, 0.00075)` | `0.000534058` |
+| Both bias tensors | `(0.001, 0.00005)` | `0.000041008` |
+
+The frozen map passed all holdouts and independently rejected zeroed and localized corrupted copies of all five outputs. These bounds apply to this TE 2.18 workload and establish numerical verification only; they do not establish a speedup.
+
 ## Profiler Evidence
 Use deep-dive runs when you want to see whether the gain came from framework overhead reduction, memory behavior, or the lower-precision path itself:
 

--- a/code/ch13/baseline_precisionfp8_te.py
+++ b/code/ch13/baseline_precisionfp8_te.py
@@ -80,12 +80,14 @@ class BaselineTEFP8Benchmark(VerificationPayloadMixin, BaseBenchmark):
         self.output: Optional[torch.Tensor] = None
         self.output_buffer: Optional[torch.Tensor] = None
         self._verify_output_buffer: Optional[torch.Tensor] = None
+        self._verify_output: Optional[dict[str, torch.Tensor]] = None
         self.parameter_count = 0
         self.register_workload_metadata(
             requests_per_iteration=1.0,
             tokens_per_iteration=float(tokens),
         )
         self._verify_input: Optional[torch.Tensor] = None
+        self._verify_target: Optional[torch.Tensor] = None
 
     def setup(self) -> None:
         _load_te_linear()
@@ -103,7 +105,11 @@ class BaselineTEFP8Benchmark(VerificationPayloadMixin, BaseBenchmark):
         self.criterion = nn.MSELoss()
         self.output_buffer = torch.empty_like(self.inputs)
         self._verify_output_buffer = torch.empty_like(self.output_buffer)
-        self._verify_input = self.inputs.detach().clone()
+        # Keep live references so verification jitter reaches the tensors used
+        # by the training step. Teardown retains CPU snapshots for comparison.
+        self._verify_input = self.inputs
+        self._verify_target = self.targets
+        self._verify_output = None
 
         for _ in range(5):
             self._train_step(capture_output=False)
@@ -135,11 +141,27 @@ class BaselineTEFP8Benchmark(VerificationPayloadMixin, BaseBenchmark):
             raise RuntimeError("Verification input/output not initialized")
 
     def capture_verification_payload(self) -> None:
-        if self._verify_input is None or self.output is None or self._verify_output_buffer is None:
+        if (
+            self._verify_input is None
+            or self._verify_target is None
+            or self.output is None
+            or self._verify_output_buffer is None
+            or self.model is None
+        ):
             raise RuntimeError("benchmark_fn() must run before capture_verification_payload()")
-        self._verify_output_buffer.copy_(self.output)
+        with torch.inference_mode():
+            self._verify_output_buffer.copy_(self.output)
+            self._verify_output = {
+                "prediction": self._verify_output_buffer.detach().to(device="cpu", copy=True)
+            }
+            self._verify_output.update(
+                {
+                    f"parameter.{name}": parameter.detach().to(device="cpu", copy=True)
+                    for name, parameter in self.model.named_parameters()
+                }
+            )
         self._set_verification_payload(
-            inputs={"input": self._verify_input},
+            inputs={"input": self._verify_input, "target": self._verify_target},
             output=self._verify_output_buffer,
             batch_size=self._verify_input.shape[0],
             parameter_count=self.parameter_count,
@@ -149,10 +171,30 @@ class BaselineTEFP8Benchmark(VerificationPayloadMixin, BaseBenchmark):
                 "fp8": False,
                 "tf32": torch.backends.cuda.matmul.allow_tf32,
             },
+            # Keep the historical threshold until repeated B200 full-output
+            # receipts can calibrate prediction and parameter error bounds.
             output_tolerance=(0.5, 5.0),
         )
 
+    def get_verify_inputs(self) -> dict[str, torch.Tensor]:
+        if self._verify_input is not None and self._verify_target is not None:
+            return {"input": self._verify_input, "target": self._verify_target}
+        return super().get_verify_inputs()
+
+    def get_verify_output(self) -> dict[str, torch.Tensor]:
+        if self._verify_output is None:
+            raise RuntimeError("capture_verification_payload() must run before get_verify_output()")
+        return {name: tensor.detach().clone() for name, tensor in self._verify_output.items()}
+
     def teardown(self) -> None:
+        payload = getattr(self, "_verification_payload", None)
+        if payload is not None:
+            payload.inputs = {
+                name: tensor.detach().to(device="cpu", copy=True)
+                for name, tensor in payload.inputs.items()
+            }
+            if self._verify_output is not None:
+                payload.output = self._verify_output["prediction"]
         self.model = None
         self.inputs = None
         self.targets = None
@@ -162,6 +204,7 @@ class BaselineTEFP8Benchmark(VerificationPayloadMixin, BaseBenchmark):
         self.output_buffer = None
         self._verify_output_buffer = None
         self._verify_input = None
+        self._verify_target = None
         super().teardown()
 
     def get_config(self) -> BenchmarkConfig:
@@ -169,12 +212,12 @@ class BaselineTEFP8Benchmark(VerificationPayloadMixin, BaseBenchmark):
         return BenchmarkConfig(adaptive_iterations=False, iterations=50, warmup=10, backend_policy="fp32_strict")
 
     def get_custom_metrics(self) -> Optional[dict]:
-        """Return truthful precision metrics for the current FP32 TE run."""
+        """Return truthful precision metrics for the current FP16 TE run."""
         from core.benchmark.metrics import compute_precision_metrics
         return compute_precision_metrics(
-            fp32_time_ms=getattr(self, "_last_elapsed_ms", None),
-            reduced_precision_time_ms=None,
-            precision_type="fp8",
+            fp32_time_ms=None,
+            reduced_precision_time_ms=getattr(self, "_last_elapsed_ms", None),
+            precision_type="fp16",
         )
 
     def validate_result(self) -> Optional[str]:

--- a/code/ch13/baseline_precisionfp8_te.py
+++ b/code/ch13/baseline_precisionfp8_te.py
@@ -12,7 +12,10 @@ from typing import Any, Optional
 import torch
 import torch.nn as nn
 
-from ch13.te_runtime_common import ensure_te_runtime_initialized
+from ch13.te_runtime_common import (
+    ensure_te_runtime_initialized,
+    get_te_precision_output_tolerances,
+)
 from core.benchmark.verification_mixin import VerificationPayloadMixin
 from core.harness.benchmark_harness import (
     BaseBenchmark,
@@ -171,9 +174,8 @@ class BaselineTEFP8Benchmark(VerificationPayloadMixin, BaseBenchmark):
                 "fp8": False,
                 "tf32": torch.backends.cuda.matmul.allow_tf32,
             },
-            # Keep the historical threshold until repeated B200 full-output
-            # receipts can calibrate prediction and parameter error bounds.
-            output_tolerance=(0.5, 5.0),
+            output_tolerance=(0.4, 1.0),
+            output_tolerances=self.get_output_tolerances(),
         )
 
     def get_verify_inputs(self) -> dict[str, torch.Tensor]:
@@ -185,6 +187,9 @@ class BaselineTEFP8Benchmark(VerificationPayloadMixin, BaseBenchmark):
         if self._verify_output is None:
             raise RuntimeError("capture_verification_payload() must run before get_verify_output()")
         return {name: tensor.detach().clone() for name, tensor in self._verify_output.items()}
+
+    def get_output_tolerances(self) -> dict[str, tuple[float, float]]:
+        return get_te_precision_output_tolerances()
 
     def teardown(self) -> None:
         payload = getattr(self, "_verification_payload", None)

--- a/code/ch13/optimized_precisionfp8_te.py
+++ b/code/ch13/optimized_precisionfp8_te.py
@@ -8,7 +8,10 @@ import torch
 import torch.nn as nn
 from torch.optim import Optimizer
 
-from ch13.te_runtime_common import ensure_te_runtime_initialized
+from ch13.te_runtime_common import (
+    ensure_te_runtime_initialized,
+    get_te_precision_output_tolerances,
+)
 from core.benchmark.verification_mixin import VerificationPayloadMixin
 from core.harness.benchmark_harness import (
     BaseBenchmark,
@@ -213,9 +216,8 @@ class OptimizedTEFP8Benchmark(VerificationPayloadMixin, BaseBenchmark):
                 "fp8": True,
                 "tf32": torch.backends.cuda.matmul.allow_tf32,
             },
-            # Keep the historical threshold until repeated B200 full-output
-            # receipts can calibrate prediction and parameter error bounds.
-            output_tolerance=(0.5, 5.0),
+            output_tolerance=(0.4, 1.0),
+            output_tolerances=self.get_output_tolerances(),
         )
 
     def get_verify_inputs(self) -> dict[str, torch.Tensor]:
@@ -227,6 +229,9 @@ class OptimizedTEFP8Benchmark(VerificationPayloadMixin, BaseBenchmark):
         if self._verify_output is None:
             raise RuntimeError("capture_verification_payload() must run before get_verify_output()")
         return {name: tensor.detach().clone() for name, tensor in self._verify_output.items()}
+
+    def get_output_tolerances(self) -> dict[str, tuple[float, float]]:
+        return get_te_precision_output_tolerances()
 
     def teardown(self) -> None:
         payload = getattr(self, "_verification_payload", None)

--- a/code/ch13/optimized_precisionfp8_te.py
+++ b/code/ch13/optimized_precisionfp8_te.py
@@ -87,6 +87,7 @@ class OptimizedTEFP8Benchmark(VerificationPayloadMixin, BaseBenchmark):
         self.target_pool: List[torch.Tensor] = []
         self.output_buffer: Optional[torch.Tensor] = None
         self._verify_output_buffer: Optional[torch.Tensor] = None
+        self._verify_output: Optional[dict[str, torch.Tensor]] = None
         tokens = self.batch_size * self.hidden_dim
         self._workload = WorkloadMetadata(
             requests_per_iteration=1.0,
@@ -94,6 +95,7 @@ class OptimizedTEFP8Benchmark(VerificationPayloadMixin, BaseBenchmark):
         )
         self.output = None
         self._verify_input: Optional[torch.Tensor] = None
+        self._verify_target: Optional[torch.Tensor] = None
         self.parameter_count: int = 0
         self.register_workload_metadata(
             requests_per_iteration=1.0,
@@ -131,7 +133,11 @@ class OptimizedTEFP8Benchmark(VerificationPayloadMixin, BaseBenchmark):
         # benchmark pair instead of being folded into this precision comparison.
         self.output_buffer = torch.empty_like(self.input_pool[0])
         self._verify_output_buffer = torch.empty_like(self.output_buffer)
-        self._verify_input = self.input_pool[0].detach().clone()
+        # Keep live references so verification jitter reaches the tensors used
+        # by the training step. Teardown retains CPU snapshots for comparison.
+        self._verify_input = self.input_pool[0]
+        self._verify_target = self.target_pool[0]
+        self._verify_output = None
         self.register_workload_metadata(
             requests_per_iteration=self._workload.requests_per_iteration,
             tokens_per_iteration=self._workload.tokens_per_iteration,
@@ -177,11 +183,27 @@ class OptimizedTEFP8Benchmark(VerificationPayloadMixin, BaseBenchmark):
             raise RuntimeError("Verification input/output not initialized")
 
     def capture_verification_payload(self) -> None:
-        if self.output is None or self._verify_output_buffer is None:
+        if (
+            self._verify_input is None
+            or self._verify_target is None
+            or self.output is None
+            or self._verify_output_buffer is None
+            or self.model is None
+        ):
             raise RuntimeError("benchmark_fn() must run before capture_verification_payload()")
-        self._verify_output_buffer.copy_(self.output)
+        with torch.inference_mode():
+            self._verify_output_buffer.copy_(self.output)
+            self._verify_output = {
+                "prediction": self._verify_output_buffer.detach().to(device="cpu", copy=True)
+            }
+            self._verify_output.update(
+                {
+                    f"parameter.{name}": parameter.detach().to(device="cpu", copy=True)
+                    for name, parameter in self.model.named_parameters()
+                }
+            )
         self._set_verification_payload(
-            inputs={"input": self._verify_input},
+            inputs={"input": self._verify_input, "target": self._verify_target},
             output=self._verify_output_buffer,
             batch_size=self._verify_input.shape[0],
             parameter_count=self.parameter_count,
@@ -191,16 +213,38 @@ class OptimizedTEFP8Benchmark(VerificationPayloadMixin, BaseBenchmark):
                 "fp8": True,
                 "tf32": torch.backends.cuda.matmul.allow_tf32,
             },
+            # Keep the historical threshold until repeated B200 full-output
+            # receipts can calibrate prediction and parameter error bounds.
             output_tolerance=(0.5, 5.0),
         )
 
+    def get_verify_inputs(self) -> dict[str, torch.Tensor]:
+        if self._verify_input is not None and self._verify_target is not None:
+            return {"input": self._verify_input, "target": self._verify_target}
+        return super().get_verify_inputs()
+
+    def get_verify_output(self) -> dict[str, torch.Tensor]:
+        if self._verify_output is None:
+            raise RuntimeError("capture_verification_payload() must run before get_verify_output()")
+        return {name: tensor.detach().clone() for name, tensor in self._verify_output.items()}
+
     def teardown(self) -> None:
+        payload = getattr(self, "_verification_payload", None)
+        if payload is not None:
+            payload.inputs = {
+                name: tensor.detach().to(device="cpu", copy=True)
+                for name, tensor in payload.inputs.items()
+            }
+            if self._verify_output is not None:
+                payload.output = self._verify_output["prediction"]
         self.model = None
         self.optimizer = None
         self.criterion = None
         self.output_buffer = None
         self.output = None
         self._verify_output_buffer = None
+        self._verify_input = None
+        self._verify_target = None
         self.input_pool = []
         self.target_pool = []
         super().teardown()

--- a/code/ch13/te_runtime_common.py
+++ b/code/ch13/te_runtime_common.py
@@ -17,6 +17,19 @@ _TORCH_CUDA_LIBS = (
     "libc10_cuda.so",
 )
 
+_TE_PRECISION_OUTPUT_TOLERANCES: dict[str, tuple[float, float]] = {
+    "prediction": (0.4, 1.0),
+    "parameter.fc1.weight": (0.001, 0.00075),
+    "parameter.fc1.bias": (0.001, 0.00005),
+    "parameter.fc2.weight": (0.001, 0.00075),
+    "parameter.fc2.bias": (0.001, 0.00005),
+}
+
+
+def get_te_precision_output_tolerances() -> dict[str, tuple[float, float]]:
+    """Return the calibrated full-output policy for the TE2.18 precision pair."""
+    return dict(_TE_PRECISION_OUTPUT_TOLERANCES)
+
 
 @lru_cache(maxsize=1)
 def ensure_te_runtime_initialized() -> None:

--- a/code/core/benchmark/models.py
+++ b/code/core/benchmark/models.py
@@ -371,6 +371,9 @@ class BenchmarkResult(BaseModel):
     mode: Optional[str] = Field(None, description="Benchmark mode (e.g., 'triton', 'pytorch', 'custom')")
     launch_via: Optional[str] = Field(None, description="Launcher used for execution (python or torchrun)")
     world_size: Optional[int] = Field(None, description="World size used when launching distributed benchmarks")
+    local_world_size: Optional[int] = Field(
+        None, strict=True, gt=0, description="Local worker count passed to the execution launcher"
+    )
     multi_gpu: Optional[bool] = Field(None, description="Whether multiple GPUs were used")
     multi_gpu_required: Optional[bool] = Field(None, description="Benchmark declared multi-GPU requirement")
     seeds: Optional[Dict[str, Any]] = Field(None, description="Seeds applied for reproducibility (random, numpy, torch, cuda)")

--- a/code/core/benchmark/models.py
+++ b/code/core/benchmark/models.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, ConfigDict, field_validator
 from core.benchmark.evaluation_provenance import EvaluationProvenance
-from core.benchmark.run_manifest import RunManifest
+from core.benchmark.run_manifest import RunManifest, RuntimeProvenance
 
 
 class MemoryStats(BaseModel):
@@ -382,6 +382,18 @@ class BenchmarkResult(BaseModel):
     runtime_env: Dict[str, str] = Field(
         default_factory=dict,
         description="Runtime environment overrides applied during benchmark execution",
+    )
+    runtime_provenance: Optional[RuntimeProvenance] = Field(
+        None,
+        description="Runtime/library identity captured in the process executing the benchmark",
+    )
+    runtime_provenance_by_local_rank: Dict[int, RuntimeProvenance] = Field(
+        default_factory=dict,
+        description="Validated runtime snapshots for every local torchrun worker",
+    )
+    execution_process_ids: Dict[int, int] = Field(
+        default_factory=dict,
+        description="Worker PIDs independently retained by the execution transport, keyed by local rank",
     )
     gpu_metrics: Optional[Dict[str, Optional[float | str]]] = Field(
         None,

--- a/code/core/benchmark/run_manifest.py
+++ b/code/core/benchmark/run_manifest.py
@@ -9,10 +9,13 @@ import os
 import subprocess
 import sys
 from datetime import datetime, timezone
+from importlib import metadata as importlib_metadata
 from pathlib import Path
-from typing import Any, Dict, Optional, TypedDict
+from typing import Any, Dict, Literal, Optional, TypedDict
 
 import torch
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
+
 from core.benchmark.evaluation_provenance import (
     EvaluationContract,
     EvaluationFailure,
@@ -37,10 +40,60 @@ try:
 except ImportError:
     TRITON_VERSION = None
 
-from pydantic import BaseModel, Field, ConfigDict, field_serializer
-
 PROJECT_ROOT = Path(__file__).parents[2]
 SCHEMA_VERSION = "1.0"
+
+# Keep this inventory limited to libraries that can materially change numerical
+# behavior, generated kernels, or benchmark execution. Distribution names are
+# normalized with the same ``[-_.]`` equivalence used by Python packaging.
+_RELEVANT_LIBRARY_NAMES = frozenset(
+    {
+        "bitsandbytes",
+        "deepspeed",
+        "jax",
+        "jaxlib",
+        "numpy",
+        "onnxruntime",
+        "scipy",
+        "sglang",
+        "tensorrt",
+        "transformers",
+        "vllm",
+        "xformers",
+    }
+)
+_RELEVANT_LIBRARY_PREFIXES = (
+    "cupy-",
+    "flash-attn",
+    "flashinfer-",
+    "nvidia-",
+    "pytorch-triton",
+    "torch",
+    "transformer-engine",
+    "triton",
+)
+
+RuntimeParityTarget = Literal["cpu", "cuda"]
+CPU_RUNTIME_PARITY_FIELDS = (
+    "torch_version",
+    "python_version",
+    "os",
+    "library_versions",
+)
+CUDA_RUNTIME_PARITY_FIELDS = (
+    "cuda_available",
+    "driver_version",
+    "torch_version",
+    "cuda_version",
+    "cudnn_version",
+    "python_version",
+    "os",
+    "library_versions",
+)
+RUNTIME_PARITY_FIELDS_BY_TARGET: Dict[RuntimeParityTarget, tuple[str, ...]] = {
+    "cpu": CPU_RUNTIME_PARITY_FIELDS,
+    "cuda": CUDA_RUNTIME_PARITY_FIELDS,
+}
 
 
 class GitStatusDict(TypedDict):
@@ -404,6 +457,289 @@ class SoftwareInfo(BaseModel):
     schemaVersion: str = Field(SCHEMA_VERSION, description="Schema version for forward compatibility")
 
 
+class RuntimeProvenance(BaseModel):
+    """Runtime versions captured inside the process that executes a benchmark."""
+
+    cuda_available: bool = Field(
+        ...,
+        description="Whether CUDA was available in the executing process",
+    )
+    driver_version: Optional[str] = Field(
+        None,
+        description="NVIDIA driver version visible to the process",
+    )
+    torch_version: str = Field(..., description="Imported PyTorch runtime version")
+    cuda_version: Optional[str] = Field(
+        None,
+        description="CUDA version reported by the imported PyTorch runtime",
+    )
+    cudnn_version: Optional[str] = Field(
+        None,
+        description="cuDNN version reported by the imported PyTorch runtime",
+    )
+    python_version: str = Field(..., description="Executing Python version")
+    os: str = Field(..., description="Executing operating-system identifier")
+    python_executable: str = Field(
+        ...,
+        description="Python executable used by the benchmark process",
+    )
+    process_id: int = Field(..., description="Process that captured this runtime provenance")
+    captured_at: str = Field(..., description="UTC timestamp when runtime provenance was captured")
+    library_versions: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Normalized versions of installed performance-relevant Python distributions",
+    )
+    library_versions_complete: bool = Field(
+        False,
+        description="Whether relevant installed-library enumeration completed without ambiguity",
+    )
+    shadowed_library_versions: Dict[str, list[str]] = Field(
+        default_factory=dict,
+        description="Relevant distribution versions hidden by earlier sys.path entries",
+    )
+    collection_warnings: list[str] = Field(
+        default_factory=list,
+        description="Runtime provenance fields that could not be captured reliably",
+    )
+
+    schemaVersion: str = Field(
+        SCHEMA_VERSION,
+        description="Schema version for forward compatibility",
+    )
+
+
+RuntimeFieldParityStatus = Literal["match", "mismatch", "unknown"]
+
+
+class RuntimeProvenanceFieldParity(BaseModel):
+    """One required field in a cross-run runtime provenance comparison."""
+
+    status: RuntimeFieldParityStatus
+    reference: Any = None
+    candidate: Any = None
+    detail: Optional[str] = None
+
+    schemaVersion: str = Field(
+        SCHEMA_VERSION,
+        description="Schema version for forward compatibility",
+    )
+
+
+class RuntimeProvenanceParity(BaseModel):
+    """Fail-closed runtime parity verdict for two benchmark run manifests."""
+
+    target: RuntimeParityTarget
+    matches: bool
+    required_fields: list[str]
+    fields: Dict[str, RuntimeProvenanceFieldParity]
+    mismatched_fields: list[str] = Field(default_factory=list)
+    unknown_fields: list[str] = Field(default_factory=list)
+
+    schemaVersion: str = Field(
+        SCHEMA_VERSION,
+        description="Schema version for forward compatibility",
+    )
+
+
+class RuntimeProvenanceParityError(RuntimeError):
+    """Raised when required cross-run runtime provenance does not match."""
+
+    def __init__(self, comparison: RuntimeProvenanceParity) -> None:
+        self.comparison = comparison
+        details: list[str] = []
+        if comparison.mismatched_fields:
+            details.append(f"mismatched={','.join(comparison.mismatched_fields)}")
+        if comparison.unknown_fields:
+            details.append(f"unknown={','.join(comparison.unknown_fields)}")
+        suffix = "; ".join(details) or "required runtime provenance did not match"
+        super().__init__(
+            f"RUNTIME PROVENANCE PARITY FAILED for target={comparison.target}: {suffix}"
+        )
+
+
+def _normalize_distribution_name(name: str) -> str:
+    normalized = name.strip().casefold().replace("_", "-").replace(".", "-")
+    while "--" in normalized:
+        normalized = normalized.replace("--", "-")
+    return normalized
+
+
+def _is_relevant_library(name: str) -> bool:
+    return name in _RELEVANT_LIBRARY_NAMES or name.startswith(_RELEVANT_LIBRARY_PREFIXES)
+
+
+def _distribution_sys_path_index(distribution: Any) -> Optional[int]:
+    """Return the sys.path precedence index for a distribution's metadata root."""
+
+    distribution_root = Path(distribution.locate_file("")).resolve()
+    for index, entry in enumerate(sys.path):
+        search_root = Path(entry or os.getcwd()).resolve()
+        if distribution_root == search_root:
+            return index
+    return None
+
+
+def _collect_relevant_library_versions(
+    collection_warnings: list[str],
+) -> tuple[Dict[str, str], Dict[str, list[str]], bool]:
+    """Capture relevant distribution versions without treating partial data as complete."""
+
+    try:
+        distributions = list(importlib_metadata.distributions())
+    except Exception as exc:
+        _append_collection_warning(
+            collection_warnings,
+            f"Failed to enumerate installed runtime libraries: {exc}",
+        )
+        return {}, {}, False
+
+    observed: Dict[str, list[tuple[Optional[int], str]]] = {}
+    complete = True
+    for distribution in distributions:
+        try:
+            raw_name = distribution.metadata.get("Name")
+        except Exception as exc:
+            _append_collection_warning(
+                collection_warnings,
+                f"Failed to read installed distribution metadata: {exc}",
+            )
+            complete = False
+            continue
+        if not raw_name:
+            _append_collection_warning(
+                collection_warnings,
+                "Installed distribution metadata omitted its Name field; "
+                "library provenance is incomplete.",
+            )
+            complete = False
+            continue
+
+        name = _normalize_distribution_name(str(raw_name))
+        if not _is_relevant_library(name):
+            continue
+        try:
+            version = str(distribution.version).strip()
+        except Exception as exc:
+            _append_collection_warning(
+                collection_warnings,
+                f"Failed to read installed runtime library version for {name}: {exc}",
+            )
+            complete = False
+            continue
+        if not version:
+            _append_collection_warning(
+                collection_warnings,
+                f"Installed runtime library {name} has no version; "
+                "library provenance is incomplete.",
+            )
+            complete = False
+            continue
+        try:
+            path_index = _distribution_sys_path_index(distribution)
+        except Exception as exc:
+            _append_collection_warning(
+                collection_warnings,
+                f"Failed to determine sys.path precedence for runtime library {name}: {exc}",
+            )
+            complete = False
+            path_index = None
+        observed.setdefault(name, []).append((path_index, version))
+
+    versions: Dict[str, str] = {}
+    shadowed_versions: Dict[str, list[str]] = {}
+    for name, records in sorted(observed.items()):
+        known_indices = [path_index for path_index, _ in records if path_index is not None]
+        active_index = min(known_indices) if known_indices else None
+        active_records = [
+            version
+            for path_index, version in records
+            if path_index == active_index
+        ]
+        active_versions = sorted(set(active_records))
+        if len(active_versions) > 1:
+            joined_versions = ", ".join(active_versions)
+            _append_collection_warning(
+                collection_warnings,
+                f"Runtime library {name} has conflicting active distribution versions at the "
+                f"same sys.path precedence ({joined_versions}); library provenance is ambiguous.",
+            )
+            complete = False
+        versions[name] = " | ".join(active_versions)
+
+        shadows = sorted(
+            {
+                version
+                for path_index, version in records
+                if path_index != active_index
+            }
+        )
+        if shadows:
+            shadowed_versions[name] = shadows
+
+    return versions, shadowed_versions, complete
+
+
+def capture_runtime_provenance() -> RuntimeProvenance:
+    """Capture provenance in the current benchmark-executing process."""
+
+    collection_warnings: list[str] = []
+    cuda_available = bool(torch.cuda.is_available())
+    cuda_info = get_cuda_info()
+
+    cudnn_version: Optional[str] = None
+    try:
+        cudnn_backend = getattr(torch.backends, "cudnn", None)
+        raw_cudnn_version = cudnn_backend.version() if cudnn_backend is not None else None
+        if raw_cudnn_version is not None:
+            cudnn_version = str(raw_cudnn_version)
+    except Exception as exc:
+        _append_collection_warning(
+            collection_warnings,
+            f"Failed to capture cuDNN runtime version: {exc}",
+        )
+
+    (
+        library_versions,
+        shadowed_library_versions,
+        library_versions_complete,
+    ) = _collect_relevant_library_versions(collection_warnings)
+
+    if cuda_available:
+        missing_cuda_fields = [
+            field_name
+            for field_name, value in (
+                ("driver_version", cuda_info.get("driver_version")),
+                ("cuda_version", cuda_info.get("version")),
+                ("cudnn_version", cudnn_version),
+            )
+            if not value
+        ]
+        if missing_cuda_fields:
+            _append_collection_warning(
+                collection_warnings,
+                "CUDA runtime provenance unavailable for fields: "
+                f"{', '.join(missing_cuda_fields)}; CUDA cross-run parity is incomplete.",
+            )
+
+    return RuntimeProvenance(
+        cuda_available=cuda_available,
+        driver_version=cuda_info.get("driver_version"),
+        torch_version=str(torch.__version__),
+        cuda_version=cuda_info.get("version"),
+        cudnn_version=cudnn_version,
+        python_version=sys.version.split()[0],
+        os=sys.platform,
+        python_executable=sys.executable,
+        process_id=os.getpid(),
+        captured_at=datetime.now(timezone.utc).isoformat(),
+        library_versions=library_versions,
+        library_versions_complete=library_versions_complete,
+        shadowed_library_versions=shadowed_library_versions,
+        collection_warnings=collection_warnings,
+        schemaVersion=SCHEMA_VERSION,
+    )
+
+
 class EnvironmentInfo(BaseModel):
     """Environment variable information."""
     
@@ -558,6 +894,14 @@ class RunManifest(BaseModel):
     
     # Software information
     software: SoftwareInfo = Field(..., description="Software versions")
+
+    # Runtime parity authority. In subprocess mode this must be supplied by the
+    # process that executed the benchmark; coordinator hardware/software fields
+    # are informational and are never used by the parity comparator.
+    runtime_provenance: Optional[RuntimeProvenance] = Field(
+        None,
+        description="Runtime and installed-library provenance from the benchmark-executing process",
+    )
     
     # Environment information
     environment: EnvironmentInfo = Field(..., description="Environment variables")
@@ -600,12 +944,20 @@ class RunManifest(BaseModel):
     schemaVersion: str = Field(SCHEMA_VERSION, description="Schema version for forward compatibility")
     
     @classmethod
-    def create(cls, config: Optional[Dict] = None, start_time: Optional[datetime] = None) -> RunManifest:
+    def create(
+        cls,
+        config: Optional[Dict] = None,
+        start_time: Optional[datetime] = None,
+        *,
+        capture_execution_runtime: bool = True,
+    ) -> RunManifest:
         """Create a RunManifest with current environment state.
         
         Args:
             config: Optional serialized BenchmarkConfig dictionary
             start_time: Optional start time (defaults to now)
+            capture_execution_runtime: Capture runtime identity in this process.
+                Benchmark coordinators disable this and attach the worker receipt later.
         
         Returns:
             RunManifest instance with current environment captured
@@ -616,8 +968,26 @@ class RunManifest(BaseModel):
         collection_warnings: list[str] = []
         runtime_capability_limitations = _collect_runtime_capability_limitations(collection_warnings)
 
+        execution_mode = str((config or {}).get("execution_mode", "")).strip().casefold()
+        subprocess_coordinator = execution_mode == "subprocess"
+        runtime_provenance = (
+            capture_runtime_provenance()
+            if capture_execution_runtime and not subprocess_coordinator
+            else None
+        )
+        if runtime_provenance is not None:
+            for warning in runtime_provenance.collection_warnings:
+                _append_collection_warning(collection_warnings, warning)
+
         # Get hardware info
-        cuda_info = get_cuda_info()
+        cuda_info: CudaInfoDict = (
+            {
+                "version": runtime_provenance.cuda_version,
+                "driver_version": runtime_provenance.driver_version,
+            }
+            if runtime_provenance is not None
+            else get_cuda_info()
+        )
         gpu_info = get_gpu_info()
         validity_profile = str((config or {}).get("validity_profile", "strict")).strip().lower()
         gpu_state = get_gpu_state(allow_telemetry_failures=validity_profile == "portable")
@@ -712,6 +1082,7 @@ class RunManifest(BaseModel):
         return cls(
             hardware=hardware,
             software=software,
+            runtime_provenance=runtime_provenance,
             environment=environment,
             git=git,
             seeds=seeds,
@@ -811,6 +1182,28 @@ class RunManifest(BaseModel):
                     "os": "linux",
                     "schemaVersion": "1.0"
                 },
+                "runtime_provenance": {
+                    "cuda_available": True,
+                    "driver_version": "580.126.09",
+                    "torch_version": "2.9.1+cu130",
+                    "cuda_version": "13.0",
+                    "cudnn_version": "91300",
+                    "python_version": "3.12.0",
+                    "os": "linux",
+                    "python_executable": "/usr/bin/python3",
+                    "process_id": 12345,
+                    "captured_at": "2024-01-01T12:00:00+00:00",
+                    "library_versions": {
+                        "numpy": "2.1.2",
+                        "nvidia-cublas-cu13": "13.0.0",
+                        "torch": "2.9.1+cu130",
+                        "triton": "3.5.0"
+                    },
+                    "library_versions_complete": True,
+                    "shadowed_library_versions": {},
+                    "collection_warnings": [],
+                    "schemaVersion": "1.0"
+                },
                 "environment": {
                     "cuda_visible_devices": "0",
                     "relevant_env_vars": {},
@@ -838,3 +1231,154 @@ class RunManifest(BaseModel):
         except AttributeError:
             # Some pydantic versions pass SerializationInfo unexpectedly
             return None
+
+
+def compare_runtime_provenance(
+    reference: RunManifest,
+    candidate: RunManifest,
+    *,
+    target: RuntimeParityTarget,
+) -> RuntimeProvenanceParity:
+    """Compare executor runtime provenance using the canonical target field set.
+
+    ``target`` is mandatory so a CPU comparison cannot be reused as CUDA
+    qualification. Missing or partially collected provenance is ``unknown`` and
+    therefore never produces a matching verdict.
+    """
+
+    if target not in RUNTIME_PARITY_FIELDS_BY_TARGET:
+        allowed = ", ".join(sorted(RUNTIME_PARITY_FIELDS_BY_TARGET))
+        raise ValueError(
+            f"Unsupported runtime parity target {target!r}; expected one of: {allowed}"
+        )
+
+    reference_runtime = reference.runtime_provenance
+    candidate_runtime = candidate.runtime_provenance
+    required_fields = RUNTIME_PARITY_FIELDS_BY_TARGET[target]
+    fields: Dict[str, RuntimeProvenanceFieldParity] = {}
+
+    for field_name in required_fields:
+        reference_value = (
+            getattr(reference_runtime, field_name)
+            if reference_runtime is not None
+            else None
+        )
+        candidate_value = (
+            getattr(candidate_runtime, field_name)
+            if candidate_runtime is not None
+            else None
+        )
+
+        if field_name == "library_versions":
+            reference_complete = bool(
+                reference_runtime is not None
+                and reference_runtime.library_versions_complete
+            )
+            candidate_complete = bool(
+                candidate_runtime is not None
+                and candidate_runtime.library_versions_complete
+            )
+            if not reference_complete or not candidate_complete:
+                fields[field_name] = RuntimeProvenanceFieldParity(
+                    status="unknown",
+                    reference=reference_value,
+                    candidate=candidate_value,
+                    detail=(
+                        "Relevant installed-library collection must be complete in both "
+                        "benchmark-executing processes."
+                    ),
+                )
+            elif reference_value == candidate_value:
+                fields[field_name] = RuntimeProvenanceFieldParity(
+                    status="match",
+                    reference=reference_value,
+                    candidate=candidate_value,
+                )
+            else:
+                fields[field_name] = RuntimeProvenanceFieldParity(
+                    status="mismatch",
+                    reference=reference_value,
+                    candidate=candidate_value,
+                    detail="Relevant installed-library versions differ between runs.",
+                )
+            continue
+
+        if field_name == "cuda_available":
+            if reference_value is None or candidate_value is None:
+                fields[field_name] = RuntimeProvenanceFieldParity(
+                    status="unknown",
+                    reference=reference_value,
+                    candidate=candidate_value,
+                    detail="CUDA availability was not captured in both executing processes.",
+                )
+            elif reference_value is True and candidate_value is True:
+                fields[field_name] = RuntimeProvenanceFieldParity(
+                    status="match",
+                    reference=reference_value,
+                    candidate=candidate_value,
+                )
+            else:
+                fields[field_name] = RuntimeProvenanceFieldParity(
+                    status="mismatch",
+                    reference=reference_value,
+                    candidate=candidate_value,
+                    detail="CUDA parity requires CUDA to be available in both executing processes.",
+                )
+            continue
+
+        reference_known = reference_value is not None and reference_value != ""
+        candidate_known = candidate_value is not None and candidate_value != ""
+        if not reference_known or not candidate_known:
+            fields[field_name] = RuntimeProvenanceFieldParity(
+                status="unknown",
+                reference=reference_value,
+                candidate=candidate_value,
+                detail=f"{field_name} must be known in both benchmark-executing processes.",
+            )
+        elif reference_value == candidate_value:
+            fields[field_name] = RuntimeProvenanceFieldParity(
+                status="match",
+                reference=reference_value,
+                candidate=candidate_value,
+            )
+        else:
+            fields[field_name] = RuntimeProvenanceFieldParity(
+                status="mismatch",
+                reference=reference_value,
+                candidate=candidate_value,
+                detail=f"{field_name} differs between runs.",
+            )
+
+    mismatched_fields = [
+        field_name
+        for field_name in required_fields
+        if fields[field_name].status == "mismatch"
+    ]
+    unknown_fields = [
+        field_name
+        for field_name in required_fields
+        if fields[field_name].status == "unknown"
+    ]
+    return RuntimeProvenanceParity(
+        target=target,
+        matches=not mismatched_fields and not unknown_fields,
+        required_fields=list(required_fields),
+        fields=fields,
+        mismatched_fields=mismatched_fields,
+        unknown_fields=unknown_fields,
+        schemaVersion=SCHEMA_VERSION,
+    )
+
+
+def require_runtime_provenance_parity(
+    reference: RunManifest,
+    candidate: RunManifest,
+    *,
+    target: RuntimeParityTarget,
+) -> RuntimeProvenanceParity:
+    """Return a matching parity receipt or raise with structured failure details."""
+
+    comparison = compare_runtime_provenance(reference, candidate, target=target)
+    if not comparison.matches:
+        raise RuntimeProvenanceParityError(comparison)
+    return comparison

--- a/code/core/benchmark/runtime_comparison.py
+++ b/code/core/benchmark/runtime_comparison.py
@@ -1,0 +1,358 @@
+"""Fail-closed admission for runtime parity between executed benchmark runs."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Literal
+
+import torch
+from pydantic import BaseModel, Field
+
+from core.benchmark.models import BenchmarkRun
+from core.benchmark.run_manifest import (
+    RuntimeParityTarget,
+    RuntimeProvenance,
+    RuntimeProvenanceParity,
+    compare_runtime_provenance,
+)
+
+RunSide = Literal["reference", "candidate"]
+
+
+class RuntimeIntegrityFailure(BaseModel):
+    """One reason an executed runtime receipt cannot be admitted."""
+
+    code: str
+    detail: str
+    run: RunSide | None = None
+    schemaVersion: str = "1.0"  # noqa: N815 - repository schema convention
+
+
+class ExecutedRuntimeComparison(BaseModel):
+    """Combined transport-integrity and runtime-version parity verdict."""
+
+    matches: bool
+    target: RuntimeParityTarget | None = None
+    runtime_parity: RuntimeProvenanceParity | None = None
+    integrity_failures: list[RuntimeIntegrityFailure] = Field(default_factory=list)
+    schemaVersion: str = "1.0"  # noqa: N815 - repository schema convention
+
+
+class ExecutedRuntimeComparisonError(RuntimeError):
+    """Raised after a structured executed-runtime rejection has been retained."""
+
+    def __init__(self, comparison: ExecutedRuntimeComparison) -> None:
+        self.comparison = comparison
+        details = [failure.code for failure in comparison.integrity_failures]
+        if comparison.runtime_parity is not None:
+            details.extend(
+                f"runtime_mismatch:{field_name}"
+                for field_name in comparison.runtime_parity.mismatched_fields
+            )
+            details.extend(
+                f"runtime_unknown:{field_name}"
+                for field_name in comparison.runtime_parity.unknown_fields
+            )
+        if not details:
+            details.append("comparison_unavailable")
+        super().__init__(
+            "EXECUTED RUNTIME COMPARISON FAILED: " + ", ".join(details)
+        )
+
+
+def _failure(
+    failures: list[RuntimeIntegrityFailure],
+    code: str,
+    detail: str,
+    *,
+    run: RunSide | None = None,
+) -> None:
+    failures.append(RuntimeIntegrityFailure(code=code, detail=detail, run=run))
+
+
+def _validated_target(
+    value: str | None,
+    *,
+    run: RunSide,
+    failures: list[RuntimeIntegrityFailure],
+) -> RuntimeParityTarget | None:
+    if value is None or not str(value).strip():
+        _failure(
+            failures,
+            "device_missing",
+            "The executed benchmark result did not retain a device identity.",
+            run=run,
+        )
+        return None
+    try:
+        target = torch.device(value).type
+    except (TypeError, RuntimeError, ValueError) as exc:
+        _failure(
+            failures,
+            "device_invalid",
+            f"The executed benchmark device {value!r} is invalid: {exc}",
+            run=run,
+        )
+        return None
+    if target not in {"cpu", "cuda"}:
+        _failure(
+            failures,
+            "device_unsupported",
+            f"Runtime comparison supports only CPU or CUDA results, got {value!r}.",
+            run=run,
+        )
+        return None
+    return target
+
+
+def _timing_failures(
+    run: BenchmarkRun,
+    *,
+    side: RunSide,
+    failures: list[RuntimeIntegrityFailure],
+) -> None:
+    result = run.result
+    if result.errors:
+        rendered = "; ".join(str(error) for error in result.errors[:3])
+        if len(result.errors) > 3:
+            rendered += f"; and {len(result.errors) - 3} more"
+        _failure(
+            failures,
+            "result_errors",
+            f"The benchmark result retained execution errors: {rendered}",
+            run=side,
+        )
+
+    timing = result.timing
+    if isinstance(timing.iterations, bool) or timing.iterations <= 0:
+        _failure(
+            failures,
+            "timing_iterations_invalid",
+            f"Timing iterations must be positive, got {timing.iterations!r}.",
+            run=side,
+        )
+
+    positive_values: dict[str, Any] = {
+        "mean_ms": timing.mean_ms,
+        "median_ms": timing.median_ms,
+        "min_ms": timing.min_ms,
+        "max_ms": timing.max_ms,
+    }
+    for name in ("p50_ms", "p90_ms", "p95_ms", "p99_ms"):
+        value = getattr(timing, name)
+        if value is not None:
+            positive_values[name] = value
+    positive_values.update(
+        {f"percentiles[{key!r}]": value for key, value in timing.percentiles.items()}
+    )
+    positive_values.update(
+        {f"raw_times_ms[{index}]": value for index, value in enumerate(timing.raw_times_ms or [])}
+    )
+
+    invalid_values: list[str] = []
+    for field_name, value in positive_values.items():
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            invalid_values.append(f"{field_name}={value!r}")
+            continue
+        if isinstance(value, bool) or not math.isfinite(numeric) or numeric <= 0:
+            invalid_values.append(f"{field_name}={value!r}")
+    try:
+        std_ms = float(timing.std_ms)
+    except (TypeError, ValueError):
+        invalid_values.append(f"std_ms={timing.std_ms!r}")
+    else:
+        if isinstance(timing.std_ms, bool) or not math.isfinite(std_ms) or std_ms < 0:
+            invalid_values.append(f"std_ms={timing.std_ms!r}")
+
+    if invalid_values:
+        rendered_invalid_values = ", ".join(invalid_values[:8])
+        if len(invalid_values) > 8:
+            rendered_invalid_values += f", and {len(invalid_values) - 8} more"
+        _failure(
+            failures,
+            "timing_values_invalid",
+            "Timing values must be finite and positive (standard deviation may be zero): "
+            + rendered_invalid_values,
+            run=side,
+        )
+
+
+def _runtime_receipt_failures(
+    run: BenchmarkRun,
+    *,
+    side: RunSide,
+    failures: list[RuntimeIntegrityFailure],
+) -> None:
+    manifest_runtime = run.manifest.runtime_provenance if run.manifest is not None else None
+    result_runtime = run.result.runtime_provenance
+
+    if run.manifest is None:
+        _failure(
+            failures,
+            "manifest_missing",
+            "The benchmark run did not retain a run manifest.",
+            run=side,
+        )
+    if manifest_runtime is None:
+        _failure(
+            failures,
+            "manifest_runtime_provenance_missing",
+            "The run manifest did not retain executing-process runtime provenance.",
+            run=side,
+        )
+    if result_runtime is None:
+        _failure(
+            failures,
+            "result_runtime_provenance_missing",
+            "The benchmark result did not retain executing-process runtime provenance.",
+            run=side,
+        )
+    if (
+        manifest_runtime is not None
+        and result_runtime is not None
+        and manifest_runtime != result_runtime
+    ):
+        _failure(
+            failures,
+            "manifest_result_runtime_mismatch",
+            "Manifest runtime provenance differs from the executing worker result receipt.",
+            run=side,
+        )
+
+    execution_process_ids = getattr(run.result, "execution_process_ids", None)
+    if not isinstance(execution_process_ids, dict) or not execution_process_ids:
+        _failure(
+            failures,
+            "execution_process_ids_missing",
+            "No independently observed execution-process IDs were retained.",
+            run=side,
+        )
+        return
+
+    invalid_execution_ids = {
+        rank: process_id
+        for rank, process_id in execution_process_ids.items()
+        if isinstance(rank, bool)
+        or not isinstance(rank, int)
+        or rank < 0
+        or isinstance(process_id, bool)
+        or not isinstance(process_id, int)
+        or process_id <= 0
+    }
+    if invalid_execution_ids:
+        _failure(
+            failures,
+            "execution_process_ids_invalid",
+            f"Execution-process IDs contain invalid rank/PID entries: {invalid_execution_ids!r}.",
+            run=side,
+        )
+
+    rank_zero_pid = execution_process_ids.get(0)
+    if rank_zero_pid is None:
+        _failure(
+            failures,
+            "rank_zero_execution_process_id_missing",
+            "The independently observed execution-process IDs omit local rank 0.",
+            run=side,
+        )
+    elif result_runtime is not None and result_runtime.process_id != rank_zero_pid:
+        _failure(
+            failures,
+            "runtime_process_id_mismatch",
+            "The primary runtime snapshot PID does not match the independently observed "
+            f"local-rank-0 execution PID ({result_runtime.process_id} != {rank_zero_pid}).",
+            run=side,
+        )
+
+    per_rank = run.result.runtime_provenance_by_local_rank
+    if len(execution_process_ids) > 1 or per_rank:
+        expected_ranks = set(execution_process_ids)
+        observed_ranks = set(per_rank)
+        if observed_ranks != expected_ranks:
+            _failure(
+                failures,
+                "runtime_rank_receipts_incomplete",
+                "Per-rank runtime receipt ranks differ from independently observed execution "
+                f"ranks (runtime={sorted(observed_ranks)}, execution={sorted(expected_ranks)}).",
+                run=side,
+            )
+        for rank in sorted(observed_ranks & expected_ranks):
+            runtime_pid = per_rank[rank].process_id
+            execution_pid = execution_process_ids[rank]
+            if runtime_pid != execution_pid:
+                _failure(
+                    failures,
+                    "runtime_rank_process_id_mismatch",
+                    f"Local rank {rank} runtime snapshot PID does not match its independently "
+                    f"observed execution PID ({runtime_pid} != {execution_pid}).",
+                    run=side,
+                )
+        rank_zero_runtime: RuntimeProvenance | None = per_rank.get(0)
+        if (
+            rank_zero_runtime is not None
+            and result_runtime is not None
+            and rank_zero_runtime != result_runtime
+        ):
+            _failure(
+                failures,
+                "primary_rank_zero_runtime_mismatch",
+                "The primary runtime snapshot differs from the local-rank-0 runtime receipt.",
+                run=side,
+            )
+
+
+def compare_executed_runtime_provenance(
+    reference: BenchmarkRun,
+    candidate: BenchmarkRun,
+) -> ExecutedRuntimeComparison:
+    """Admit a pair only when execution receipts and required versions match."""
+
+    failures: list[RuntimeIntegrityFailure] = []
+    _timing_failures(reference, side="reference", failures=failures)
+    _timing_failures(candidate, side="candidate", failures=failures)
+    _runtime_receipt_failures(reference, side="reference", failures=failures)
+    _runtime_receipt_failures(candidate, side="candidate", failures=failures)
+
+    reference_target = _validated_target(
+        reference.result.device,
+        run="reference",
+        failures=failures,
+    )
+    candidate_target = _validated_target(
+        candidate.result.device,
+        run="candidate",
+        failures=failures,
+    )
+    target: RuntimeParityTarget | None = None
+    if reference_target is not None and candidate_target is not None:
+        if reference_target == candidate_target:
+            target = reference_target
+        else:
+            _failure(
+                failures,
+                "device_target_mismatch",
+                "Reference and candidate executed different device types "
+                f"({reference_target} != {candidate_target}).",
+            )
+
+    runtime_parity: RuntimeProvenanceParity | None = None
+    if target is not None and reference.manifest is not None and candidate.manifest is not None:
+        runtime_parity = compare_runtime_provenance(
+            reference.manifest,
+            candidate.manifest,
+            target=target,
+        )
+
+    matches = (
+        not failures
+        and runtime_parity is not None
+        and runtime_parity.matches
+    )
+    return ExecutedRuntimeComparison(
+        matches=matches,
+        target=target,
+        runtime_parity=runtime_parity,
+        integrity_failures=failures,
+    )

--- a/code/core/benchmark/runtime_comparison.py
+++ b/code/core/benchmark/runtime_comparison.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field
 
 from core.benchmark.models import BenchmarkRun
 from core.benchmark.run_manifest import (
+    RunManifest,
     RuntimeParityTarget,
     RuntimeProvenance,
     RuntimeProvenanceParity,
@@ -25,6 +26,7 @@ class RuntimeIntegrityFailure(BaseModel):
     code: str
     detail: str
     run: RunSide | None = None
+    local_rank: int | None = None
     schemaVersion: str = "1.0"  # noqa: N815 - repository schema convention
 
 
@@ -66,8 +68,22 @@ def _failure(
     detail: str,
     *,
     run: RunSide | None = None,
+    local_rank: int | None = None,
 ) -> None:
-    failures.append(RuntimeIntegrityFailure(code=code, detail=detail, run=run))
+    failures.append(
+        RuntimeIntegrityFailure(
+            code=code,
+            detail=detail,
+            run=run,
+            local_rank=local_rank,
+        )
+    )
+
+
+def _render_rank_keys(ranks: set[Any]) -> str:
+    """Render possibly-invalid rank keys deterministically without comparing unlike types."""
+
+    return "[" + ", ".join(sorted(repr(rank) for rank in ranks)) + "]"
 
 
 def _validated_target(
@@ -183,6 +199,7 @@ def _runtime_receipt_failures(
     run: BenchmarkRun,
     *,
     side: RunSide,
+    target: RuntimeParityTarget | None,
     failures: list[RuntimeIntegrityFailure],
 ) -> None:
     manifest_runtime = run.manifest.runtime_provenance if run.manifest is not None else None
@@ -221,6 +238,29 @@ def _runtime_receipt_failures(
             run=side,
         )
 
+    local_world_size = getattr(run.result, "local_world_size", None)
+    expected_local_ranks: set[int] | None = None
+    if local_world_size is None:
+        _failure(
+            failures,
+            "local_world_size_missing",
+            "The benchmark result did not retain the local worker count passed to the launcher.",
+            run=side,
+        )
+    elif (
+        isinstance(local_world_size, bool)
+        or not isinstance(local_world_size, int)
+        or local_world_size <= 0
+    ):
+        _failure(
+            failures,
+            "local_world_size_invalid",
+            f"The retained local worker count must be a positive integer, got {local_world_size!r}.",
+            run=side,
+        )
+    else:
+        expected_local_ranks = set(range(local_world_size))
+
     execution_process_ids = getattr(run.result, "execution_process_ids", None)
     if not isinstance(execution_process_ids, dict) or not execution_process_ids:
         _failure(
@@ -229,7 +269,7 @@ def _runtime_receipt_failures(
             "No independently observed execution-process IDs were retained.",
             run=side,
         )
-        return
+        execution_process_ids = {}
 
     invalid_execution_ids = {
         rank: process_id
@@ -246,6 +286,17 @@ def _runtime_receipt_failures(
             failures,
             "execution_process_ids_invalid",
             f"Execution-process IDs contain invalid rank/PID entries: {invalid_execution_ids!r}.",
+            run=side,
+        )
+
+    execution_ranks = set(execution_process_ids)
+    if expected_local_ranks is not None and execution_ranks != expected_local_ranks:
+        _failure(
+            failures,
+            "execution_process_ids_incomplete",
+            "Execution-process ID ranks differ from the retained local worker count "
+            f"(expected={_render_rank_keys(expected_local_ranks)}, "
+            f"observed={_render_rank_keys(execution_ranks)}).",
             run=side,
         )
 
@@ -267,18 +318,28 @@ def _runtime_receipt_failures(
         )
 
     per_rank = run.result.runtime_provenance_by_local_rank
+    observed_ranks = set(per_rank)
     if len(execution_process_ids) > 1 or per_rank:
-        expected_ranks = set(execution_process_ids)
-        observed_ranks = set(per_rank)
-        if observed_ranks != expected_ranks:
+        if observed_ranks != execution_ranks:
             _failure(
                 failures,
                 "runtime_rank_receipts_incomplete",
                 "Per-rank runtime receipt ranks differ from independently observed execution "
-                f"ranks (runtime={sorted(observed_ranks)}, execution={sorted(expected_ranks)}).",
+                f"ranks (runtime={_render_rank_keys(observed_ranks)}, "
+                f"execution={_render_rank_keys(execution_ranks)}).",
                 run=side,
             )
-        for rank in sorted(observed_ranks & expected_ranks):
+        valid_execution_ranks = {
+            rank
+            for rank in execution_ranks
+            if not isinstance(rank, bool) and isinstance(rank, int) and rank >= 0
+        }
+        valid_observed_ranks = {
+            rank
+            for rank in observed_ranks
+            if not isinstance(rank, bool) and isinstance(rank, int) and rank >= 0
+        }
+        for rank in sorted(valid_observed_ranks & valid_execution_ranks):
             runtime_pid = per_rank[rank].process_id
             execution_pid = execution_process_ids[rank]
             if runtime_pid != execution_pid:
@@ -288,6 +349,7 @@ def _runtime_receipt_failures(
                     f"Local rank {rank} runtime snapshot PID does not match its independently "
                     f"observed execution PID ({runtime_pid} != {execution_pid}).",
                     run=side,
+                    local_rank=rank,
                 )
         rank_zero_runtime: RuntimeProvenance | None = per_rank.get(0)
         if (
@@ -300,7 +362,41 @@ def _runtime_receipt_failures(
                 "primary_rank_zero_runtime_mismatch",
                 "The primary runtime snapshot differs from the local-rank-0 runtime receipt.",
                 run=side,
+                local_rank=0,
             )
+
+        if result_runtime is not None and target is not None:
+            primary_manifest = RunManifest.model_construct(
+                runtime_provenance=result_runtime,
+            )
+            for rank in sorted(valid_observed_ranks):
+                rank_manifest = RunManifest.model_construct(
+                    runtime_provenance=per_rank[rank],
+                )
+                parity = compare_runtime_provenance(
+                    primary_manifest,
+                    rank_manifest,
+                    target=target,
+                )
+                if parity.mismatched_fields:
+                    _failure(
+                        failures,
+                        "runtime_rank_provenance_mismatch",
+                        f"Local rank {rank} runtime provenance differs from the primary "
+                        f"runtime for required {target} fields: "
+                        f"{', '.join(parity.mismatched_fields)}.",
+                        run=side,
+                        local_rank=rank,
+                    )
+                if parity.unknown_fields:
+                    _failure(
+                        failures,
+                        "runtime_rank_provenance_unknown",
+                        f"Local rank {rank} runtime provenance is incomplete for required "
+                        f"{target} fields: {', '.join(parity.unknown_fields)}.",
+                        run=side,
+                        local_rank=rank,
+                    )
 
 
 def compare_executed_runtime_provenance(
@@ -312,8 +408,6 @@ def compare_executed_runtime_provenance(
     failures: list[RuntimeIntegrityFailure] = []
     _timing_failures(reference, side="reference", failures=failures)
     _timing_failures(candidate, side="candidate", failures=failures)
-    _runtime_receipt_failures(reference, side="reference", failures=failures)
-    _runtime_receipt_failures(candidate, side="candidate", failures=failures)
 
     reference_target = _validated_target(
         reference.result.device,
@@ -323,6 +417,18 @@ def compare_executed_runtime_provenance(
     candidate_target = _validated_target(
         candidate.result.device,
         run="candidate",
+        failures=failures,
+    )
+    _runtime_receipt_failures(
+        reference,
+        side="reference",
+        target=reference_target,
+        failures=failures,
+    )
+    _runtime_receipt_failures(
+        candidate,
+        side="candidate",
+        target=candidate_target,
         failures=failures,
     )
     target: RuntimeParityTarget | None = None

--- a/code/core/benchmark/verification.py
+++ b/code/core/benchmark/verification.py
@@ -18,6 +18,7 @@ import json
 import math
 import os
 import random
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -25,7 +26,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
-
 
 # =============================================================================
 # Precision Configuration
@@ -478,6 +478,135 @@ class ToleranceSpec:
         )
 
 
+OutputToleranceMap = Dict[str, Tuple[float, float]]
+
+
+def normalize_output_tolerances(
+    value: Any,
+    *,
+    source: str = "get_output_tolerances()",
+) -> Optional[OutputToleranceMap]:
+    """Normalize an optional full-output numeric tolerance map.
+
+    The public benchmark hook is intentionally limited to a dictionary whose
+    values are ``(rtol, atol)`` tuples.  This keeps the policy serializable and
+    rules out output transforms or custom comparators.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise TypeError(f"{source} must return dict[str, tuple[float, float]] or None")
+    if not value:
+        raise ValueError(f"{source} must not return an empty dictionary")
+
+    normalized: OutputToleranceMap = {}
+    for name, raw_tolerance in value.items():
+        if not isinstance(name, str) or not name:
+            raise TypeError(f"{source} keys must be non-empty strings")
+        if not isinstance(raw_tolerance, tuple) or len(raw_tolerance) != 2:
+            raise TypeError(
+                f"{source}[{name!r}] must be an (rtol, atol) tuple"
+            )
+        tolerance = ToleranceSpec(
+            rtol=raw_tolerance[0],
+            atol=raw_tolerance[1],
+        )
+        normalized[name] = (tolerance.rtol, tolerance.atol)
+    return normalized
+
+
+def get_output_tolerances(benchmark: Any) -> Optional[OutputToleranceMap]:
+    """Return a benchmark's optional per-output numeric tolerance policy."""
+    if hasattr(benchmark, "_subprocess_output_tolerances"):
+        transported = getattr(benchmark, "_subprocess_output_tolerances")
+        return normalize_output_tolerances(
+            transported,
+            source=f"{benchmark.__class__.__name__} subprocess output tolerances",
+        )
+
+    getter = getattr(benchmark, "get_output_tolerances", None)
+    if getter is None:
+        return None
+    if not callable(getter):
+        raise TypeError(
+            f"{benchmark.__class__.__name__}.get_output_tolerances must be callable"
+        )
+    return normalize_output_tolerances(
+        getter(),
+        source=f"{benchmark.__class__.__name__}.get_output_tolerances()",
+    )
+
+
+def output_tolerances_to_dict(
+    tolerances: Optional[OutputToleranceMap],
+) -> Optional[Dict[str, Dict[str, float]]]:
+    """Serialize a normalized tolerance map for result and transport receipts."""
+    if tolerances is None:
+        return None
+    return {
+        name: {"rtol": float(values[0]), "atol": float(values[1])}
+        for name, values in sorted(tolerances.items())
+    }
+
+
+def output_tolerances_from_dict(
+    value: Any,
+    *,
+    source: str = "serialized output tolerances",
+) -> Optional[OutputToleranceMap]:
+    """Deserialize the JSON representation emitted by output_tolerances_to_dict."""
+    if value is None:
+        return None
+    if not isinstance(value, dict) or not value:
+        raise TypeError(f"{source} must be a non-empty dictionary")
+    tuple_map: OutputToleranceMap = {}
+    for name, raw_tolerance in value.items():
+        if not isinstance(raw_tolerance, dict):
+            raise TypeError(f"{source}[{name!r}] must contain rtol and atol")
+        tuple_map[name] = (raw_tolerance.get("rtol"), raw_tolerance.get("atol"))  # type: ignore[assignment]
+    return normalize_output_tolerances(tuple_map, source=source)
+
+
+def resolve_output_tolerances(
+    baseline: Optional[OutputToleranceMap],
+    optimized: Optional[OutputToleranceMap],
+    *,
+    baseline_output_names: Iterable[str],
+    optimized_output_names: Iterable[str],
+) -> Optional[OutputToleranceMap]:
+    """Validate opt-in parity and exact output-key coverage for a pair."""
+    if baseline is None and optimized is None:
+        return None
+    if baseline is None or optimized is None:
+        raise ValueError(
+            "baseline and optimized benchmarks must both declare get_output_tolerances()"
+        )
+
+    baseline_names = set(baseline_output_names)
+    optimized_names = set(optimized_output_names)
+    baseline_policy_names = set(baseline)
+    optimized_policy_names = set(optimized)
+    if baseline_policy_names != baseline_names:
+        missing = sorted(baseline_names - baseline_policy_names)
+        extra = sorted(baseline_policy_names - baseline_names)
+        raise ValueError(
+            "baseline get_output_tolerances() must exactly cover captured output keys "
+            f"(missing={missing}, extra={extra})"
+        )
+    if optimized_policy_names != optimized_names:
+        missing = sorted(optimized_names - optimized_policy_names)
+        extra = sorted(optimized_policy_names - optimized_names)
+        raise ValueError(
+            "optimized get_output_tolerances() must exactly cover captured output keys "
+            f"(missing={missing}, extra={extra})"
+        )
+    if baseline != optimized:
+        raise ValueError(
+            "baseline and optimized get_output_tolerances() maps must be identical"
+        )
+    return dict(baseline)
+
+
 # Default tolerances by dtype - these are the canonical tolerances used throughout
 DEFAULT_TOLERANCES: Dict[torch.dtype, ToleranceSpec] = {
     torch.float32: ToleranceSpec(rtol=1e-5, atol=1e-8),
@@ -809,6 +938,7 @@ class ComparisonDetails:
     expected_sample: Optional[float] = None
     actual_sample: Optional[float] = None
     tolerance_used: Optional[ToleranceSpec] = None
+    output_tolerances: Optional[OutputToleranceMap] = None
     
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to dictionary."""
@@ -826,6 +956,8 @@ class ComparisonDetails:
             result["actual_sample"] = self.actual_sample
         if self.tolerance_used is not None:
             result["tolerance_used"] = self.tolerance_used.to_dict()
+        if self.output_tolerances is not None:
+            result["output_tolerances"] = output_tolerances_to_dict(self.output_tolerances)
         return result
 
 
@@ -1368,12 +1500,16 @@ def get_output_tolerance(benchmark: Any) -> Optional[ToleranceSpec]:
     Returns:
         ToleranceSpec if benchmark provides custom tolerance, None otherwise
     """
-    if not hasattr(benchmark, "get_output_tolerance") or not callable(getattr(benchmark, "get_output_tolerance")):
+    if hasattr(benchmark, "_subprocess_output_tolerance"):
+        result = getattr(benchmark, "_subprocess_output_tolerance")
+        if result is None:
+            raise ValueError("transported subprocess output tolerance is missing")
+    elif not hasattr(benchmark, "get_output_tolerance") or not callable(getattr(benchmark, "get_output_tolerance")):
         raise NotImplementedError(
             f"{benchmark.__class__.__name__} must implement get_output_tolerance()"
         )
-    
-    result = benchmark.get_output_tolerance()
+    else:
+        result = benchmark.get_output_tolerance()
     if result is None:
         raise ValueError(f"{benchmark.__class__.__name__}.get_output_tolerance() returned None")
     

--- a/code/core/benchmark/verification_mixin.py
+++ b/code/core/benchmark/verification_mixin.py
@@ -230,7 +230,12 @@ class VerificationPayloadMixin:
         return (tol.rtol, tol.atol)
 
     def get_output_tolerances(self) -> Optional[OutputToleranceMap]:
-        payload = self._require_payload()
+        # This hook is optional. Coordinator processes may hold transported
+        # output and global-tolerance receipts without ever creating a local
+        # verification payload, so absence means no per-output policy.
+        payload = getattr(self, "_verification_payload", None)
+        if payload is None:
+            return None
         if payload.output_tolerances is None:
             return None
         return dict(payload.output_tolerances)

--- a/code/core/benchmark/verification_mixin.py
+++ b/code/core/benchmark/verification_mixin.py
@@ -5,6 +5,7 @@ The mixin provides a single `_set_verification_payload()` call that wires up:
 - get_verify_output()
 - get_input_signature()
 - get_output_tolerance()
+- get_output_tolerances() when an exact-keyed policy is supplied
 
 CRITICAL: `_set_verification_payload()` must be called from
 `BaseBenchmark.capture_verification_payload()` (post-timing) to keep the timed
@@ -14,18 +15,20 @@ measurement, and VerifyRunner calls it after verify runs.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import inspect
+from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
 
 from core.benchmark.verification import (
     InputSignature,
+    OutputToleranceMap,
     PrecisionFlags,
     ToleranceSpec,
     coerce_input_signature,
     get_tolerance_for_dtype,
+    normalize_output_tolerances,
     simple_signature,
 )
 
@@ -39,6 +42,7 @@ class VerificationPayload:
     parameter_count: int
     precision_flags: PrecisionFlags
     output_tolerance: Optional[ToleranceSpec] = None
+    output_tolerances: Optional[OutputToleranceMap] = None
     signature_overrides: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -149,6 +153,7 @@ class VerificationPayloadMixin:
         parameter_count: int = 0,
         precision_flags: Optional[Dict[str, bool] | PrecisionFlags] = None,
         output_tolerance: Optional[Union[ToleranceSpec, Tuple[float, float]]] = None,
+        output_tolerances: Optional[Dict[str, Tuple[float, float]]] = None,
         signature_overrides: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Populate verification payload in a single call."""
@@ -169,6 +174,10 @@ class VerificationPayloadMixin:
 
         flags = self._normalize_precision_flags(precision_flags)
         tolerance_spec = self._coerce_tolerance(output_tolerance, output)
+        tolerance_map = normalize_output_tolerances(
+            output_tolerances,
+            source="output_tolerances",
+        )
         signature_overrides_normalized = self._normalize_signature_overrides(signature_overrides)
 
         self._verification_payload = VerificationPayload(
@@ -178,6 +187,7 @@ class VerificationPayloadMixin:
             parameter_count=int(parameter_count),
             precision_flags=flags,
             output_tolerance=tolerance_spec,
+            output_tolerances=tolerance_map,
             signature_overrides=signature_overrides_normalized,
         )
 
@@ -218,6 +228,12 @@ class VerificationPayloadMixin:
         payload = self._require_payload()
         tol = payload.output_tolerance or get_tolerance_for_dtype(payload.output.dtype)
         return (tol.rtol, tol.atol)
+
+    def get_output_tolerances(self) -> Optional[OutputToleranceMap]:
+        payload = self._require_payload()
+        if payload.output_tolerances is None:
+            return None
+        return dict(payload.output_tolerances)
 
 
 __all__ = [

--- a/code/core/benchmark/verified_comparison.py
+++ b/code/core/benchmark/verified_comparison.py
@@ -1,0 +1,339 @@
+"""Fail-closed comparison of already executed benchmark pairs."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+
+from core.benchmark.models import BenchmarkRun
+from core.benchmark.runtime_comparison import (
+    ExecutedRuntimeComparisonError,
+    compare_executed_runtime_provenance,
+)
+from core.benchmark.verification import (
+    InputSignature,
+    ToleranceSpec,
+    coerce_input_signature,
+    get_output_tolerance,
+    get_signature_equivalence_spec,
+    signature_workload_dict,
+)
+from core.benchmark.verify_runner import VerifyRunner
+
+
+class VerifiedComparisonError(RuntimeError):
+    """Raised when captured verification evidence cannot admit a comparison."""
+
+    def __init__(self, code: str, detail: str, *, evidence: Any = None) -> None:
+        self.code = code
+        self.detail = detail
+        self.evidence = evidence
+        super().__init__(f"VERIFIED COMPARISON FAILED [{code}]: {detail}")
+
+
+def _positive_finite(value: object, *, field_name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise TypeError(f"{field_name} must be numeric")
+    numeric = float(value)
+    if not math.isfinite(numeric) or numeric <= 0:
+        raise ValueError(f"{field_name} must be finite and positive")
+    return numeric
+
+
+def _nonnegative_finite(value: object, *, field_name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise TypeError(f"{field_name} must be numeric")
+    numeric = float(value)
+    if not math.isfinite(numeric) or numeric < 0:
+        raise ValueError(f"{field_name} must be finite and nonnegative")
+    return numeric
+
+
+def calculate_speed_metrics(
+    baseline_mean_ms: float,
+    optimized_mean_ms: float,
+    *,
+    regression_threshold_pct: float = 5.0,
+) -> dict[str, Any]:
+    """Calculate speedup and mathematically accurate slowdown percentage."""
+
+    baseline_mean = _positive_finite(
+        baseline_mean_ms,
+        field_name="baseline_mean_ms",
+    )
+    optimized_mean = _positive_finite(
+        optimized_mean_ms,
+        field_name="optimized_mean_ms",
+    )
+    threshold = _nonnegative_finite(
+        regression_threshold_pct,
+        field_name="regression_threshold_pct",
+    )
+
+    speedup = baseline_mean / optimized_mean
+    slowdown_pct = (optimized_mean / baseline_mean - 1.0) * 100.0
+    is_slower = optimized_mean > baseline_mean
+    return {
+        "speedup": speedup,
+        "regression": is_slower and slowdown_pct >= threshold,
+        "regression_pct": slowdown_pct if is_slower else None,
+    }
+
+
+def _require_signature(benchmark: Any, *, side: str) -> InputSignature:
+    getter = getattr(benchmark, "get_input_signature", None)
+    if not callable(getter):
+        raise VerifiedComparisonError(
+            f"{side}_input_signature_missing",
+            f"{side.title()} benchmark must expose get_input_signature().",
+        )
+    try:
+        return coerce_input_signature(getter())
+    except Exception as exc:
+        raise VerifiedComparisonError(
+            f"{side}_input_signature_invalid",
+            f"{side.title()} captured input signature is unavailable or invalid: {exc}",
+        ) from exc
+
+
+def _compare_signatures(baseline: Any, optimized: Any) -> dict[str, Any]:
+    baseline_signature = _require_signature(baseline, side="baseline")
+    optimized_signature = _require_signature(optimized, side="optimized")
+    try:
+        baseline_equivalence = get_signature_equivalence_spec(baseline)
+        optimized_equivalence = get_signature_equivalence_spec(optimized)
+    except Exception as exc:
+        raise VerifiedComparisonError(
+            "signature_equivalence_invalid",
+            f"Signature equivalence declaration is invalid: {exc}",
+        ) from exc
+
+    if baseline_equivalence != optimized_equivalence:
+        raise VerifiedComparisonError(
+            "signature_equivalence_mismatch",
+            "Baseline and optimized signature-equivalence declarations differ.",
+            evidence={
+                "baseline": baseline_equivalence,
+                "optimized": optimized_equivalence,
+            },
+        )
+
+    baseline_workload = signature_workload_dict(
+        baseline_signature,
+        equivalence=baseline_equivalence,
+    )
+    optimized_workload = signature_workload_dict(
+        optimized_signature,
+        equivalence=baseline_equivalence,
+    )
+    if baseline_workload != optimized_workload:
+        differing_fields = sorted(
+            key
+            for key in set(baseline_workload) | set(optimized_workload)
+            if baseline_workload.get(key) != optimized_workload.get(key)
+        )
+        raise VerifiedComparisonError(
+            "input_signature_mismatch",
+            "Captured input signatures differ for fields: "
+            + ", ".join(differing_fields),
+            evidence={
+                "baseline": baseline_workload,
+                "optimized": optimized_workload,
+            },
+        )
+
+    equivalence_receipt = None
+    if baseline_equivalence is not None:
+        equivalence_receipt = {
+            "group": baseline_equivalence.group,
+            "ignore_fields": list(baseline_equivalence.ignore_fields),
+        }
+    return {
+        "passed": True,
+        "baseline_signature": baseline_signature.to_dict(),
+        "optimized_signature": optimized_signature.to_dict(),
+        "equivalence": equivalence_receipt,
+    }
+
+
+def _require_tolerance(benchmark: Any, *, side: str) -> ToleranceSpec:
+    try:
+        tolerance = get_output_tolerance(benchmark)
+    except Exception as exc:
+        raise VerifiedComparisonError(
+            f"{side}_output_tolerance_invalid",
+            f"{side.title()} output tolerance is unavailable or invalid: {exc}",
+        ) from exc
+    if tolerance is None:
+        raise VerifiedComparisonError(
+            f"{side}_output_tolerance_missing",
+            f"{side.title()} benchmark did not provide an output tolerance.",
+        )
+    if tolerance.comparator_fn is not None:
+        raise VerifiedComparisonError(
+            f"{side}_output_tolerance_unsupported",
+            "Post-timing comparison requires explicit numeric rtol/atol values.",
+        )
+    return tolerance
+
+
+def _require_captured_output(benchmark: Any, *, side: str) -> torch.Tensor | dict[str, torch.Tensor]:
+    getter = getattr(benchmark, "get_verify_output", None)
+    if not callable(getter):
+        raise VerifiedComparisonError(
+            f"{side}_verify_output_missing",
+            f"{side.title()} benchmark must expose get_verify_output().",
+        )
+    try:
+        output = getter()
+    except Exception as exc:
+        raise VerifiedComparisonError(
+            f"{side}_verify_output_invalid",
+            f"{side.title()} captured verify output is unavailable: {exc}",
+        ) from exc
+
+    tensors: list[tuple[str, torch.Tensor]]
+    if isinstance(output, torch.Tensor):
+        tensors = [("output", output)]
+    elif isinstance(output, dict):
+        if not output:
+            raise VerifiedComparisonError(
+                f"{side}_verify_output_empty",
+                f"{side.title()} captured verify-output dictionary is empty.",
+            )
+        invalid = {
+            name: type(value).__name__
+            for name, value in output.items()
+            if not isinstance(name, str) or not name or not isinstance(value, torch.Tensor)
+        }
+        if invalid:
+            raise VerifiedComparisonError(
+                f"{side}_verify_output_invalid",
+                f"{side.title()} verify-output dictionary contains invalid entries: {invalid!r}.",
+            )
+        tensors = list(output.items())
+    else:
+        raise VerifiedComparisonError(
+            f"{side}_verify_output_invalid",
+            f"{side.title()} get_verify_output() returned {type(output).__name__}; "
+            "expected a tensor or nonempty tensor dictionary.",
+        )
+
+    empty_names = [name for name, tensor in tensors if tensor.numel() == 0]
+    if empty_names:
+        raise VerifiedComparisonError(
+            f"{side}_verify_output_empty",
+            f"{side.title()} captured verify output contains empty tensors: {empty_names!r}.",
+        )
+    return output
+
+
+def _compare_outputs(baseline: Any, optimized: Any) -> dict[str, Any]:
+    baseline_tolerance = _require_tolerance(baseline, side="baseline")
+    optimized_tolerance = _require_tolerance(optimized, side="optimized")
+    if (
+        optimized_tolerance.rtol > baseline_tolerance.rtol
+        or optimized_tolerance.atol > baseline_tolerance.atol
+    ):
+        raise VerifiedComparisonError(
+            "optimized_output_tolerance_looser",
+            "Optimized output tolerance cannot be looser than the baseline tolerance: "
+            f"baseline=({baseline_tolerance.rtol}, {baseline_tolerance.atol}), "
+            f"optimized=({optimized_tolerance.rtol}, {optimized_tolerance.atol}).",
+        )
+
+    effective_tolerance = ToleranceSpec(
+        rtol=min(baseline_tolerance.rtol, optimized_tolerance.rtol),
+        atol=min(baseline_tolerance.atol, optimized_tolerance.atol),
+        justification=optimized_tolerance.justification or baseline_tolerance.justification,
+    )
+    baseline_output = _require_captured_output(baseline, side="baseline")
+    optimized_output = _require_captured_output(optimized, side="optimized")
+    comparison = VerifyRunner().compare_perf_outputs(
+        baseline_output,
+        optimized_output,
+        (effective_tolerance.rtol, effective_tolerance.atol),
+    )
+    comparison_receipt = comparison.to_dict()
+    comparison_receipt.update(
+        {
+            "rtol": effective_tolerance.rtol,
+            "atol": effective_tolerance.atol,
+            "baseline_tolerance": baseline_tolerance.to_dict(),
+            "optimized_tolerance": optimized_tolerance.to_dict(),
+        }
+    )
+    if not comparison.passed:
+        detail = "Captured full timed outputs do not match"
+        if comparison.max_diff is not None:
+            detail += f" (max_diff={comparison.max_diff})"
+        raise VerifiedComparisonError(
+            "output_mismatch",
+            detail + ".",
+            evidence=comparison_receipt,
+        )
+    return comparison_receipt
+
+
+def _timing_summary(run: BenchmarkRun) -> dict[str, float]:
+    timing = run.result.timing
+    return {
+        "mean_ms": timing.mean_ms,
+        "median_ms": timing.median_ms,
+        "std_ms": timing.std_ms,
+        "min_ms": timing.min_ms,
+        "max_ms": timing.max_ms,
+    }
+
+
+def compare_verified_benchmark_runs(
+    baseline: Any,
+    optimized: Any,
+    baseline_run: BenchmarkRun,
+    optimized_run: BenchmarkRun,
+    *,
+    name: str = "Comparison",
+    regression_threshold_pct: float = 5.0,
+) -> dict[str, Any]:
+    """Compare two completed runs without executing either benchmark again."""
+
+    if not isinstance(baseline_run, BenchmarkRun):
+        raise TypeError("baseline_run must be a BenchmarkRun")
+    if not isinstance(optimized_run, BenchmarkRun):
+        raise TypeError("optimized_run must be a BenchmarkRun")
+
+    runtime_comparison = compare_executed_runtime_provenance(
+        baseline_run,
+        optimized_run,
+    )
+    if not runtime_comparison.matches:
+        raise ExecutedRuntimeComparisonError(runtime_comparison)
+
+    input_verification = _compare_signatures(baseline, optimized)
+    output_verification = _compare_outputs(baseline, optimized)
+    speed_metrics = calculate_speed_metrics(
+        baseline_run.result.timing.mean_ms,
+        optimized_run.result.timing.mean_ms,
+        regression_threshold_pct=regression_threshold_pct,
+    )
+
+    return {
+        "name": name,
+        "baseline": _timing_summary(baseline_run),
+        "optimized": _timing_summary(optimized_run),
+        **speed_metrics,
+        "baseline_result": baseline_run.result,
+        "optimized_result": optimized_run.result,
+        "runtime_comparison": runtime_comparison.model_dump(mode="json"),
+        "input_verification": input_verification,
+        "verification": output_verification,
+    }
+
+
+__all__ = [
+    "VerifiedComparisonError",
+    "calculate_speed_metrics",
+    "compare_verified_benchmark_runs",
+]

--- a/code/core/benchmark/verified_comparison.py
+++ b/code/core/benchmark/verified_comparison.py
@@ -14,10 +14,14 @@ from core.benchmark.runtime_comparison import (
 )
 from core.benchmark.verification import (
     InputSignature,
+    OutputToleranceMap,
     ToleranceSpec,
     coerce_input_signature,
     get_output_tolerance,
+    get_output_tolerances,
     get_signature_equivalence_spec,
+    output_tolerances_to_dict,
+    resolve_output_tolerances,
     signature_workload_dict,
 )
 from core.benchmark.verify_runner import VerifyRunner
@@ -180,14 +184,22 @@ def _require_tolerance(benchmark: Any, *, side: str) -> ToleranceSpec:
 
 
 def _require_captured_output(benchmark: Any, *, side: str) -> torch.Tensor | dict[str, torch.Tensor]:
-    getter = getattr(benchmark, "get_verify_output", None)
-    if not callable(getter):
-        raise VerifiedComparisonError(
-            f"{side}_verify_output_missing",
-            f"{side.title()} benchmark must expose get_verify_output().",
-        )
+    getter = None
+    if not hasattr(benchmark, "_subprocess_verify_output"):
+        getter = getattr(benchmark, "get_verify_output", None)
+        if not callable(getter):
+            raise VerifiedComparisonError(
+                f"{side}_verify_output_missing",
+                f"{side.title()} benchmark must expose get_verify_output().",
+            )
     try:
-        output = getter()
+        if hasattr(benchmark, "_subprocess_verify_output"):
+            output = getattr(benchmark, "_subprocess_verify_output")
+            if output is None:
+                raise ValueError("transported subprocess verify output is missing")
+        else:
+            assert getter is not None
+            output = getter()
     except Exception as exc:
         raise VerifiedComparisonError(
             f"{side}_verify_output_invalid",
@@ -230,6 +242,24 @@ def _require_captured_output(benchmark: Any, *, side: str) -> torch.Tensor | dic
     return output
 
 
+def _require_output_tolerances(
+    benchmark: Any,
+    *,
+    side: str,
+) -> OutputToleranceMap | None:
+    try:
+        return get_output_tolerances(benchmark)
+    except Exception as exc:
+        raise VerifiedComparisonError(
+            f"{side}_output_tolerances_invalid",
+            f"{side.title()} per-output tolerances are invalid: {exc}",
+        ) from exc
+
+
+def _output_names(output: torch.Tensor | dict[str, torch.Tensor]) -> set[str]:
+    return {"output"} if isinstance(output, torch.Tensor) else set(output)
+
+
 def _compare_outputs(baseline: Any, optimized: Any) -> dict[str, Any]:
     baseline_tolerance = _require_tolerance(baseline, side="baseline")
     optimized_tolerance = _require_tolerance(optimized, side="optimized")
@@ -251,10 +281,30 @@ def _compare_outputs(baseline: Any, optimized: Any) -> dict[str, Any]:
     )
     baseline_output = _require_captured_output(baseline, side="baseline")
     optimized_output = _require_captured_output(optimized, side="optimized")
+    baseline_output_tolerances = _require_output_tolerances(baseline, side="baseline")
+    optimized_output_tolerances = _require_output_tolerances(optimized, side="optimized")
+    try:
+        output_tolerances = resolve_output_tolerances(
+            baseline_output_tolerances,
+            optimized_output_tolerances,
+            baseline_output_names=_output_names(baseline_output),
+            optimized_output_names=_output_names(optimized_output),
+        )
+    except (TypeError, ValueError) as exc:
+        raise VerifiedComparisonError(
+            "output_tolerances_mismatch",
+            str(exc),
+            evidence={
+                "baseline": output_tolerances_to_dict(baseline_output_tolerances),
+                "optimized": output_tolerances_to_dict(optimized_output_tolerances),
+            },
+        ) from exc
     comparison = VerifyRunner().compare_perf_outputs(
         baseline_output,
         optimized_output,
-        (effective_tolerance.rtol, effective_tolerance.atol),
+        output_tolerances
+        if output_tolerances is not None
+        else (effective_tolerance.rtol, effective_tolerance.atol),
     )
     comparison_receipt = comparison.to_dict()
     comparison_receipt.update(
@@ -263,6 +313,7 @@ def _compare_outputs(baseline: Any, optimized: Any) -> dict[str, Any]:
             "atol": effective_tolerance.atol,
             "baseline_tolerance": baseline_tolerance.to_dict(),
             "optimized_tolerance": optimized_tolerance.to_dict(),
+            "output_tolerances": output_tolerances_to_dict(output_tolerances),
         }
     )
     if not comparison.passed:

--- a/code/core/benchmark/verify_runner.py
+++ b/code/core/benchmark/verify_runner.py
@@ -41,6 +41,7 @@ from core.benchmark.verification import (
     ComparisonDetails,
     EnforcementPhase,
     InputSignature,
+    OutputToleranceMap,
     PrecisionFlags,
     SignatureEquivalenceSpec,
     QuarantineReason,
@@ -52,8 +53,13 @@ from core.benchmark.verification import (
     get_enforcement_phase,
     get_signature_equivalence_spec,
     get_output_tolerance,
+    get_output_tolerances,
     is_verification_enabled,
     get_tolerance_for_dtype,
+    normalize_output_tolerances,
+    output_tolerances_from_dict,
+    output_tolerances_to_dict,
+    resolve_output_tolerances,
     select_jitter_dimension,
     signature_cache_key,
     signature_workload_dict,
@@ -118,6 +124,7 @@ class GoldenOutput:
     created_at: datetime
     seed: int
     tolerance: Optional["ToleranceSpec"] = None
+    output_tolerances: Optional[OutputToleranceMap] = None
     
     def compute_checksum(self) -> str:
         """Compute checksum of outputs for integrity verification."""
@@ -197,6 +204,10 @@ class GoldenOutputCache:
                 created_at=datetime.fromisoformat(data["created_at"]),
                 seed=data["seed"],
                 tolerance=self._load_tolerance(data),
+                output_tolerances=output_tolerances_from_dict(
+                    data.get("output_tolerances"),
+                    source="golden output cache output_tolerances",
+                ),
             )
         except Exception:
             return None
@@ -219,6 +230,7 @@ class GoldenOutputCache:
             "seed": golden.seed,
             "cache_salt": self.cache_salt,
             "tolerance": self._dump_tolerance(golden.tolerance),
+            "output_tolerances": output_tolerances_to_dict(golden.output_tolerances),
         }
         with open(path, "wb") as f:
             pickle.dump(data, f)
@@ -299,6 +311,7 @@ class _OutputToleranceSnapshot:
     """Tolerance metadata captured before benchmark teardown."""
 
     value: Optional[ToleranceSpec]
+    output_tolerances: Optional[OutputToleranceMap]
     error: Optional[str]
 
 
@@ -479,8 +492,17 @@ class VerifyRunner:
             outputs["output"] = out.detach().clone()
         elif isinstance(out, dict):
             for k, v in out.items():
-                if isinstance(v, torch.Tensor):
-                    outputs[k] = v.detach().clone()
+                if not isinstance(k, str) or not k:
+                    raise TypeError(
+                        f"{benchmark.__class__.__name__}.get_verify_output() dictionary "
+                        "keys must be non-empty strings"
+                    )
+                if not isinstance(v, torch.Tensor):
+                    raise TypeError(
+                        f"{benchmark.__class__.__name__}.get_verify_output()[{k!r}] "
+                        f"must be a torch.Tensor, got {type(v)}"
+                    )
+                outputs[k] = v.detach().clone()
             if not outputs:
                 raise ValueError(
                     f"{benchmark.__class__.__name__}.get_verify_output() returned dict "
@@ -665,19 +687,38 @@ class VerifyRunner:
         expected: Dict[str, torch.Tensor],
         actual: Dict[str, torch.Tensor],
         tolerance: Optional[ToleranceSpec] = None,
+        output_tolerances: Optional[OutputToleranceMap] = None,
     ) -> ComparisonDetails:
         """Compare expected and actual outputs.
         
         Args:
             expected: Expected output tensors (from baseline)
             actual: Actual output tensors (from optimized)
-            tolerance: Optional custom tolerance override
+            tolerance: Optional global tolerance override
+            output_tolerances: Optional exact-keyed per-output tolerances
             
         Returns:
             ComparisonDetails with comparison results
         """
-        if set(expected.keys()) != set(actual.keys()):
+        expected_names = set(expected)
+        actual_names = set(actual)
+        if output_tolerances is not None:
+            tolerance_names = set(output_tolerances)
+            if tolerance_names != expected_names or tolerance_names != actual_names:
+                raise ValueError(
+                    "output_tolerances must exactly cover baseline and optimized output keys"
+                )
+
+        def _details(**kwargs: Any) -> ComparisonDetails:
             return ComparisonDetails(
+                output_tolerances=(
+                    dict(output_tolerances) if output_tolerances is not None else None
+                ),
+                **kwargs,
+            )
+
+        if expected_names != actual_names:
+            return _details(
                 passed=False,
                 max_diff=None,
                 location=None,
@@ -699,26 +740,30 @@ class VerifyRunner:
             
             # Check shapes match
             if exp_tensor.shape != act_tensor.shape:
-                return ComparisonDetails(
+                return _details(
                     passed=False,
                     max_diff=float('inf'),
                     location=None,
                 )
             
             # Get tolerance for dtype
-            tol = tolerance or get_tolerance_for_dtype(exp_tensor.dtype)
+            if output_tolerances is not None:
+                per_output = output_tolerances[name]
+                tol = ToleranceSpec(rtol=per_output[0], atol=per_output[1])
+            else:
+                tol = tolerance or get_tolerance_for_dtype(exp_tensor.dtype)
             
             # Custom comparator takes precedence
             if tol.comparator_fn is not None:
                 try:
                     if not tol.comparator_fn(exp_tensor, act_tensor):
-                        return ComparisonDetails(
+                        return _details(
                             passed=False,
                             tolerance_used=tol,
                         )
                     continue
                 except Exception:
-                    return ComparisonDetails(passed=False, tolerance_used=tol)
+                    return _details(passed=False, tolerance_used=tol)
             
             # Standard numeric comparison
             if exp_tensor.is_floating_point():
@@ -727,7 +772,7 @@ class VerifyRunner:
                 # precedence, but avoid max()/argmax() on an empty tensor.
                 if exp_tensor.numel() == 0:
                     if not torch.allclose(exp_tensor, act_tensor, rtol=tol.rtol, atol=tol.atol):
-                        return ComparisonDetails(passed=False, tolerance_used=tol)
+                        return _details(passed=False, tolerance_used=tol)
                     continue
                 # Use allclose with tolerances
                 diff = torch.abs(exp_tensor - act_tensor)
@@ -744,7 +789,7 @@ class VerifyRunner:
                 
                 # Check if passes tolerance
                 if not torch.allclose(exp_tensor, act_tensor, rtol=tol.rtol, atol=tol.atol):
-                    return ComparisonDetails(
+                    return _details(
                         passed=False,
                         max_diff=max_diff_overall,
                         location=worst_location,
@@ -759,7 +804,7 @@ class VerifyRunner:
                     max_idx = diff.int().argmax()
                     flat_idx = max_idx.item()
                     worst_location = tuple(int(x) for x in np.unravel_index(flat_idx, diff.shape))
-                    return ComparisonDetails(
+                    return _details(
                         passed=False,
                         max_diff=float('inf'),
                         location=worst_location,
@@ -768,23 +813,23 @@ class VerifyRunner:
                         tolerance_used=tol,
                     )
         
-        return ComparisonDetails(
+        return _details(
             passed=True,
             max_diff=max_diff_overall if max_diff_overall > 0 else None,
-            tolerance_used=tolerance,
+            tolerance_used=tolerance if output_tolerances is None else None,
         )
 
     def compare_perf_outputs(
         self,
         baseline_output: Union[torch.Tensor, Dict[str, torch.Tensor]],
         optimized_output: Union[torch.Tensor, Dict[str, torch.Tensor]],
-        tolerance: Tuple[float, float],
+        tolerance: Union[Tuple[float, float], OutputToleranceMap],
     ) -> ComparisonDetails:
         """Compare already-captured perf-run outputs strictly.
 
         This is used for post-timing verification. Callers MUST supply an
-        explicit tolerance from the baseline benchmark; no fallbacks or
-        auto-inference are permitted.
+        explicit global tuple or exact-keyed per-output tolerance map from the
+        benchmark pair; no fallbacks or auto-inference are permitted.
         """
         def _coerce(out: Union[torch.Tensor, Dict[str, torch.Tensor]]) -> Dict[str, torch.Tensor]:
             if isinstance(out, torch.Tensor):
@@ -802,7 +847,19 @@ class VerifyRunner:
 
         expected = _coerce(baseline_output)
         actual = _coerce(optimized_output)
-        tol_spec = ToleranceSpec(rtol=float(tolerance[0]), atol=float(tolerance[1]))
+        if isinstance(tolerance, dict):
+            output_tolerances = normalize_output_tolerances(
+                tolerance,
+                source="compare_perf_outputs tolerance map",
+            )
+            if output_tolerances is None:  # pragma: no cover - normalized dict cannot be None
+                raise ValueError("compare_perf_outputs tolerance map is missing")
+            return self._compare_outputs(
+                expected,
+                actual,
+                output_tolerances=output_tolerances,
+            )
+        tol_spec = ToleranceSpec(rtol=tolerance[0], atol=tolerance[1])
         return self._compare_outputs(expected, actual, tol_spec)
     
     def _run_with_seed(
@@ -834,6 +891,16 @@ class VerifyRunner:
             Tuple of (outputs, workload_metrics, seed_info, inputs_used,
             input_signature, output_tolerance_snapshot)
         """
+        # A direct verification execution must not consume verification receipts
+        # left on an instance by an earlier subprocess harness dispatch.
+        for transport_attr in (
+            "_subprocess_verify_output",
+            "_subprocess_output_tolerance",
+            "_subprocess_output_tolerances",
+            "_subprocess_input_signature",
+        ):
+            vars(benchmark).pop(transport_attr, None)
+
         # Set deterministic seeds BEFORE setup and capture seed_info
         # NOTE: We do NOT re-seed after setup. This ensures inputs created
         # in setup() are deterministic - both baseline and optimized get
@@ -945,13 +1012,23 @@ class VerifyRunner:
                 # during teardown. Preserve only normalized tolerance metadata (or
                 # its read error) while the payload is still live.
                 try:
+                    output_tolerances = get_output_tolerances(benchmark)
+                    if output_tolerances is not None and set(output_tolerances) != set(outputs):
+                        missing = sorted(set(outputs) - set(output_tolerances))
+                        extra = sorted(set(output_tolerances) - set(outputs))
+                        raise ValueError(
+                            "get_output_tolerances() must exactly cover captured output keys "
+                            f"(missing={missing}, extra={extra})"
+                        )
                     tolerance_snapshot = _OutputToleranceSnapshot(
                         value=get_output_tolerance(benchmark),
+                        output_tolerances=output_tolerances,
                         error=None,
                     )
                 except Exception as exc:
                     tolerance_snapshot = _OutputToleranceSnapshot(
                         value=None,
+                        output_tolerances=None,
                         error=str(exc),
                     )
 
@@ -1542,6 +1619,7 @@ class VerifyRunner:
                 created_at=datetime.now(),
                 seed=config.seed,
                 tolerance=baseline_tol,
+                output_tolerances=tolerance_snapshot.output_tolerances,
             )
             golden.checksum = golden.compute_checksum()
             self.cache.put(golden)
@@ -1605,7 +1683,9 @@ class VerifyRunner:
             outputs, metrics, seed_info, inputs, signature, tolerance_snapshot = self._run_with_seed(
                 optimized,
                 config.seed,
-                capture_output_tolerance=config.tolerance_override is None,
+                # Per-output policy is benchmark-owned and must still be
+                # captured when a legacy global override is supplied.
+                capture_output_tolerance=True,
             )
             evaluation_provenance = self._last_evaluation_provenance
             if not getattr(optimized, "parameter_signature_only", False):
@@ -1752,12 +1832,29 @@ class VerifyRunner:
                     atol=min(tolerance.atol, baseline_tol.atol),
                     justification=tolerance.justification or baseline_tol.justification,
                 )
+
+            try:
+                output_tolerances = resolve_output_tolerances(
+                    golden.output_tolerances,
+                    tolerance_snapshot.output_tolerances if tolerance_snapshot is not None else None,
+                    baseline_output_names=golden.outputs,
+                    optimized_output_names=outputs,
+                )
+            except (TypeError, ValueError) as exc:
+                return VerifyResult(
+                    passed=False,
+                    reason=QuarantineReason.MISSING_OUTPUT_TOLERANCE.value,
+                    signature_hash=sig_hash,
+                    details={"error": str(exc)},
+                    timestamp=datetime.now(),
+                )
             
             # Compare outputs
             comparison = self._compare_outputs(
                 golden.outputs,
                 outputs,
                 tolerance,
+                output_tolerances=output_tolerances,
             )
             
             if not comparison.passed:

--- a/code/core/harness/benchmark_harness.py
+++ b/code/core/harness/benchmark_harness.py
@@ -722,6 +722,7 @@ _configure_quick_wins()
 
 _VERIFY_OUTPUT_MAX_BYTES = 64 * 1024 * 1024
 """Maximum verify_output payload size (bytes) before spilling to file."""
+_RUNTIME_PROVENANCE_TIMEOUT_SECONDS = 15.0
 
 
 def _extract_skip_reason_from_messages(messages: Sequence[str]) -> Optional[str]:
@@ -2569,6 +2570,7 @@ class BenchmarkHarness:
     def _benchmark_with_torchrun(self, benchmark: BaseBenchmark, config: BenchmarkConfig) -> PydanticBenchmarkResult:
         """Launch benchmark via torchrun for multi-GPU targets."""
         import inspect
+        from core.harness.torchrun_runtime_provenance import parse_torchrun_runtime_provenance_stdout
         print("[harness] _benchmark_with_torchrun start", flush=True)
 
         def _filter_logs(lines: List[str], dedupe: bool = True) -> List[str]:
@@ -2726,6 +2728,7 @@ class BenchmarkHarness:
         wrapper_args: List[str] = [
             "--aisp-expected-torch-seed",
             str(int(expected_torch_seed)),
+            "--aisp-emit-runtime-provenance",
         ]
         if script_path is not None:
             wrapper_args[0:0] = ["--aisp-target-script", str(script_path)]
@@ -2774,6 +2777,7 @@ class BenchmarkHarness:
 
         stdout = ""
         stderr = ""
+        worker_runtime_receipts = None
         elapsed = 0.0
         reported_time_per_iter_ms: Optional[float] = None
         timeout_limit = config.get_effective_timeout("measurement")
@@ -2859,6 +2863,14 @@ class BenchmarkHarness:
                     if tail:
                         errors.append("stderr_tail: " + " | ".join(tail))
             else:
+                worker_runtime_receipts = parse_torchrun_runtime_provenance_stdout(
+                    stdout,
+                    expected_local_ranks=range(int(nproc_per_node)),
+                    target=self.device.type,
+                )
+                # Raw stdout was retained above; protocol records must not
+                # contaminate human logs, throughput parsing or callbacks.
+                stdout = worker_runtime_receipts.clean_stdout
                 if spec.timing_source == "rank0_time_per_iter_ms":
                     reported_time_per_iter_ms = self._extract_rank0_time_per_iter_ms(
                         stdout.splitlines()
@@ -2899,6 +2911,13 @@ class BenchmarkHarness:
                 iterations_per_sample=1,
             )
         result = self._compute_stats(times_ms, config)
+        if worker_runtime_receipts is not None:
+            result.runtime_provenance = worker_runtime_receipts.primary_snapshot.model_copy(deep=True)
+            result.runtime_provenance_by_local_rank = {
+                rank: snapshot.model_copy(deep=True)
+                for rank, snapshot in worker_runtime_receipts.snapshots_by_local_rank.items()
+            }
+            result.execution_process_ids = dict(worker_runtime_receipts.execution_process_ids)
         if reported_iteration_mean:
             # The worker emitted one aggregate mean. Do not invent percentiles
             # or a distribution from the iterations represented by that mean.
@@ -3008,6 +3027,8 @@ class BenchmarkHarness:
         Uses subprocess isolation (if enabled) or threading timeout to prevent hangs.
         Default timeout is 15 seconds.
         """
+        from core.harness.profiler_guard import assert_no_active_profiler
+        assert_no_active_profiler()
         callable_wrapped = False
         # Support callable benchmarks by wrapping in a minimal BaseBenchmark
         if not isinstance(benchmark, BaseBenchmark):
@@ -3159,6 +3180,8 @@ class BenchmarkHarness:
             probe=self._environment_probe,
             allow_virtualization=bool(getattr(config, "allow_virtualization", False)),
             allow_foreign_gpu_processes=bool(getattr(config, "allow_foreign_gpu_processes", False)),
+            expected_device_uuid=config.expected_device_uuid if self.device.type == "cuda" else None,
+            expected_compute_capability=config.expected_compute_capability if self.device.type == "cuda" else None,
         )
         if LOGGER_AVAILABLE:
             if env_result.details:
@@ -3297,7 +3320,9 @@ class BenchmarkHarness:
             )
 
         config_dict = {k: _serialize_manifest_value(v) for k, v in self.config.__dict__.items()}
-        manifest = RunManifest.create(config=config_dict, start_time=start_time)
+        manifest = RunManifest.create(
+            config=config_dict, start_time=start_time, capture_execution_runtime=False,
+        )
 
         def _append_manifest_warning(message: str) -> None:
             if message not in manifest.collection_warnings:
@@ -3334,6 +3359,13 @@ class BenchmarkHarness:
         worker_evaluation = getattr(result, "evaluation", None)
         if worker_evaluation is not None:
             manifest.evaluation = worker_evaluation.model_copy(deep=True)
+
+        # Qualification must use the execution process, never substitute the
+        # coordinator's package inventory when a worker receipt is missing.
+        worker_runtime = result.runtime_provenance
+        manifest.runtime_provenance = (
+            worker_runtime.model_copy(deep=True) if worker_runtime is not None else None
+        )
 
         result_seed_info = _seed_info_to_manifest(getattr(result, "seeds", None))
         if result_seed_info is not None:
@@ -3520,6 +3552,8 @@ class BenchmarkHarness:
         """Run benchmark in subprocess for reliable timeout cancellation."""
         import json
         import inspect
+        import torch
+        from core.benchmark.run_manifest import RuntimeProvenance
         
         errors: List[str] = []
         memory_peak_mb: Optional[float] = None
@@ -3536,6 +3570,9 @@ class BenchmarkHarness:
         child_runtime_env: Optional[Dict[str, str]] = None
         child_gpu_metrics: Optional[Dict[str, Optional[float | str]]] = None
         child_evaluation: Optional[EvaluationProvenance] = None
+        child_runtime_provenance: Optional[RuntimeProvenance] = None
+        child_device: Optional[str] = None
+        execution_process_ids: Dict[int, int] = {}
         stage_watchdog: Dict[str, Dict[str, Any]] = {
             "setup": {"status": "pending"},
             "warmup": {"status": "pending"},
@@ -3691,6 +3728,7 @@ class BenchmarkHarness:
                 preexec_fn=_benchmark_child_preexec,
             )
             child_pgid = process.pid  # _benchmark_child_preexec() starts a fresh session.
+            execution_process_ids = {0: process.pid}
             if LOGGER_AVAILABLE:
                 logger.info(
                     "SUBPROCESS DISPATCH: coordinator_pid=%s worker_pid=%s owner_run_id=%s owner_pid=%s",
@@ -3704,7 +3742,10 @@ class BenchmarkHarness:
             input_json = json.dumps(input_data)
             subprocess_failed = False
             try:
-                stdout, stderr = process.communicate(input=input_json, timeout=measurement_timeout)
+                stdout, stderr = process.communicate(
+                    input=input_json,
+                    timeout=measurement_timeout + _RUNTIME_PROVENANCE_TIMEOUT_SECONDS,
+                )
             except BrokenPipeError as exc:
                 subprocess_failed = True
                 errors.append(f"Subprocess stdin closed early: {exc}")
@@ -3773,6 +3814,14 @@ class BenchmarkHarness:
                     )
                     if benchmark_result is not None and benchmark_result.evaluation is not None:
                         child_evaluation = benchmark_result.evaluation.model_copy(deep=True)
+                    if benchmark_result is not None and benchmark_result.runtime_provenance is not None:
+                        child_runtime_provenance = benchmark_result.runtime_provenance.model_copy(deep=True)
+                        if child_runtime_provenance.process_id != process.pid:
+                            raise ValueError("Runtime provenance PID does not match the launched benchmark worker")
+                    if benchmark_result is not None:
+                        child_device = benchmark_result.device
+                        if child_device is None or torch.device(child_device) != torch.device(input_data["device"]):
+                            raise ValueError("Executed child device does not match the dispatched benchmark device")
                     if result_success and benchmark_result is not None:
                         # Deserialize Pydantic BenchmarkResult from JSON
                         child_gpu_metrics = getattr(benchmark_result, "gpu_metrics", None)
@@ -4032,6 +4081,10 @@ class BenchmarkHarness:
             )
             if child_evaluation is not None:
                 result.evaluation = child_evaluation.model_copy(deep=True)
+            if child_runtime_provenance is not None:
+                result.runtime_provenance = child_runtime_provenance.model_copy(deep=True)
+            result.execution_process_ids = dict(execution_process_ids)
+            result.device = child_device
             return result
         
         # Compute statistics only from actual samples. Summary-only children
@@ -4049,6 +4102,10 @@ class BenchmarkHarness:
             result.gpu_metrics = child_gpu_metrics
         if child_evaluation is not None:
             result.evaluation = child_evaluation.model_copy(deep=True)
+        if child_runtime_provenance is not None:
+            result.runtime_provenance = child_runtime_provenance.model_copy(deep=True)
+        result.execution_process_ids = dict(execution_process_ids)
+        result.device = child_device
         if child_custom_metrics is not None:
             result.custom_metrics = child_custom_metrics
         else:
@@ -4151,6 +4208,7 @@ class BenchmarkHarness:
         """Run benchmark using threading (alternative to subprocess method)."""
         self._ensure_runtime_initialized()
         import inspect
+        from core.benchmark.run_manifest import RuntimeProvenance, capture_runtime_provenance
         
         errors = []
         memory_peak_mb = None
@@ -4165,6 +4223,7 @@ class BenchmarkHarness:
         locked_gpu_metrics: Optional[Dict[str, Optional[float | str]]] = None
         captured_custom_metrics: Optional[Dict[str, float]] = None
         evaluation_provenance: Optional[EvaluationProvenance] = None
+        worker_runtime_provenance: Optional[RuntimeProvenance] = None
         
         # Get benchmark name for error messages (same as subprocess path)
         benchmark_class = benchmark.__class__.__name__
@@ -4178,6 +4237,8 @@ class BenchmarkHarness:
             probe=self._environment_probe,
             allow_virtualization=bool(getattr(config, "allow_virtualization", False)),
             allow_foreign_gpu_processes=bool(getattr(config, "allow_foreign_gpu_processes", False)),
+            expected_device_uuid=config.expected_device_uuid if self.device.type == "cuda" else None,
+            expected_compute_capability=config.expected_compute_capability if self.device.type == "cuda" else None,
         )
         if LOGGER_AVAILABLE:
             for warning in env_result.warnings:
@@ -4231,6 +4292,8 @@ class BenchmarkHarness:
         # Use a lock to prevent teardown from running while benchmark is executing
         execution_lock = threading.Lock()
         execution_complete = threading.Event()
+        provenance_started = threading.Event()
+        provenance_start_time: List[float] = []
         teardown_called = threading.Event()  # Track if teardown has been called
         
         # Store timeout result if one occurs (needs to be accessible from outer scope)
@@ -4240,6 +4303,7 @@ class BenchmarkHarness:
             'warmup': {'status': 'pending', 'duration': 0.0},
             'measurement': {'status': 'pending', 'duration': 0.0},
             'profiling': {'status': 'pending', 'duration': 0.0},
+            'runtime_provenance': {'status': 'pending', 'duration': 0.0},
         }
         stage_start_times: Dict[str, float] = {}
 
@@ -4261,6 +4325,9 @@ class BenchmarkHarness:
             """Attach a stable worker receipt to every result path."""
 
             result.errors = list(errors)
+            if worker_runtime_provenance is not None:
+                result.runtime_provenance = worker_runtime_provenance.model_copy(deep=True)
+            result.execution_process_ids = {0: os.getpid()}
             if evaluation_provenance is not None:
                 receipt = evaluation_provenance.model_copy(deep=True)
                 if receipt.finalized_at is None:
@@ -4271,6 +4338,7 @@ class BenchmarkHarness:
         def run_benchmark_internal():
             """Internal benchmark execution function."""
             nonlocal times_ms, memory_peak_mb, memory_allocated_mb, profiling_outputs, errors, nsys_metrics, ncu_metrics, timeout_result_storage, inference_timing_data, locked_gpu_metrics, captured_custom_metrics, evaluation_provenance
+            nonlocal worker_runtime_provenance
             validity_profile = str(getattr(config, "validity_profile", "strict")).strip().lower()
             portable_mode = validity_profile == "portable"
             clock_lock_active = False
@@ -4669,6 +4737,19 @@ class BenchmarkHarness:
                     
                     if stage_watchdog['measurement']['status'] == 'running':
                         finish_stage('measurement')
+                    # Collect versions after timed work so metadata enumeration
+                    # and runtime queries cannot pre-warm the measured workload.
+                    # A separate bounded grace period covers this receipt stage.
+                    start_stage('runtime_provenance')
+                    provenance_start_time.append(time.monotonic())
+                    provenance_started.set()
+                    worker_runtime_provenance = capture_runtime_provenance()
+                    if time.monotonic() - provenance_start_time[0] > _RUNTIME_PROVENANCE_TIMEOUT_SECONDS:
+                        raise TimeoutError(
+                            "Runtime provenance collection exceeded its separate "
+                            f"{_RUNTIME_PROVENANCE_TIMEOUT_SECONDS:g} second budget"
+                        )
+                    finish_stage('runtime_provenance')
                 
                 except Exception as e:
                     error_msg = str(e) or repr(e)
@@ -4681,6 +4762,8 @@ class BenchmarkHarness:
                     times_ms = cast(List[float], [])
                     if stage_watchdog['measurement']['status'] == 'running':
                         finish_stage('measurement', status='error')
+                    if stage_watchdog['runtime_provenance']['status'] == 'running':
+                        finish_stage('runtime_provenance', status='error')
                 finally:
                     # Mark execution as complete before teardown
                     execution_complete.set()
@@ -4776,12 +4859,32 @@ class BenchmarkHarness:
         future = self._thread_executor.submit(run_benchmark_internal)
         timeout_result: Optional[PydanticBenchmarkResult] = None
         try:
-            future.result(timeout=measurement_timeout)
+            try:
+                future.result(timeout=measurement_timeout)
+            except _FuturesTimeoutError:
+                if not provenance_started.is_set():
+                    raise
+                remaining = _RUNTIME_PROVENANCE_TIMEOUT_SECONDS - (
+                    time.monotonic() - provenance_start_time[0]
+                )
+                future.result(timeout=max(0.0, remaining))
             elapsed_time = time.time() - thread_start_time
         except _FuturesTimeoutError:
             elapsed_time = time.time() - thread_start_time
             future.cancel()
-            finish_stage('measurement', status='timeout')
+            timeout_stage = 'measurement'
+            if provenance_started.is_set():
+                timeout_stage = (
+                    'runtime_provenance'
+                    if stage_watchdog['runtime_provenance']['status'] == 'running'
+                    else 'finalization'
+                )
+            timeout_limit = _RUNTIME_PROVENANCE_TIMEOUT_SECONDS if provenance_started.is_set() else measurement_timeout
+            timeout_duration = (
+                time.monotonic() - provenance_start_time[0]
+                if provenance_started.is_set() else elapsed_time
+            )
+            finish_stage(timeout_stage, status='timeout')
 
             if timeout_result_storage[0] is not None:
                 timeout_result = timeout_result_storage[0]
@@ -4790,8 +4893,8 @@ class BenchmarkHarness:
                 logger.error("TIMEOUT: Benchmark execution exceeded timeout limit")
                 logger.error("=" * 80)
                 logger.error(f"   Benchmark: {benchmark_name}")
-                logger.error(f"   Stage: measurement (benchmark iterations)")
-                logger.error(f"   Timeout limit: {measurement_timeout} seconds")
+                logger.error(f"   Stage: {timeout_stage}")
+                logger.error(f"   Timeout limit: {timeout_limit} seconds")
                 logger.error(f"   Elapsed time: {elapsed_time:.2f} seconds")
                 logger.error(f"   Config: iterations={config.iterations}, warmup={config.warmup}")
                 logger.error(f"   Status: Benchmark did not complete within timeout period")
@@ -4813,8 +4916,8 @@ class BenchmarkHarness:
                 logger.error("=" * 80)
                 
                 timeout_error_msg = (
-                    f"TIMEOUT: Benchmark measurement stage exceeded timeout of {measurement_timeout} seconds "
-                    f"(ran for {elapsed_time:.2f}s). "
+                    f"TIMEOUT: Benchmark {timeout_stage} stage exceeded timeout of {timeout_limit} seconds "
+                    f"(ran for {timeout_duration:.2f}s). "
                     f"Consider increasing measurement_timeout_seconds or using timeout_multiplier. "
                     f"Thread-mode cannot force-stop hung CUDA kernels - consider subprocess mode for stricter isolation."
                 )
@@ -4828,9 +4931,9 @@ class BenchmarkHarness:
                 gc.collect()
                 
                 timeout_result = self._create_timeout_result(
-                    stage="measurement",
-                    duration=elapsed_time,
-                    limit=measurement_timeout,
+                    stage=timeout_stage,
+                    duration=timeout_duration,
+                    limit=timeout_limit,
                     errors=errors,
                     benchmark_name=benchmark_name,
                     config=config,
@@ -5016,6 +5119,8 @@ class BenchmarkHarness:
         self, fn: Callable, config: BenchmarkConfig
     ) -> tuple[List[float], Dict[str, str]]:
         """Benchmark with profiling enabled."""
+        from core.harness.profiler_guard import assert_no_active_profiler
+        assert_no_active_profiler()
         self._ensure_runtime_initialized()
         profiling_outputs = {}
         
@@ -5054,6 +5159,10 @@ class BenchmarkHarness:
                     "with_flops": False,
                     "schedule": torch.profiler.schedule(wait=1, warmup=1, active=1, repeat=1),
                 }
+            if self.device.type == "cpu":
+                # Profiling activity follows the explicitly configured workload
+                # device. A CUDA-only preset cannot record a CPU benchmark.
+                torch_profiler_kwargs["activities"] = [torch.profiler.ProfilerActivity.CPU]
             
             # Run benchmark with PyTorch profiler
             with torch.profiler.profile(**torch_profiler_kwargs) as prof:
@@ -5120,6 +5229,8 @@ class BenchmarkHarness:
     
     def _benchmark_triton(self, fn: Callable, config: BenchmarkConfig) -> List[float]:
         """Use Triton's do_bench (returns single value per call)."""
+        from core.harness.profiler_guard import assert_no_active_profiler
+        assert_no_active_profiler()
         try:
             import triton.testing as tt
             times_ms = cast(List[float], [])
@@ -5138,6 +5249,8 @@ class BenchmarkHarness:
         Timer chooses its block size/count using min_run_time_ms. The result's
         iterations field counts measured blocks, not config.iterations calls.
         """
+        from core.harness.profiler_guard import assert_no_active_profiler
+        assert_no_active_profiler()
         try:
             from torch.utils.benchmark import Timer
             
@@ -5176,6 +5289,8 @@ class BenchmarkHarness:
             Tuple of (times_ms, inference_timing_data) where inference_timing_data is None
             or a dict with 'ttft_times_ms' and 'tpot_times_ms' keys
         """
+        from core.harness.profiler_guard import assert_no_active_profiler
+        assert_no_active_profiler()
         self._ensure_runtime_initialized()
         times_ms: List[float] = []
         inference_timing_data: Optional[Dict[str, List[float]]] = None
@@ -5208,6 +5323,8 @@ class BenchmarkHarness:
             probe=self._environment_probe,
             allow_virtualization=bool(getattr(config, "allow_virtualization", False)),
             allow_foreign_gpu_processes=bool(getattr(config, "allow_foreign_gpu_processes", False)),
+            expected_device_uuid=config.expected_device_uuid if self.device.type == "cuda" else None,
+            expected_compute_capability=config.expected_compute_capability if self.device.type == "cuda" else None,
         )
         for warning in env_result.warnings:
             import warnings as warn_module
@@ -6377,42 +6494,14 @@ def compare_benchmarks(
     if harness is None:
         harness = BenchmarkHarness()
     
-    baseline_result = harness.benchmark(baseline)
-    optimized_result = harness.benchmark(optimized)
-    
-    baseline_mean = baseline_result.timing.mean_ms if baseline_result.timing else 0.0
-    optimized_mean = optimized_result.timing.mean_ms if optimized_result.timing else 0.0
-    speedup = baseline_mean / optimized_mean if optimized_mean > 0 else 1.0
-    
-    # Detect regression: optimized is slower by threshold
-    regression = False
-    regression_pct = None
-    if speedup < 1.0:
-        regression_pct = (1.0 - speedup) * 100
-        regression = regression_pct >= regression_threshold_pct
-    
-    return {
-        "name": name,
-        "baseline": {
-            "mean_ms": baseline_result.timing.mean_ms if baseline_result.timing else 0.0,
-            "median_ms": baseline_result.timing.median_ms if baseline_result.timing else 0.0,
-            "std_ms": baseline_result.timing.std_ms if baseline_result.timing else 0.0,
-            "min_ms": baseline_result.timing.min_ms if baseline_result.timing else 0.0,
-            "max_ms": baseline_result.timing.max_ms if baseline_result.timing else 0.0,
-        },
-        "optimized": {
-            "mean_ms": optimized_result.timing.mean_ms if optimized_result.timing else 0.0,
-            "median_ms": optimized_result.timing.median_ms if optimized_result.timing else 0.0,
-            "std_ms": optimized_result.timing.std_ms if optimized_result.timing else 0.0,
-            "min_ms": optimized_result.timing.min_ms if optimized_result.timing else 0.0,
-            "max_ms": optimized_result.timing.max_ms if optimized_result.timing else 0.0,
-        },
-        "speedup": speedup,
-        "regression": regression,
-        "regression_pct": regression_pct,
-        "baseline_result": baseline_result,
-        "optimized_result": optimized_result,
-    }
+    from core.benchmark.verified_comparison import compare_verified_benchmark_runs
+
+    baseline_run = harness.benchmark_with_manifest(baseline)
+    optimized_run = harness.benchmark_with_manifest(optimized)
+    return compare_verified_benchmark_runs(
+        baseline, optimized, baseline_run, optimized_run,
+        name=name, regression_threshold_pct=regression_threshold_pct,
+    )
 
 
 def benchmark_main(

--- a/code/core/harness/benchmark_harness.py
+++ b/code/core/harness/benchmark_harness.py
@@ -2918,6 +2918,7 @@ class BenchmarkHarness:
                 for rank, snapshot in worker_runtime_receipts.snapshots_by_local_rank.items()
             }
             result.execution_process_ids = dict(worker_runtime_receipts.execution_process_ids)
+        result.local_world_size = int(nproc_per_node)
         if reported_iteration_mean:
             # The worker emitted one aggregate mean. Do not invent percentiles
             # or a distribution from the iterations represented by that mean.
@@ -4084,6 +4085,7 @@ class BenchmarkHarness:
             if child_runtime_provenance is not None:
                 result.runtime_provenance = child_runtime_provenance.model_copy(deep=True)
             result.execution_process_ids = dict(execution_process_ids)
+            result.local_world_size = 1
             result.device = child_device
             return result
         
@@ -4105,6 +4107,7 @@ class BenchmarkHarness:
         if child_runtime_provenance is not None:
             result.runtime_provenance = child_runtime_provenance.model_copy(deep=True)
         result.execution_process_ids = dict(execution_process_ids)
+        result.local_world_size = 1
         result.device = child_device
         if child_custom_metrics is not None:
             result.custom_metrics = child_custom_metrics
@@ -4328,6 +4331,7 @@ class BenchmarkHarness:
             if worker_runtime_provenance is not None:
                 result.runtime_provenance = worker_runtime_provenance.model_copy(deep=True)
             result.execution_process_ids = {0: os.getpid()}
+            result.local_world_size = 1
             if evaluation_provenance is not None:
                 receipt = evaluation_provenance.model_copy(deep=True)
                 if receipt.finalized_at is None:

--- a/code/core/harness/benchmark_harness.py
+++ b/code/core/harness/benchmark_harness.py
@@ -58,6 +58,12 @@ from core.benchmark.evaluation_provenance import (
     finalize_evaluation as finalize_evaluation_provenance,
     start_evaluation,
 )
+from core.benchmark.verification import (
+    OutputToleranceMap,
+    get_output_tolerances,
+    output_tolerances_from_dict,
+    output_tolerances_to_dict,
+)
 from core.benchmark.verification_mixin import VerificationPayloadMixin
 from core.harness.backend_policy import apply_backend_policy, normalize_backend_policy, restore_backend_policy
 from core.harness.device_identity_contract import (
@@ -176,6 +182,34 @@ _NCU_FIRST_CLASS_METRIC_PREFIXES = (
     "ncu_l2_throughput_pct",
     "ncu_occupancy_pct",
 )
+
+
+def _parse_subprocess_output_tolerances(
+    result_dict: Dict[str, Any],
+    *,
+    declared_output_tolerances: Optional[OutputToleranceMap],
+) -> Tuple[bool, Optional[OutputToleranceMap]]:
+    """Read a child policy receipt and bind it to any pre-dispatch declaration."""
+    if "output_tolerances" not in result_dict:
+        if declared_output_tolerances is not None:
+            raise ValueError(
+                "Subprocess omitted output_tolerances required by the benchmark's "
+                "pre-dispatch declaration"
+            )
+        return False, None
+
+    captured = output_tolerances_from_dict(
+        result_dict["output_tolerances"],
+        source="subprocess output_tolerances",
+    )
+    if declared_output_tolerances is not None and captured != declared_output_tolerances:
+        raise ValueError(
+            "Subprocess output_tolerances do not match the benchmark's pre-dispatch "
+            "declaration "
+            f"(declared={output_tolerances_to_dict(declared_output_tolerances)!r}, "
+            f"captured={output_tolerances_to_dict(captured)!r})"
+        )
+    return True, captured
 
 
 def _ncu_metrics_from_flat(ncu_metrics: Dict[str, Any]) -> NcuMetrics:
@@ -1928,6 +1962,12 @@ class BaseBenchmark:
             "tolerance via _set_verification_payload() from capture_verification_payload() (post-timing)."
         )
 
+    def get_output_tolerances(self) -> Optional[Dict[str, Tuple[float, float]]]:
+        """Return an optional exact-keyed per-output tolerance policy."""
+        if isinstance(self, VerificationPayloadMixin):
+            return VerificationPayloadMixin.get_output_tolerances(self)
+        return None
+
     def get_custom_streams(self) -> List["torch.cuda.Stream"]:
         """Return any non-default streams used by this benchmark."""
         return []
@@ -3055,6 +3095,17 @@ class BenchmarkHarness:
         elif name and getattr(benchmark, "name", None) is None:
             # Preserve provided name if the benchmark did not set one
             benchmark.name = name
+
+        # Subprocess verification artifacts belong to exactly one completed
+        # dispatch. Reusing a benchmark instance must never admit a later run
+        # with output, tolerance, or signature data from an earlier child.
+        for transport_attr in (
+            "_subprocess_verify_output",
+            "_subprocess_output_tolerance",
+            "_subprocess_output_tolerances",
+            "_subprocess_input_signature",
+        ):
+            vars(benchmark).pop(transport_attr, None)
         
         print("[harness] benchmark() start", flush=True)
         # Clone config to avoid mutating shared instance; deepcopy prevents
@@ -3171,6 +3222,18 @@ class BenchmarkHarness:
         # Benchmarks read this via get_config() / self._config.
         benchmark._config = ReadOnlyBenchmarkConfigView.from_config(config)  # type: ignore[attr-defined]
 
+        # A benchmark-level override is a declaration made before execution and
+        # must survive subprocess transport unchanged. Payload-only mixins are
+        # populated after measurement, so they intentionally have no pre-dispatch
+        # declaration to bind here.
+        declared_output_tolerances: Optional[OutputToleranceMap] = None
+        output_tolerances_impl = getattr(type(benchmark), "get_output_tolerances", None)
+        if output_tolerances_impl not in (
+            BaseBenchmark.get_output_tolerances,
+            VerificationPayloadMixin.get_output_tolerances,
+        ):
+            declared_output_tolerances = get_output_tolerances(benchmark)
+
         # Environment validity gate (loud warning on virtualization).
         # Note: validate_environment() also runs inside the timed harness path; this early check ensures
         # the message is visible even when using subprocess isolation.
@@ -3263,6 +3326,12 @@ class BenchmarkHarness:
                 return self._benchmark_with_torchrun(benchmark, config)
             if config.execution_mode == ExecutionMode.SUBPROCESS:
                 print("[harness] dispatch subprocess", flush=True)
+                if declared_output_tolerances is not None:
+                    return self._benchmark_with_subprocess(
+                        benchmark,
+                        config,
+                        declared_output_tolerances=declared_output_tolerances,
+                    )
                 return self._benchmark_with_subprocess(benchmark, config)
             print("[harness] dispatch threading (direct)", flush=True)
             return self._benchmark_with_threading(benchmark, config)
@@ -3549,7 +3618,13 @@ class BenchmarkHarness:
         runner = VerifyRunner()
         return runner.gate_perf(benchmark_path)
     
-    def _benchmark_with_subprocess(self, benchmark: BaseBenchmark, config: BenchmarkConfig) -> PydanticBenchmarkResult:
+    def _benchmark_with_subprocess(
+        self,
+        benchmark: BaseBenchmark,
+        config: BenchmarkConfig,
+        *,
+        declared_output_tolerances: Optional[OutputToleranceMap] = None,
+    ) -> PydanticBenchmarkResult:
         """Run benchmark in subprocess for reliable timeout cancellation."""
         import json
         import inspect
@@ -3927,6 +4002,21 @@ class BenchmarkHarness:
                             except Exception as e:
                                 errors.append(f"Failed to parse output_tolerance from subprocess: {e}")
                                 raise
+
+                        try:
+                            has_output_tolerances, output_tolerances = (
+                                _parse_subprocess_output_tolerances(
+                                    result_dict,
+                                    declared_output_tolerances=declared_output_tolerances,
+                                )
+                            )
+                            if has_output_tolerances:
+                                benchmark._subprocess_output_tolerances = output_tolerances
+                        except Exception as e:
+                            errors.append(
+                                f"Failed to parse output_tolerances from subprocess: {e}"
+                            )
+                            raise
 
                         sig_data = result_dict.get("input_signature")
                         if sig_data is not None:

--- a/code/core/harness/isolated_runner.py
+++ b/code/core/harness/isolated_runner.py
@@ -336,6 +336,7 @@ def run_benchmark(input_data: Dict[str, Any]) -> Dict[str, Any]:
                 "error": None,
                 "verify_output": None,
                 "output_tolerance": None,
+                "output_tolerances": None,
                 "input_signature": None,
             }
 
@@ -347,6 +348,9 @@ def run_benchmark(input_data: Dict[str, Any]) -> Dict[str, Any]:
                 try:
                     verify_output_obj = benchmark.get_verify_output()
                     output_tol_obj = benchmark.get_output_tolerance()
+                    from core.benchmark.verification import get_output_tolerances
+
+                    output_tolerances_obj = get_output_tolerances(benchmark)
                     signature_obj = benchmark.get_input_signature()
 
                     import torch  # local import after module load
@@ -368,10 +372,27 @@ def run_benchmark(input_data: Dict[str, Any]) -> Dict[str, Any]:
                             f"got {type(verify_output_obj)}"
                         )
 
+                    output_names = (
+                        {"output"}
+                        if isinstance(verify_output_obj, torch.Tensor)
+                        else set(verify_output_obj)
+                    )
+                    if (
+                        output_tolerances_obj is not None
+                        and set(output_tolerances_obj) != output_names
+                    ):
+                        missing = sorted(output_names - set(output_tolerances_obj))
+                        extra = sorted(set(output_tolerances_obj) - output_names)
+                        raise ValueError(
+                            "get_output_tolerances() must exactly cover captured output keys "
+                            f"(missing={missing}, extra={extra})"
+                        )
+
                     capture_state["output_tolerance"] = (
                         float(output_tol_obj[0]),
                         float(output_tol_obj[1]),
                     )
+                    capture_state["output_tolerances"] = output_tolerances_obj
                     capture_state["input_signature"] = (
                         signature_obj.to_dict()
                         if hasattr(signature_obj, "to_dict")
@@ -408,6 +429,7 @@ def run_benchmark(input_data: Dict[str, Any]) -> Dict[str, Any]:
             # Strictly extract verification artifacts captured from the timing run
             verify_output = capture_state["verify_output"]
             output_tol = capture_state["output_tolerance"]
+            output_tolerances = capture_state["output_tolerances"]
             signature = capture_state["input_signature"]
             import torch  # local import after module load
 
@@ -455,6 +477,14 @@ def run_benchmark(input_data: Dict[str, Any]) -> Dict[str, Any]:
                 "result_json": bench_result.model_dump_json(),
                 "verify_output": verify_output_data,
                 "output_tolerance": {"rtol": float(output_tol[0]), "atol": float(output_tol[1])},
+                "output_tolerances": (
+                    {
+                        name: {"rtol": values[0], "atol": values[1]}
+                        for name, values in sorted(output_tolerances.items())
+                    }
+                    if output_tolerances is not None
+                    else None
+                ),
                 "input_signature": signature,
                 "errors": bench_result.errors or [],
             }

--- a/code/core/harness/profiler_guard.py
+++ b/code/core/harness/profiler_guard.py
@@ -1,0 +1,19 @@
+"""Reject active in-process PyTorch profilers before benchmark execution."""
+
+import torch
+
+
+def assert_no_active_profiler() -> None:
+    """Keep measurement and profiler collection in separate phases.
+
+    This checks PyTorch's current-thread recorder state, including both Kineto
+    and the legacy autograd profiler. It does not inspect external Nsight
+    sessions or detect a profiler that starts and stops inside benchmark_fn.
+    Calling it before dispatch also protects the public threaded entrypoint.
+    """
+    if torch.autograd._profiler_enabled():
+        raise RuntimeError(
+            "Active PyTorch profiler detected before benchmark execution. "
+            "Exit the enclosing profiler before measuring or collecting another "
+            "profile; use the harness's separate profiling phase."
+        )

--- a/code/core/harness/run_benchmarks.py
+++ b/code/core/harness/run_benchmarks.py
@@ -83,6 +83,10 @@ from core.benchmark.defaults import BenchmarkDefaults, set_defaults, get_default
 from core.benchmark.informational_benchmarks import INFORMATIONAL_BENCHMARKS, is_informational_example
 from core.benchmark.run_manifest import get_gpu_state
 from core.benchmark.run_manifest import reset_gpu_state, get_git_info
+from core.benchmark.runtime_comparison import (
+    compare_executed_runtime_provenance,
+    ExecutedRuntimeComparisonError,
+)
 from core.profiling.gpu_telemetry import format_gpu_telemetry, query_gpu_telemetry
 from core.harness.serving_stack import get_serving_stack_pins
 from core.profiling.profiler_config import (
@@ -7061,6 +7065,13 @@ def _test_chapter_impl(
                         target_label=f"{chapter_name}:{example_name}",
                         technique=technique,
                     )
+                    runtime_parity = compare_executed_runtime_provenance(baseline_run, optimized_run)
+                    result_entry.setdefault("runtime_provenance_checks", []).append({
+                        "optimized_file": opt_name,
+                        "comparison": runtime_parity.model_dump(mode="json"),
+                    })
+                    if not runtime_parity.matches:
+                        raise ExecutedRuntimeComparisonError(runtime_parity)
                     optimized_timing = optimized_result.timing
                     optimized_memory = optimized_result.memory
                     optimized_custom_metrics = getattr(optimized_result, "custom_metrics", None) or {}

--- a/code/core/harness/run_benchmarks.py
+++ b/code/core/harness/run_benchmarks.py
@@ -135,6 +135,10 @@ try:
         VerifyResult,
         coerce_input_signature,
         get_signature_equivalence_spec,
+        get_output_tolerance,
+        get_output_tolerances,
+        output_tolerances_to_dict,
+        resolve_output_tolerances,
         signature_workload_dict,
     )
     from core.benchmark.quarantine import QuarantineManager
@@ -5845,12 +5849,23 @@ def _test_chapter_impl(
         return bench.get_verify_output()
 
     def _get_perf_tolerance(bench: Any) -> tuple[float, float]:
-        if hasattr(bench, "_subprocess_output_tolerance"):
-            tol = getattr(bench, "_subprocess_output_tolerance")
-            if tol is None:
-                raise RuntimeError("Missing subprocess output_tolerance")
-            return tol
-        return bench.get_output_tolerance()
+        tolerance = get_output_tolerance(bench)
+        if tolerance is None:
+            raise RuntimeError("Missing output_tolerance")
+        return (tolerance.rtol, tolerance.atol)
+
+    def _get_perf_output_tolerances(bench: Any):
+        return get_output_tolerances(bench)
+
+    def _perf_output_names(output: Any) -> set[str]:
+        if isinstance(output, torch.Tensor):
+            return {"output"}
+        if isinstance(output, dict):
+            return set(output)
+        raise TypeError(
+            "verify_output must be torch.Tensor or Dict[str, torch.Tensor], "
+            f"got {type(output)}"
+        )
 
     def _get_perf_signature(bench: Any):
         if hasattr(bench, "_subprocess_input_signature"):
@@ -6068,6 +6083,7 @@ def _test_chapter_impl(
             baseline_equivalence = None
             baseline_verify_output = None
             baseline_verify_tolerance = None
+            baseline_verify_output_tolerances = None
         
             # Check if this is a distributed benchmark and we have only 1 GPU
             is_distributed = is_distributed_benchmark(baseline_path)
@@ -6388,6 +6404,9 @@ def _test_chapter_impl(
                         if verify_output:
                             baseline_verify_output = _get_perf_output(baseline_benchmark)
                             baseline_verify_tolerance = _get_perf_tolerance(baseline_benchmark)
+                            baseline_verify_output_tolerances = _get_perf_output_tolerances(
+                                baseline_benchmark
+                            )
                     except Exception as exc:
                         logger.error("    ✗ BASELINE VERIFICATION SETUP FAILED: %s", exc)
                         result_entry["status"] = "failed_verification"
@@ -7265,10 +7284,21 @@ def _test_chapter_impl(
                             if baseline_verify_output is None or baseline_verify_tolerance is None:
                                 raise RuntimeError("Baseline verify_output/tolerance missing")
                             optimized_verify_output = _get_perf_output(optimized_benchmark)
+                            optimized_verify_output_tolerances = _get_perf_output_tolerances(
+                                optimized_benchmark
+                            )
+                            output_tolerances = resolve_output_tolerances(
+                                baseline_verify_output_tolerances,
+                                optimized_verify_output_tolerances,
+                                baseline_output_names=_perf_output_names(baseline_verify_output),
+                                optimized_output_names=_perf_output_names(optimized_verify_output),
+                            )
                             comparison = perf_compare_runner.compare_perf_outputs(
                                 baseline_verify_output,
                                 optimized_verify_output,
-                                baseline_verify_tolerance,
+                                output_tolerances
+                                if output_tolerances is not None
+                                else baseline_verify_tolerance,
                             )
                             opt_result["verification"] = {
                                 "passed": comparison.passed,
@@ -7276,6 +7306,9 @@ def _test_chapter_impl(
                                 "location": comparison.location,
                                 "rtol": baseline_verify_tolerance[0],
                                 "atol": baseline_verify_tolerance[1],
+                                "output_tolerances": output_tolerances_to_dict(
+                                    output_tolerances
+                                ),
                             }
                             if not comparison.passed:
                                 reason = "Output mismatch"

--- a/code/core/harness/torchrun_runtime_provenance.py
+++ b/code/core/harness/torchrun_runtime_provenance.py
@@ -1,0 +1,570 @@
+"""Fail-closed runtime-provenance transport for torchrun workers.
+
+Each opted-in worker captures its own runtime after the target succeeds. Large
+logical records are split into bounded frames, and each frame is written with
+one ``os.write`` call no larger than ``PIPE_BUF`` so concurrent ranks cannot
+interleave bytes. Coordinators retain the raw stream and use ``clean_stdout``
+for ordinary timing and diagnostic parsing.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import os
+import select
+import sys
+from collections.abc import Collection, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import ValidationError
+
+from core.benchmark.run_manifest import (
+    RunManifest,
+    RuntimeParityTarget,
+    RuntimeProvenance,
+    RuntimeProvenanceParityError,
+    capture_runtime_provenance,
+    require_runtime_provenance_parity,
+)
+
+TORCHRUN_RUNTIME_PROVENANCE_SCHEMA = "aisp.torchrun-runtime-provenance.v1"
+TORCHRUN_RUNTIME_PROVENANCE_PREFIX = "__AISP_TORCHRUN_RUNTIME_PROVENANCE_V1__="
+
+_FRAME_KEYS = frozenset({"s", "r", "lr", "ws", "lws", "p", "i", "n", "h", "d"})
+_SHA256_HEX_LENGTH = 64
+
+
+class TorchrunRuntimeProvenanceError(RuntimeError):
+    """Raised when a torchrun runtime receipt is absent, ambiguous, or invalid."""
+
+
+@dataclass(frozen=True)
+class TorchrunRuntimeProvenanceParseResult:
+    """Validated worker snapshots plus raw and protocol-free stdout."""
+
+    raw_stdout: str
+    clean_stdout: str
+    snapshots_by_local_rank: dict[int, RuntimeProvenance]
+    execution_process_ids: dict[int, int]
+
+    @property
+    def primary_snapshot(self) -> RuntimeProvenance:
+        """Return local rank zero's snapshot after strict rank validation."""
+
+        try:
+            return self.snapshots_by_local_rank[0]
+        except KeyError as exc:
+            raise TorchrunRuntimeProvenanceError(
+                "Torchrun runtime provenance has no local-rank-zero snapshot"
+            ) from exc
+
+
+@dataclass(frozen=True)
+class _FrameMetadata:
+    rank: int
+    local_rank: int
+    world_size: int
+    local_world_size: int
+    process_id: int
+    frame_count: int
+    digest: str
+
+
+def _require_plain_int(value: Any, *, field_name: str, minimum: int) -> int:
+    if type(value) is not int or value < minimum:
+        raise TorchrunRuntimeProvenanceError(
+            f"Torchrun runtime provenance {field_name} must be an integer >= {minimum}, "
+            f"got {value!r}"
+        )
+    return value
+
+
+def _environment_int(name: str, *, default: int, minimum: int) -> int:
+    raw = os.environ.get(name)
+    if raw in (None, ""):
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise TorchrunRuntimeProvenanceError(
+            f"Invalid integer for torchrun runtime provenance {name}: {raw!r}"
+        ) from exc
+    return _require_plain_int(value, field_name=name, minimum=minimum)
+
+
+def _pipe_buf(fd: int) -> int:
+    try:
+        value = int(os.fpathconf(fd, "PC_PIPE_BUF"))
+    except (OSError, ValueError):
+        value = int(getattr(select, "PIPE_BUF", 512))
+    if value <= 0:
+        raise TorchrunRuntimeProvenanceError(
+            f"Invalid PIPE_BUF={value} for torchrun runtime provenance stdout"
+        )
+    return value
+
+
+def _validate_rank_metadata(
+    *, rank: int, local_rank: int, world_size: int, local_world_size: int
+) -> None:
+    if rank >= world_size or local_rank >= local_world_size:
+        raise TorchrunRuntimeProvenanceError(
+            "Torchrun runtime provenance rank metadata is outside its declared world size"
+        )
+    if local_world_size > world_size:
+        raise TorchrunRuntimeProvenanceError(
+            "Torchrun runtime provenance local_world_size cannot exceed world_size"
+        )
+
+
+def _serialize_frame(
+    *,
+    rank: int,
+    local_rank: int,
+    world_size: int,
+    local_world_size: int,
+    process_id: int,
+    frame_index: int,
+    frame_count: int,
+    digest: str,
+    data: str,
+) -> bytes:
+    payload = {
+        "s": TORCHRUN_RUNTIME_PROVENANCE_SCHEMA,
+        "r": rank,
+        "lr": local_rank,
+        "ws": world_size,
+        "lws": local_world_size,
+        "p": process_id,
+        "i": frame_index,
+        "n": frame_count,
+        "h": digest,
+        "d": data,
+    }
+    return (
+        TORCHRUN_RUNTIME_PROVENANCE_PREFIX
+        + json.dumps(
+            payload,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def format_torchrun_runtime_provenance_frames(
+    snapshot: RuntimeProvenance,
+    *,
+    local_rank: int,
+    rank: int,
+    world_size: int,
+    local_world_size: int,
+    pipe_buf: int,
+) -> tuple[bytes, ...]:
+    """Encode one complete worker snapshot as independently atomic frames."""
+
+    if not isinstance(snapshot, RuntimeProvenance):
+        raise TypeError(f"snapshot must be RuntimeProvenance, got {type(snapshot).__name__}")
+    local_rank = _require_plain_int(local_rank, field_name="local_rank", minimum=0)
+    rank = _require_plain_int(rank, field_name="rank", minimum=0)
+    world_size = _require_plain_int(world_size, field_name="world_size", minimum=1)
+    local_world_size = _require_plain_int(
+        local_world_size, field_name="local_world_size", minimum=1
+    )
+    pipe_buf = _require_plain_int(pipe_buf, field_name="pipe_buf", minimum=1)
+    process_id = _require_plain_int(snapshot.process_id, field_name="process_id", minimum=1)
+    _validate_rank_metadata(
+        rank=rank,
+        local_rank=local_rank,
+        world_size=world_size,
+        local_world_size=local_world_size,
+    )
+
+    runtime_json = json.dumps(
+        snapshot.model_dump(mode="json"),
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    digest = hashlib.sha256(runtime_json).hexdigest()
+    encoded_runtime = base64.b64encode(runtime_json).decode("ascii")
+
+    frame_count = 1
+    while True:
+        empty_frame = _serialize_frame(
+            rank=rank,
+            local_rank=local_rank,
+            world_size=world_size,
+            local_world_size=local_world_size,
+            process_id=process_id,
+            frame_index=frame_count - 1,
+            frame_count=frame_count,
+            digest=digest,
+            data="",
+        )
+        chunk_capacity = pipe_buf - len(empty_frame)
+        if chunk_capacity <= 0:
+            raise TorchrunRuntimeProvenanceError(
+                "Torchrun runtime provenance PIPE_BUF cannot hold frame metadata: "
+                f"{pipe_buf} bytes available, {len(empty_frame)} required"
+            )
+        required_frames = max(1, (len(encoded_runtime) + chunk_capacity - 1) // chunk_capacity)
+        if required_frames <= frame_count:
+            break
+        frame_count = required_frames
+
+    base_chunk_size, larger_chunk_count = divmod(len(encoded_runtime), frame_count)
+    frames: list[bytes] = []
+    offset = 0
+    for frame_index in range(frame_count):
+        chunk_size = base_chunk_size + (frame_index < larger_chunk_count)
+        data = encoded_runtime[offset : offset + chunk_size]
+        offset += chunk_size
+        frame = _serialize_frame(
+            rank=rank,
+            local_rank=local_rank,
+            world_size=world_size,
+            local_world_size=local_world_size,
+            process_id=process_id,
+            frame_index=frame_index,
+            frame_count=frame_count,
+            digest=digest,
+            data=data,
+        )
+        if len(frame) > pipe_buf:
+            raise TorchrunRuntimeProvenanceError(
+                "Torchrun runtime provenance frame exceeds atomic stdout PIPE_BUF: "
+                f"frame {frame_index + 1}/{frame_count} is {len(frame)} > {pipe_buf} bytes"
+            )
+        frames.append(frame)
+    if offset != len(encoded_runtime):
+        raise AssertionError("Torchrun runtime provenance frame partition was incomplete")
+    return tuple(frames)
+
+
+def emit_torchrun_runtime_provenance(*, local_rank: int) -> RuntimeProvenance:
+    """Capture and atomically emit this worker's complete runtime provenance."""
+
+    local_rank = _require_plain_int(local_rank, field_name="local_rank", minimum=0)
+    rank = _environment_int("RANK", default=local_rank, minimum=0)
+    world_size = _environment_int("WORLD_SIZE", default=1, minimum=1)
+    local_world_size = _environment_int("LOCAL_WORLD_SIZE", default=1, minimum=1)
+
+    snapshot = capture_runtime_provenance()
+    actual_process_id = os.getpid()
+    if snapshot.process_id != actual_process_id:
+        raise TorchrunRuntimeProvenanceError(
+            "Captured torchrun runtime provenance process ID does not identify the "
+            f"emitting worker: captured {snapshot.process_id}, actual {actual_process_id}"
+        )
+    stdout_fd = sys.stdout.fileno()
+    frames = format_torchrun_runtime_provenance_frames(
+        snapshot,
+        local_rank=local_rank,
+        rank=rank,
+        world_size=world_size,
+        local_world_size=local_world_size,
+        pipe_buf=_pipe_buf(stdout_fd),
+    )
+    sys.stdout.flush()
+    for frame_index, frame in enumerate(frames):
+        written = os.write(stdout_fd, frame)
+        if written != len(frame):
+            raise TorchrunRuntimeProvenanceError(
+                "Incomplete torchrun runtime provenance stdout write: "
+                f"frame {frame_index + 1}/{len(frames)} wrote {written} of {len(frame)} bytes"
+            )
+    return snapshot
+
+
+def _runtime_only_manifest(snapshot: RuntimeProvenance) -> RunManifest:
+    """Build the narrow carrier accepted by the canonical parity comparator."""
+
+    return RunManifest.model_construct(runtime_provenance=snapshot)
+
+
+def _require_rank_runtime_consistency(
+    snapshots_by_local_rank: Mapping[int, RuntimeProvenance],
+    *,
+    target: RuntimeParityTarget,
+) -> None:
+    ordered_ranks = sorted(snapshots_by_local_rank)
+    if not ordered_ranks:
+        raise TorchrunRuntimeProvenanceError(
+            "Torchrun runtime provenance contains no worker snapshots"
+        )
+
+    reference_rank = ordered_ranks[0]
+    reference = _runtime_only_manifest(snapshots_by_local_rank[reference_rank])
+    try:
+        # A self-comparison also rejects incomplete required provenance for a
+        # single-rank launch instead of postponing the failure to pair gating.
+        require_runtime_provenance_parity(reference, reference, target=target)
+        for local_rank in ordered_ranks[1:]:
+            candidate = _runtime_only_manifest(snapshots_by_local_rank[local_rank])
+            require_runtime_provenance_parity(reference, candidate, target=target)
+    except RuntimeProvenanceParityError as exc:
+        raise TorchrunRuntimeProvenanceError(
+            "Torchrun worker runtime provenance is incomplete or inconsistent "
+            f"relative to local rank {reference_rank}: {exc}"
+        ) from exc
+
+
+def _parse_frame_payload(encoded_payload: str, *, line_number: int) -> dict[str, Any]:
+    try:
+        payload = json.loads(encoded_payload)
+    except json.JSONDecodeError as exc:
+        raise TorchrunRuntimeProvenanceError(
+            f"Malformed torchrun runtime provenance JSON on stdout line {line_number}: {exc.msg}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise TorchrunRuntimeProvenanceError(
+            f"Torchrun runtime provenance line {line_number} must contain a JSON object"
+        )
+    payload_keys = frozenset(payload)
+    if payload_keys != _FRAME_KEYS:
+        missing = sorted(_FRAME_KEYS - payload_keys)
+        unexpected = sorted(payload_keys - _FRAME_KEYS)
+        raise TorchrunRuntimeProvenanceError(
+            "Torchrun runtime provenance frame fields differ from schema; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    if payload["s"] != TORCHRUN_RUNTIME_PROVENANCE_SCHEMA:
+        raise TorchrunRuntimeProvenanceError(
+            f"Unsupported torchrun runtime provenance schema {payload['s']!r}"
+        )
+    return payload
+
+
+def _validate_digest(value: Any) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != _SHA256_HEX_LENGTH
+        or value.lower() != value
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise TorchrunRuntimeProvenanceError(
+            f"Torchrun runtime provenance digest must be lowercase SHA-256 hex, got {value!r}"
+        )
+    return value
+
+
+def _decode_snapshot(*, metadata: _FrameMetadata, encoded_chunks: list[str]) -> RuntimeProvenance:
+    encoded_runtime = "".join(encoded_chunks)
+    try:
+        runtime_json = base64.b64decode(encoded_runtime.encode("ascii"), validate=True)
+    except (binascii.Error, UnicodeEncodeError, ValueError) as exc:
+        raise TorchrunRuntimeProvenanceError(
+            f"Invalid base64 runtime provenance payload for local rank {metadata.local_rank}"
+        ) from exc
+    actual_digest = hashlib.sha256(runtime_json).hexdigest()
+    if not hmac.compare_digest(actual_digest, metadata.digest):
+        raise TorchrunRuntimeProvenanceError(
+            "Torchrun runtime provenance digest mismatch for local rank " f"{metadata.local_rank}"
+        )
+    try:
+        runtime_payload = json.loads(runtime_json)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise TorchrunRuntimeProvenanceError(
+            f"Malformed runtime provenance payload for local rank {metadata.local_rank}: {exc}"
+        ) from exc
+    try:
+        snapshot = RuntimeProvenance.model_validate(runtime_payload)
+    except (ValidationError, TypeError, ValueError) as exc:
+        raise TorchrunRuntimeProvenanceError(
+            f"Invalid runtime provenance snapshot for local rank {metadata.local_rank}: {exc}"
+        ) from exc
+    if snapshot.process_id <= 0:
+        raise TorchrunRuntimeProvenanceError(
+            "Torchrun runtime provenance requires an actual process_id > 0; "
+            f"local rank {metadata.local_rank} reported {snapshot.process_id}"
+        )
+    if snapshot.process_id != metadata.process_id:
+        raise TorchrunRuntimeProvenanceError(
+            "Torchrun runtime provenance process ID differs between frame metadata and "
+            f"snapshot for local rank {metadata.local_rank}"
+        )
+    return snapshot
+
+
+def parse_torchrun_runtime_provenance_stdout(
+    raw_stdout: str,
+    *,
+    expected_local_ranks: Collection[int],
+    target: RuntimeParityTarget,
+) -> TorchrunRuntimeProvenanceParseResult:
+    """Reassemble and validate opted-in worker receipts from captured stdout.
+
+    Every recognized protocol frame is removed from ``clean_stdout``. Missing,
+    duplicate, partial, malformed, reordered, unexpected, or cross-rank-
+    inconsistent records fail closed.
+    """
+
+    if not isinstance(raw_stdout, str):
+        raise TypeError(f"raw_stdout must be str, got {type(raw_stdout).__name__}")
+    expected_sequence = tuple(expected_local_ranks)
+    if not expected_sequence:
+        raise ValueError("expected_local_ranks must contain at least local rank zero")
+    if any(type(rank) is not int or rank < 0 for rank in expected_sequence):
+        raise ValueError("expected_local_ranks must contain nonnegative plain integers")
+    if len(set(expected_sequence)) != len(expected_sequence):
+        raise ValueError("expected_local_ranks contains duplicates")
+    expected = set(expected_sequence)
+
+    clean_parts: list[str] = []
+    frame_groups: dict[int, tuple[_FrameMetadata, list[str]]] = {}
+    for line_number, line in enumerate(raw_stdout.splitlines(keepends=True), start=1):
+        content = line.rstrip("\r\n")
+        if TORCHRUN_RUNTIME_PROVENANCE_PREFIX not in content:
+            clean_parts.append(line)
+            continue
+        if not line.endswith("\n"):
+            raise TorchrunRuntimeProvenanceError(
+                f"Incomplete torchrun runtime provenance frame on stdout line {line_number}"
+            )
+        if not content.startswith(TORCHRUN_RUNTIME_PROVENANCE_PREFIX):
+            raise TorchrunRuntimeProvenanceError(
+                "Malformed torchrun runtime provenance prefix placement on stdout "
+                f"line {line_number}"
+            )
+        payload = _parse_frame_payload(
+            content[len(TORCHRUN_RUNTIME_PROVENANCE_PREFIX) :],
+            line_number=line_number,
+        )
+
+        local_rank = _require_plain_int(payload["lr"], field_name="local_rank", minimum=0)
+        rank = _require_plain_int(payload["r"], field_name="rank", minimum=0)
+        world_size = _require_plain_int(payload["ws"], field_name="world_size", minimum=1)
+        local_world_size = _require_plain_int(
+            payload["lws"], field_name="local_world_size", minimum=1
+        )
+        process_id = _require_plain_int(payload["p"], field_name="process_id", minimum=1)
+        frame_index = _require_plain_int(payload["i"], field_name="frame_index", minimum=0)
+        frame_count = _require_plain_int(payload["n"], field_name="frame_count", minimum=1)
+        digest = _validate_digest(payload["h"])
+        data = payload["d"]
+        if not isinstance(data, str):
+            raise TorchrunRuntimeProvenanceError(
+                f"Torchrun runtime provenance frame data must be a string, got {type(data).__name__}"
+            )
+        _validate_rank_metadata(
+            rank=rank,
+            local_rank=local_rank,
+            world_size=world_size,
+            local_world_size=local_world_size,
+        )
+        if frame_index >= frame_count:
+            raise TorchrunRuntimeProvenanceError(
+                "Torchrun runtime provenance frame index is outside its declared frame count"
+            )
+
+        metadata = _FrameMetadata(
+            rank=rank,
+            local_rank=local_rank,
+            world_size=world_size,
+            local_world_size=local_world_size,
+            process_id=process_id,
+            frame_count=frame_count,
+            digest=digest,
+        )
+        existing = frame_groups.get(local_rank)
+        if existing is None:
+            if frame_index != 0:
+                raise TorchrunRuntimeProvenanceError(
+                    "Torchrun runtime provenance frame sequence must start at zero for "
+                    f"local rank {local_rank}, got {frame_index}"
+                )
+            frame_groups[local_rank] = (metadata, [data])
+            continue
+
+        existing_metadata, encoded_chunks = existing
+        if metadata != existing_metadata:
+            raise TorchrunRuntimeProvenanceError(
+                "Torchrun runtime provenance frame metadata changed within local rank "
+                f"{local_rank}"
+            )
+        expected_frame_index = len(encoded_chunks)
+        if frame_index < expected_frame_index:
+            raise TorchrunRuntimeProvenanceError(
+                "Duplicate torchrun runtime provenance frame "
+                f"{frame_index} for local rank {local_rank}"
+            )
+        if frame_index != expected_frame_index:
+            raise TorchrunRuntimeProvenanceError(
+                "Torchrun runtime provenance frame sequence is missing or reordered for "
+                f"local rank {local_rank}: expected {expected_frame_index}, got {frame_index}"
+            )
+        encoded_chunks.append(data)
+
+    observed = set(frame_groups)
+    if observed != expected:
+        raise TorchrunRuntimeProvenanceError(
+            "Torchrun runtime provenance rank set mismatch; "
+            f"missing={sorted(expected - observed)}, unexpected={sorted(observed - expected)}"
+        )
+
+    records: dict[int, tuple[_FrameMetadata, RuntimeProvenance]] = {}
+    for local_rank, (metadata, encoded_chunks) in frame_groups.items():
+        if len(encoded_chunks) != metadata.frame_count:
+            raise TorchrunRuntimeProvenanceError(
+                "Incomplete torchrun runtime provenance frame sequence for local rank "
+                f"{local_rank}: expected {metadata.frame_count}, observed {len(encoded_chunks)}"
+            )
+        records[local_rank] = (
+            metadata,
+            _decode_snapshot(metadata=metadata, encoded_chunks=encoded_chunks),
+        )
+
+    expected_count = len(expected)
+    declared_world_sizes = {record[0].world_size for record in records.values()}
+    declared_local_world_sizes = {record[0].local_world_size for record in records.values()}
+    if len(declared_world_sizes) != 1 or len(declared_local_world_sizes) != 1:
+        raise TorchrunRuntimeProvenanceError(
+            "Torchrun runtime provenance ranks disagree on world-size metadata"
+        )
+    declared_local_world_size = next(iter(declared_local_world_sizes))
+    if declared_local_world_size != expected_count:
+        raise TorchrunRuntimeProvenanceError(
+            "Torchrun runtime provenance record count differs from local_world_size: "
+            f"expected {declared_local_world_size}, observed {expected_count}"
+        )
+    global_ranks = [record[0].rank for record in records.values()]
+    if len(set(global_ranks)) != expected_count:
+        raise TorchrunRuntimeProvenanceError(
+            "Torchrun runtime provenance contains duplicate global ranks"
+        )
+    process_ids = [record[0].process_id for record in records.values()]
+    if len(set(process_ids)) != expected_count:
+        raise TorchrunRuntimeProvenanceError(
+            "Torchrun runtime provenance contains duplicate worker process IDs"
+        )
+
+    snapshots = {local_rank: records[local_rank][1] for local_rank in sorted(records)}
+    _require_rank_runtime_consistency(snapshots, target=target)
+    return TorchrunRuntimeProvenanceParseResult(
+        raw_stdout=raw_stdout,
+        clean_stdout="".join(clean_parts),
+        snapshots_by_local_rank=snapshots,
+        execution_process_ids={
+            local_rank: records[local_rank][0].process_id for local_rank in sorted(records)
+        },
+    )
+
+
+__all__ = [
+    "TORCHRUN_RUNTIME_PROVENANCE_PREFIX",
+    "TORCHRUN_RUNTIME_PROVENANCE_SCHEMA",
+    "TorchrunRuntimeProvenanceError",
+    "TorchrunRuntimeProvenanceParseResult",
+    "emit_torchrun_runtime_provenance",
+    "format_torchrun_runtime_provenance_frames",
+    "parse_torchrun_runtime_provenance_stdout",
+]

--- a/code/core/harness/torchrun_wrapper.py
+++ b/code/core/harness/torchrun_wrapper.py
@@ -6,6 +6,8 @@ multi-process benchmarks.
 Currently enforced:
 - RNG seed immutability: benchmarks must not reseed away from the harness-
   configured seeds (default seed=42).
+- Optional per-rank runtime provenance, captured only after successful target
+  execution and seed validation.
 
 The harness launches torchrun with this wrapper as the entrypoint and passes the
 original benchmark script path + args through unchanged.
@@ -19,12 +21,12 @@ import random
 import runpy
 import sys
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 import torch
 
 from core.harness.backend_policy import BackendPolicyName, apply_backend_policy
+from core.harness.torchrun_runtime_provenance import emit_torchrun_runtime_provenance
 from core.utils.python_entrypoints import temporary_sys_path
 
 
@@ -40,7 +42,7 @@ def _set_seeds(seed: int) -> None:
         torch.cuda.manual_seed_all(seed)
 
 
-def _parse_int_env(name: str) -> Optional[int]:
+def _parse_int_env(name: str) -> int | None:
     value = os.environ.get(name)
     if value is None or value == "":
         return None
@@ -83,7 +85,7 @@ def _run_target_module(module_name: str, argv: list[str]) -> None:
 
 
 def _run_profiled_target(
-    script_path: Optional[Path], module_name: Optional[str], argv: list[str]
+    script_path: Path | None, module_name: str | None, argv: list[str]
 ) -> None:
     def run_target() -> None:
         try:
@@ -119,7 +121,7 @@ def _run_profiled_target(
     profiler.export_chrome_trace(str(trace_path))
 
 
-def main(argv: Optional[list[str]] = None) -> None:
+def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(add_help=True)
     parser.add_argument(
         "--aisp-target-script",
@@ -148,15 +150,18 @@ def main(argv: Optional[list[str]] = None) -> None:
         action="store_true",
         help="Enable deterministic algorithms (mirrors harness deterministic mode).",
     )
+    parser.add_argument(
+        "--aisp-emit-runtime-provenance",
+        action="store_true",
+        help="Emit one atomic runtime-provenance receipt after successful execution.",
+    )
     args, remainder = parser.parse_known_args(argv)
 
     if bool(args.aisp_target_script) == bool(args.aisp_target_module):
-        raise RuntimeError(
-            "Specify exactly one of --aisp-target-script or --aisp-target-module."
-        )
+        raise RuntimeError("Specify exactly one of --aisp-target-script or --aisp-target-module.")
 
-    script_path: Optional[Path] = None
-    module_name: Optional[str] = None
+    script_path: Path | None = None
+    module_name: str | None = None
     if args.aisp_target_script:
         script_path = Path(args.aisp_target_script).resolve()
         if not script_path.exists():
@@ -168,7 +173,7 @@ def main(argv: Optional[list[str]] = None) -> None:
     _set_seeds(int(args.aisp_expected_torch_seed))
 
     expected_torch_seed = int(args.aisp_expected_torch_seed)
-    expected_cuda_seed: Optional[int] = args.aisp_expected_cuda_seed
+    expected_cuda_seed: int | None = args.aisp_expected_cuda_seed
 
     lock_requested = os.environ.get("AISP_LOCK_GPU_CLOCKS") == "1"
     ramp_requested = os.environ.get("AISP_RAMP_GPU_CLOCKS", "1") == "1"
@@ -212,6 +217,9 @@ def main(argv: Optional[list[str]] = None) -> None:
                 f"Expected torch.cuda.initial_seed()={int(expected_cuda_seed)}, got {current_cuda_seed}. "
                 "Benchmarks MUST NOT reseed; rely on harness-configured seeds."
             )
+
+    if args.aisp_emit_runtime_provenance:
+        emit_torchrun_runtime_provenance(local_rank=local_rank)
 
 
 if __name__ == "__main__":

--- a/code/core/harness/validity_checks.py
+++ b/code/core/harness/validity_checks.py
@@ -21,6 +21,7 @@ import statistics
 import sys
 import time
 import warnings
+from collections.abc import Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field, fields
 from datetime import datetime, timezone
@@ -1135,6 +1136,8 @@ def validate_environment(
     probe: Optional[EnvironmentProbe] = None,
     allow_virtualization: bool = False,
     allow_foreign_gpu_processes: bool = False,
+    expected_device_uuid: str | None = None,
+    expected_compute_capability: str | Sequence[int] | None = None,
 ) -> EnvironmentValidationResult:
     """Validate benchmark environment is suitable (fail-fast on known invalid states)."""
     probe = probe or EnvironmentProbe()
@@ -1145,6 +1148,38 @@ def validate_environment(
     details: Dict[str, Any] = {
         "platform": sys.platform,
     }
+
+    identity_expectation = None
+    identity_expectation_requested = (
+        expected_device_uuid is not None or expected_compute_capability is not None
+    )
+    if identity_expectation_requested:
+        try:
+            from core.harness.device_identity_contract import (
+                build_device_identity_expectation,
+            )
+
+            identity_expectation = build_device_identity_expectation(
+                expected_device_uuid,
+                expected_compute_capability,
+            )
+        except Exception as exc:
+            errors.append(f"Expected GPU identity contract is invalid: {exc}.")
+        else:
+            if identity_expectation is None:
+                errors.append("Expected GPU identity contract was requested but no expectation was built.")
+            else:
+                details.update(
+                    {
+                        "expected_device_uuid": identity_expectation.expected_uuid,
+                        "expected_compute_capability": (
+                            identity_expectation.expected_compute_capability
+                        ),
+                        "observed_device_uuid": None,
+                        "observed_cuda_device_uuid": None,
+                        "observed_compute_capability": None,
+                    }
+                )
 
     if not sys.platform.startswith("linux"):
         errors.append(f"Non-Linux platform '{sys.platform}' is not supported for benchmark validity checks.")
@@ -1169,6 +1204,10 @@ def validate_environment(
     if device.type == "cuda":
         if torch is None or not torch.cuda.is_available():
             errors.append("CUDA device requested but CUDA is not available (missing /dev/nvidia* or driver issue).")
+            if identity_expectation is not None:
+                errors.append(
+                    "Expected GPU identity/capability is unavailable because CUDA is not available."
+                )
         else:
             gpu_count = torch.cuda.device_count()
             details["gpu_count"] = gpu_count
@@ -1178,6 +1217,43 @@ def validate_environment(
                 )
             device_index = int(device.index) if device.index is not None else int(torch.cuda.current_device())
             details["gpu_device_index"] = device_index
+            if identity_expectation is not None:
+                from core.harness.device_identity_contract import (
+                    DeviceIdentityContract,
+                    observe_cuda_device_identity,
+                    validate_device_identity,
+                )
+
+                identity_contract = DeviceIdentityContract(device, identity_expectation)
+                try:
+                    identity_contract.establish_configured_device()
+                    identity_observation = observe_cuda_device_identity(device)
+                    details.update(
+                        {
+                            "observed_device_uuid": identity_observation.nvml_uuid,
+                            "observed_cuda_device_uuid": identity_observation.cuda_uuid,
+                            "observed_compute_capability": (
+                                identity_observation.compute_capability
+                            ),
+                        }
+                    )
+                    validate_device_identity(
+                        identity_expectation,
+                        identity_observation,
+                        "environment_validation",
+                    )
+                except Exception as exc:
+                    errors.append(
+                        f"Expected GPU identity/capability validation failed: {exc}"
+                    )
+                finally:
+                    try:
+                        identity_contract.restore_entry_device()
+                    except Exception as exc:
+                        errors.append(
+                            "Failed to restore the CUDA device after expected GPU identity "
+                            f"validation: {exc}"
+                        )
             # Only perform live process checks against the real host filesystem.
             if probe.root.resolve() == Path("/"):
                 details["allow_foreign_gpu_processes"] = bool(allow_foreign_gpu_processes)
@@ -1275,6 +1351,11 @@ def validate_environment(
                             errors.append(msg)
             else:
                 details["foreign_cuda_compute_processes"] = []
+    elif identity_expectation is not None:
+        errors.append(
+            "Expected GPU identity/capability cannot be observed for configured "
+            f"device type {device.type!r}; configure a CUDA device."
+        )
 
     # Swap interference (Memory category)
     swaps = _read_optional(probe, "/proc/swaps")

--- a/code/core/scripts/refresh_readmes.py
+++ b/code/core/scripts/refresh_readmes.py
@@ -2339,7 +2339,17 @@ ENTRIES["ch13"] = chapter_entry(
 
                 This chapter is one of the easiest places to fool yourself with framework overhead. That is why the benchmark contract and side-by-side baseline/optimized structure matter here more than almost anywhere else.
 
-                The prior `precisionfp8_te` number compared eager FP16 with CUDA-graph-replayed FP8, so it is retired. The pair now runs both sides eagerly to isolate Transformer Engine FP8; publish a new speed result only after a fresh B200 correctness and timing run."""
+                The prior `precisionfp8_te` number compared eager FP16 with CUDA-graph-replayed FP8, so it is retired. The pair now runs both sides eagerly to isolate Transformer Engine FP8; publish a new speed result only after a fresh B200 correctness and timing run.
+
+                The TE 2.18 pair now verifies its captured prediction and every post-step parameter with a calibrated per-output policy. Previously, all outputs inherited the global `(rtol=0.5, atol=5.0)` threshold. B200 calibration of the unchanged batch-256, hidden-4096 training step selected these stricter budgets across seed 44 and fixed holdouts 45, 1044, and 1045:
+
+                | Captured outputs | Calibrated `(rtol, atol)` | Largest observed absolute error |
+                | --- | --- | --- |
+                | Prediction | `(0.4, 1.0)` | `0.5949707` |
+                | Both weight tensors | `(0.001, 0.00075)` | `0.000534058` |
+                | Both bias tensors | `(0.001, 0.00005)` | `0.000041008` |
+
+                The frozen map passed all holdouts and independently rejected zeroed and localized corrupted copies of all five outputs. These bounds apply to this TE 2.18 workload and establish numerical verification only; they do not establish a speedup."""
             ),
         ),
         MarkdownSection(

--- a/code/docs/benchmark_harness_guide.md
+++ b/code/docs/benchmark_harness_guide.md
@@ -381,6 +381,25 @@ result = compare_benchmarks(
 - Full statistics for both benchmarks
 - Complete `BenchmarkResult` objects for further analysis
 
+Benchmarks whose verification output contains tensors with different numeric
+scales can opt into exact-keyed tolerances:
+
+```python
+def get_output_tolerances(self) -> dict[str, tuple[float, float]]:
+    return {
+        "prediction": (0.4, 1.0),
+        "parameter.weight": (1e-3, 7.5e-4),
+        "parameter.bias": (1e-3, 5e-5),
+    }
+```
+
+The map must cover every key returned by `get_verify_output()`. Baseline and
+optimized maps must be identical, and every `rtol` and `atol` must be finite
+and nonnegative. The existing `get_output_tolerance()` tuple remains required
+as global compatibility metadata. When the per-output hook is present, numeric
+comparison uses the keyed map and records it under
+`verification.output_tolerances`.
+
 **Use case**: Automatic performance regression detection in CI/CD.
 
 ---

--- a/code/labs/train_distributed/optimized_ddp.py
+++ b/code/labs/train_distributed/optimized_ddp.py
@@ -58,7 +58,10 @@ def main():
 
     if not dist.is_initialized():
         if "RANK" in os.environ and "WORLD_SIZE" in os.environ:
-            dist.init_process_group(backend="nccl", device_id=local_rank)
+            if int(os.environ["WORLD_SIZE"]) > 1:
+                dist.init_process_group(backend="nccl", device_id=local_rank)
+            else:
+                dist.init_process_group(backend="nccl")
         else:
             raise RuntimeError(
                 "DDP optimized run requires torch.distributed process group to be initialized."

--- a/code/labs/train_distributed/optimized_ddp.py
+++ b/code/labs/train_distributed/optimized_ddp.py
@@ -69,7 +69,9 @@ def main():
     is_main = rank == 0
     active_seed = initialize_ddp_seed()
     configure_training_matmul_policy()
-    use_ddp = dist.is_initialized()
+    # One rank has no peer gradients to reduce. Keep the distributed sampler
+    # below so removing the reducer does not change seeded input order.
+    use_ddp = world_size > 1
     tokenizer = build_tokenizer()
     dataset = get_dataset()["train"]
 
@@ -79,7 +81,7 @@ def main():
         batch_size=args.batch_size,
         shuffle=True,
         drop_last=True,
-        distributed=use_ddp,
+        distributed=True,
         num_workers=4,
         prefetch_factor=4,
         pin_memory=True,

--- a/code/tests/evaluation_contract_test_utils.py
+++ b/code/tests/evaluation_contract_test_utils.py
@@ -1,0 +1,75 @@
+"""Exercise declared evaluation policies through real harness execution."""
+
+from datetime import datetime, timezone
+
+import torch
+
+from core.benchmark.evaluation_provenance import FeatureLineage, TemporalSplitBoundary
+from tests.test_evaluation_harness_integration import EvaluationLifecycleBenchmark, _harness
+
+
+def assert_evaluation_contract_controls(tmp_path, fault):
+    """Accept a clean workload and reject one explicit contract violation.
+
+    These are declared sample-ID/lineage policies, not semantic contamination
+    inference. Source identity compares the actual file before and after work.
+    """
+    expected_codes = {
+        "train_test_overlap": "sample_id_overlap",
+        "holdout_overlap": "sample_id_overlap",
+        "feature_label": "feature_label_lineage_overlap",
+        "missing_holdout": "required_holdout_missing",
+        "temporal_overlap": "temporal_split_overlap",
+        "source": "protected_source_mutated",
+        "threshold": "evaluator_threshold_drift",
+    }
+
+    class DeclaredEvaluation(EvaluationLifecycleBenchmark):
+        violation = None
+
+        def get_evaluation_contract(self):
+            contract = super().get_evaluation_contract()
+            assert contract is not None
+            splits = dict(contract.sample_ids_by_split)
+            if self.violation == "train_test_overlap":
+                splits["test"] = splits["train"]
+            elif self.violation == "holdout_overlap":
+                splits["holdout"] = splits["test"]
+            elif self.violation == "missing_holdout":
+                splits.pop("holdout")
+            contract = contract.model_copy(update={"sample_ids_by_split": splits})
+            if self.violation == "feature_label":
+                return contract.model_copy(update={"feature_lineage": (
+                    FeatureLineage(feature="value", source_fields=("label",)),
+                )})
+            if self.violation == "temporal_overlap":
+                return contract.model_copy(update={
+                    "split_strategy": "temporal",
+                    "temporal_boundaries": tuple(
+                        TemporalSplitBoundary(
+                            split=split,
+                            start=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                            end=datetime(2026, 2, 1, tzinfo=timezone.utc),
+                        ) for split in splits
+                    ),
+                })
+            return contract
+
+    for violation in (None, fault):
+        source = tmp_path / f"protected-{violation}.py"
+        source.write_text("THRESHOLD = 0.5\n")
+        work = DeclaredEvaluation()
+        work.protected_path = str(source)
+        work.violation = violation
+        if violation in ("source", "threshold"):
+            work.mutation_phase = f"timing_{violation}"
+        result = _harness().benchmark(work)
+        assert result.evaluation is not None
+        if violation is None:
+            assert result.evaluation.status == "PASS", result.errors
+            assert result.timing.iterations > 0
+            torch.testing.assert_close(work.output, torch.tensor([2.0]), rtol=0, atol=0)
+        else:
+            assert result.evaluation.status == "FAIL"
+            assert result.timing.iterations == 0
+            assert expected_codes[violation] in {f.code for f in result.evaluation.failures}

--- a/code/tests/protection_test_utils.py
+++ b/code/tests/protection_test_utils.py
@@ -120,6 +120,39 @@ def cpu_harness(**kwargs):
     return BenchmarkHarness(config=config), config
 
 
+def assert_expected_cuda_identity_controls(mismatch):
+    """Use live CUDA/NVML identity and the real host environment validator."""
+    from core.harness.device_identity_contract import observe_cuda_device_identity
+    from core.harness.validity_checks import validate_environment
+
+    if not torch.cuda.is_available():
+        pytest.skip("real CUDA expected-identity protection requires a device")
+    device = torch.device("cuda", torch.cuda.current_device())
+    observed = observe_cuda_device_identity(device)
+    kwargs = dict(
+        device=device,
+        allow_virtualization=True,
+        expected_device_uuid=observed.nvml_uuid,
+        expected_compute_capability=observed.compute_capability,
+    )
+    clean = validate_environment(**kwargs)
+    assert clean.is_valid, clean.errors
+    if mismatch == "compute_capability":
+        kwargs["expected_compute_capability"] = "9.0" if observed.compute_capability != "9.0" else "10.0"
+        expected_message = "Expected compute capability mismatch"
+    elif mismatch == "device_uuid":
+        wrong = "GPU-12345678-1234-5678-1234-567812345678"
+        if wrong == observed.nvml_uuid:
+            wrong = "GPU-87654321-4321-8765-4321-876543218765"
+        kwargs["expected_device_uuid"] = wrong
+        expected_message = "Expected GPU UUID mismatch"
+    else:
+        raise ValueError(f"unknown identity violation {mismatch}")
+    rejected = validate_environment(**kwargs)
+    assert not rejected.is_valid
+    assert any(expected_message in error for error in rejected.errors), rejected.errors
+
+
 def compare_tensors(runner, expected, actual, tolerance=None):
     return runner._compare_outputs({"output": expected}, {"output": actual}, tolerance)
 

--- a/code/tests/runtime_version_test_utils.py
+++ b/code/tests/runtime_version_test_utils.py
@@ -1,0 +1,55 @@
+"""Actual CUDA execution plus explicit runtime-receipt admission controls."""
+
+import pytest
+import torch
+
+from core.benchmark.runtime_comparison import compare_executed_runtime_provenance
+from core.harness.benchmark_harness import BenchmarkHarness, BenchmarkMode
+from tests.test_evaluation_harness_integration import _benchmark, _harness
+
+
+def assert_runtime_version_controls(tmp_path, field):
+    """Retain live versions; mutate a copied receipt to exercise rejection only.
+
+    This does not install another driver or library, and installed package
+    metadata does not claim to identify the native cuBLAS library loaded.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("real CUDA worker runtime/version admission requires a device")
+    config = _harness().config
+    config.device = torch.device("cuda", torch.cuda.current_device())
+    config.validity_profile = "portable"
+    config.allow_virtualization = True
+    config.enforce_environment_validation = True
+    runs = []
+    for arm in ("reference", "candidate"):
+        benchmark = _benchmark(tmp_path)
+        benchmark.device = config.device
+        run = BenchmarkHarness(mode=BenchmarkMode.CUSTOM, config=config).benchmark_with_manifest(
+            benchmark, run_id=f"runtime-version-{arm}",
+        )
+        assert not run.result.errors, run.result.errors
+        torch.testing.assert_close(
+            benchmark.get_verify_output(), torch.tensor([2.0], device=config.device),
+            rtol=0.0, atol=0.0,
+        )
+        runs.append(run)
+    comparison = compare_executed_runtime_provenance(*runs)
+    assert comparison.matches, comparison.model_dump()
+    assert comparison.target == "cuda"
+    observed = runs[1].result.runtime_provenance
+    assert observed.cudnn_version == str(torch.backends.cudnn.version())
+    assert observed.driver_version
+    assert observed.library_versions_complete and observed.library_versions
+
+    changed = runs[1].model_copy(deep=True)
+    if field == "library_versions":
+        changed.result.runtime_provenance.library_versions["torch"] += "-receipt-corruption"
+    else:
+        value = getattr(changed.result.runtime_provenance, field)
+        assert value is not None
+        setattr(changed.result.runtime_provenance, field, str(value) + "-receipt-corruption")
+    changed.manifest.runtime_provenance = changed.result.runtime_provenance.model_copy(deep=True)
+    rejected = compare_executed_runtime_provenance(runs[0], changed)
+    assert not rejected.matches
+    assert field in rejected.runtime_parity.mismatched_fields

--- a/code/tests/test_anti_cheat_edge_cases.py
+++ b/code/tests/test_anti_cheat_edge_cases.py
@@ -16,9 +16,11 @@ import torch
 
 from core.benchmark.verification import InputSignature, PrecisionFlags, ToleranceSpec
 from core.benchmark.verify_runner import VerifyConfig
+from tests.evaluation_contract_test_utils import assert_evaluation_contract_controls
 from tests.protection_test_utils import (
     TensorWork, assert_comparison_controls, assert_compile_cache_reset,
     assert_compile_guard_counts, assert_config_immutability, assert_environment_controls,
+    assert_expected_cuda_identity_controls,
     assert_gpu_state_controls, assert_materialization_diagnostic,
     assert_memory_pattern_controls, assert_signature_controls,
     assert_stream_audit_controls, check_jitter, compare_tensors, cpu_harness,
@@ -133,8 +135,19 @@ class TestTimingEdgeCases:
         assert_gpu_state_controls(clock_mhz=800)
 
     def test_profiler_overhead_nested_profilers(self):
-        'Requirement remains open; this retained test ID is not passing coverage.'
-        pytest.skip('Missing production protection: no nested-profiler rejection guard is implemented; a single profiler context did not test nesting')
+        'An actual enclosing profiler must be rejected before timing begins.'
+        harness, config = cpu_harness()
+        outputs = []
+        def work():
+            outputs.append(torch.ones(8) + 1)
+        with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU]):
+            with pytest.raises(RuntimeError, match='Active PyTorch profiler'):
+                harness._benchmark_custom(work, config)
+        assert not outputs
+        times, _ = harness._benchmark_custom(work, config)
+        assert len(times) == len(outputs) == config.iterations
+        for output in outputs:
+            torch.testing.assert_close(output, torch.full((8,), 2.0), rtol=0, atol=0)
 
 
 
@@ -287,9 +300,8 @@ class TestWorkloadEdgeCases:
         'Production signature equivalence rejects changed workload metadata, including zero batch versus nonzero.'
         assert_signature_controls(shapes={'input': (4, 7)})
 
-    def test_train_test_overlap_single_sample(self):
-        'Requirement remains open; this retained test ID is not passing coverage.'
-        pytest.skip('Missing production protection: no dataset provenance, feature-label leakage or holdout-overlap detector is implemented')
+    def test_train_test_overlap_single_sample(self, tmp_path):
+        assert_evaluation_contract_controls(tmp_path, 'train_test_overlap')
 
 
 
@@ -548,8 +560,7 @@ class TestDistributedEdgeCases:
 
 class TestEnvironmentEdgeCases:
     def test_device_mismatch_compute_capability(self):
-        'Requirement remains open; this retained test ID is not passing coverage.'
-        pytest.skip('Missing production protection: no expected-versus-observed compute-capability comparison is performed by validate_environment')
+        assert_expected_cuda_identity_controls('compute_capability')
 
     def test_frequency_boost_detection(self):
         'Exercise clock-change diagnostics without claiming a live GPU clock lock.'
@@ -613,9 +624,9 @@ class TestEnvironmentEdgeCases:
         assert observed['driver_version'] == actual_driver
         assert observed['version'] == torch.version.cuda
 
-    def test_library_version_cudnn(self):
-        'Requirement remains open; this retained test ID is not passing coverage.'
-        pytest.skip('Missing production protection: RunManifest does not record cuDNN version or compare baseline/optimized library versions')
+    def test_library_version_cudnn(self, tmp_path):
+        from tests.runtime_version_test_utils import assert_runtime_version_controls
+        assert_runtime_version_controls(tmp_path, "cudnn_version")
 
     def test_container_cgroup_limits(self, tmp_path, monkeypatch):
         assert_environment_controls(tmp_path, monkeypatch, 'memory_limit')
@@ -721,21 +732,17 @@ class TestEvaluationEdgeCases:
     def test_timeout_manipulation_extend(self):
         assert_config_immutability('timeout_seconds', 999)
 
-    def test_metric_gaming_threshold_tuning(self):
-        'Requirement remains open; this retained test ID is not passing coverage.'
-        pytest.skip('Missing production protection: no evaluation-threshold policy or dataset evaluator contract is implemented')
+    def test_metric_gaming_threshold_tuning(self, tmp_path):
+        assert_evaluation_contract_controls(tmp_path, 'threshold')
 
-    def test_data_leakage_feature_from_label(self):
-        'Requirement remains open; this retained test ID is not passing coverage.'
-        pytest.skip('Missing production protection: no dataset provenance, feature-label leakage or holdout-overlap detector is implemented')
+    def test_data_leakage_feature_from_label(self, tmp_path):
+        assert_evaluation_contract_controls(tmp_path, 'feature_label')
 
-    def test_overfitting_train_on_test(self):
-        'Requirement remains open; this retained test ID is not passing coverage.'
-        pytest.skip('Missing production protection: no dataset provenance, feature-label leakage or holdout-overlap detector is implemented')
+    def test_overfitting_train_on_test(self, tmp_path):
+        assert_evaluation_contract_controls(tmp_path, 'train_test_overlap')
 
-    def test_self_modifying_immutable_test(self):
-        'Requirement remains open; this retained test ID is not passing coverage.'
-        pytest.skip('Missing production protection: no test-source immutability guard is implemented in the benchmark protection path')
+    def test_self_modifying_immutable_test(self, tmp_path):
+        assert_evaluation_contract_controls(tmp_path, 'source')
 
     def test_memorization_hash_detection(self, runner):
         assert check_jitter(runner, 'real') == (True, None)
@@ -743,9 +750,9 @@ class TestEvaluationEdgeCases:
         assert not passed
         assert 'output unchanged' in reason
 
-    def test_missing_holdout_temporal_split(self):
-        'Requirement remains open; this retained test ID is not passing coverage.'
-        pytest.skip('Missing production protection: no dataset provenance, feature-label leakage or holdout-overlap detector is implemented')
+    def test_missing_holdout_temporal_split(self, tmp_path):
+        assert_evaluation_contract_controls(tmp_path, 'missing_holdout')
+        assert_evaluation_contract_controls(tmp_path, 'temporal_overlap')
 
 
 

--- a/code/tests/test_anti_cheat_protections.py
+++ b/code/tests/test_anti_cheat_protections.py
@@ -1473,8 +1473,9 @@ class TestEvaluationProtectionsExtended:
 class TestReproducibilityProtections:
     """Tests for reproducibility protections."""
 
-    def test_version_locking_in_manifest(self):
-        pytest.skip('Missing production protection: version provenance capture does not enforce version locking')
+    def test_version_locking_in_manifest(self, tmp_path):
+        from tests.runtime_version_test_utils import assert_runtime_version_controls
+        assert_runtime_version_controls(tmp_path, "torch_version")
 
     def test_seed_determinism(self, runner):
         work = TensorWork()

--- a/code/tests/test_anti_cheat_protections.py
+++ b/code/tests/test_anti_cheat_protections.py
@@ -4,8 +4,8 @@
 CPU detector tests run without CUDA. GPU integration/smoke tests require actual
 hardware and do not count as passed on CPU. A diagnostic state or timing fixture
 is not a GPU measurement. Legacy statistical names check reporting fidelity,
-not an unimplemented outlier/cherry-picking classifier. Missing dataset
-provenance protections are explicit skips, not passing conceptual assertions.
+not an unimplemented outlier/cherry-picking classifier. Dataset checks exercise
+the explicit evaluation contract; semantic contamination inference is not claimed.
 The number of test functions does not establish coverage of every README claim.
 """
 
@@ -19,11 +19,13 @@ from contextlib import contextmanager
 
 import pytest
 import torch
+from tests.evaluation_contract_test_utils import assert_evaluation_contract_controls
 
 from tests.protection_test_utils import (
     TensorWork, assert_comparison_controls, assert_compile_cache_reset,
     assert_compile_guard_counts, assert_cuda_timing_cross_validation,
     assert_environment_controls, assert_gpu_state_controls,
+    assert_expected_cuda_identity_controls,
     assert_materialization_diagnostic, assert_signature_controls,
     assert_stream_audit_controls, audit_cuda_work, check_fresh_input, check_jitter, compare_tensors,
     cpu_harness, make_runner, preserve_rng_state,
@@ -668,7 +670,7 @@ class TestEnvironmentProtections:
     """Tests for environment-related anti-cheat protections."""
 
     def test_device_mismatch_validation(self):
-        pytest.skip('Missing production protection: validate_environment does not compare expected and observed GPU identities')
+        assert_expected_cuda_identity_controls('device_uuid')
 
     def test_frequency_boost_clock_locking(self):
         """Observe real requested application clocks before and after CUDA work."""
@@ -829,8 +831,8 @@ class TestEvaluationProtections:
     def test_timeout_manipulation_immutability(self):
         _check_config_mutation('timeout_seconds', 999)
 
-    def test_test_data_leakage_contamination_check(self):
-        pytest.skip("Missing protection: no dataset provenance/holdout-overlap detector is implemented; set arithmetic is not detector coverage")
+    def test_test_data_leakage_contamination_check(self, tmp_path):
+        assert_evaluation_contract_controls(tmp_path, 'holdout_overlap')
 
     def test_benchmark_overfitting_jitter_fresh(self, runner):
         _check_jitter_controls(runner)
@@ -1004,8 +1006,8 @@ class TestWorkloadProtectionsExtended:
         assert baseline.matches(baseline)
         assert not baseline.matches(optimized)
 
-    def test_train_test_overlap_detection(self):
-        pytest.skip("Missing protection: no dataset provenance/holdout-overlap detector is implemented; set arithmetic is not detector coverage")
+    def test_train_test_overlap_detection(self, tmp_path):
+        assert_evaluation_contract_controls(tmp_path, 'train_test_overlap')
 
     def test_batch_shrinking_detection(self):
         """Test that batch shrinking is detected.
@@ -1382,11 +1384,13 @@ class TestEnvironmentProtectionsExtended:
             result = harness._benchmark_with_threading(bench, config)
             assert any("ENVIRONMENT INVALID" in err and "CPU governor mismatch" in err for err in result.errors), result.errors
 
-    def test_driver_version_mismatch_detection(self):
-        pytest.skip('Missing production protection: RunManifest records a driver version but no cross-run driver-version lock is enforced')
+    def test_driver_version_mismatch_detection(self, tmp_path):
+        from tests.runtime_version_test_utils import assert_runtime_version_controls
+        assert_runtime_version_controls(tmp_path, "driver_version")
 
-    def test_library_version_mismatch_detection(self):
-        pytest.skip('Missing production protection: RunManifest does not record cuDNN/cuBLAS version parity or enforce a cross-run library lock')
+    def test_library_version_mismatch_detection(self, tmp_path):
+        from tests.runtime_version_test_utils import assert_runtime_version_controls
+        assert_runtime_version_controls(tmp_path, "library_versions")
 
     def test_container_resource_limits_handling(self, tmp_path, monkeypatch):
         assert_environment_controls(tmp_path, monkeypatch, 'cpu_quota')
@@ -1458,8 +1462,8 @@ class TestEvaluationProtectionsExtended:
         """Reject cached results; allocating an output buffer is not itself cheating."""
         _check_fresh_controls(runner)
 
-    def test_missing_holdout_sets_handling(self):
-        pytest.skip("Missing protection: no dataset provenance/holdout-overlap detector is implemented; set arithmetic is not detector coverage")
+    def test_missing_holdout_sets_handling(self, tmp_path):
+        assert_evaluation_contract_controls(tmp_path, 'missing_holdout')
 
 
 # =============================================================================

--- a/code/tests/test_audit_wave1_harness.py
+++ b/code/tests/test_audit_wave1_harness.py
@@ -170,7 +170,7 @@ def _summary_payload():
         iterations=100, warmup_iterations=7, p99_ms=24.0,
         percentiles={99.0: 24.0}, raw_times_ms=None,
     )
-    return {"success": True, "result_json": BenchmarkResult(timing=timing).model_dump_json()}
+    return {"success": True, "result_json": BenchmarkResult(timing=timing, device="cpu").model_dump_json()}
 
 
 def _transport_fixture(monkeypatch, payload, tmp_path):
@@ -214,7 +214,7 @@ def test_block_mean_child_transport_preserves_measurement_scope(monkeypatch, tmp
         iterations=2, warmup_iterations=7, raw_times_ms=[2.0, 5.0],
         sample_scope="block_mean", iterations_per_sample=4,
     )
-    payload = {"success": True, "result_json": BenchmarkResult(timing=timing).model_dump_json()}
+    payload = {"success": True, "result_json": BenchmarkResult(timing=timing, device="cpu").model_dump_json()}
     result = _transport_fixture(monkeypatch, payload, tmp_path)
     assert not result.errors, result.errors
     assert result.timing.raw_times_ms == [2.0, 5.0]

--- a/code/tests/test_audit_wave1_zero2_child_protocol.py
+++ b/code/tests/test_audit_wave1_zero2_child_protocol.py
@@ -528,7 +528,7 @@ def test_adapter_cleans_success_artifacts_after_retaining_validated_diagnostics(
 
 def test_harness_invokes_only_the_explicit_zero2_result_callback(tmp_path, monkeypatch):
     target = tmp_path / "zero2_callback_control.py"
-    target.write_text("print('unused fake child')\n")
+    target.write_text("print('ZERO2_CALLBACK_CONTROL')\n")
     benchmark = Zero2TorchrunBenchmark(
         mode="baseline",
         variant="single",
@@ -537,6 +537,7 @@ def test_harness_invokes_only_the_explicit_zero2_result_callback(tmp_path, monke
         multi_gpu_required=False,
         default_nproc_per_node=1,
         name="zero2_callback_control",
+        env={"CUDA_VISIBLE_DEVICES": ""},
     )
     observed = {}
 
@@ -544,20 +545,20 @@ def test_harness_invokes_only_the_explicit_zero2_result_callback(tmp_path, monke
         observed.update(kwargs)
 
     benchmark.consume_zero2_child_results = callback
+    real_popen = subprocess.Popen
 
-    class FakeProcess:
-        returncode = 0
-        pid = os.getpid()
-
-        def communicate(self, timeout=None):
-            return "ZERO2_CALLBACK_CONTROL\n", ""
-
-    def fake_popen(command, **kwargs):
+    def observing_popen(command, **kwargs):
         observed["command"] = command
         observed["env"] = kwargs["env"]
-        return FakeProcess()
+        return real_popen(command, **kwargs)
 
-    monkeypatch.setattr("core.harness.benchmark_harness.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(
+        "core.harness.benchmark_harness.subprocess.Popen",
+        observing_popen,
+    )
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as rendezvous_socket:
+        rendezvous_socket.bind(("127.0.0.1", 0))
+        rendezvous_endpoint = f"127.0.0.1:{rendezvous_socket.getsockname()[1]}"
     config = BenchmarkConfig(
         device=torch.device("cpu"),
         iterations=1,
@@ -572,10 +573,12 @@ def test_harness_invokes_only_the_explicit_zero2_result_callback(tmp_path, monke
         measurement_timeout_seconds=30,
         nnodes="1",
         rdzv_backend="static",
-        rdzv_endpoint="127.0.0.1:1",
+        rdzv_endpoint=rendezvous_endpoint,
     )
     result = BenchmarkHarness(config=config)._benchmark_with_torchrun(benchmark, config)
     assert not result.errors
+    assert result.execution_process_ids[0] != os.getpid()
+    assert "ZERO2_CALLBACK_CONTROL" in observed["stdout"]
     assert observed["returncode"] == 0
     assert observed["launch_wall_ns"] <= observed["finish_wall_ns"]
     assert observed["launch_monotonic_ns"] <= observed["finish_monotonic_ns"]

--- a/code/tests/test_benchmark_hygiene_regressions.py
+++ b/code/tests/test_benchmark_hygiene_regressions.py
@@ -4126,9 +4126,30 @@ def test_pipeline_and_demo_activation_paths_use_inplace_relu() -> None:
         assert expected in source
         assert ".item()" not in source
 
+    # The repaired pair delegates its timed schedules to the common module.
+    # Keep the allocation check at that execution boundary; its separate real
+    # Gloo test verifies complete microbatch communication and outputs.
+    common_tree = ast.parse(
+        (REPO_ROOT / "ch04/pipeline_parallel_common.py").read_text(encoding="utf-8")
+    )
+    schedules = {
+        node.name: node
+        for node in common_tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name in {"run_gpipe_iteration", "run_1f1b_iteration"}
+    }
+    assert len(schedules) == 2
+    for schedule in schedules.values():
+        allocations = [
+            node
+            for node in ast.walk(schedule)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in {"empty", "empty_like", "zeros", "zeros_like", "new_empty"}
+        ]
+        assert not allocations, f"Timed tensor allocation in {schedule.name}"
+
     for relative in (
-        "ch04/baseline_pipeline_parallel.py",
-        "ch04/optimized_pipeline_parallel_1f1b.py",
         "ch04/baseline_pipeline_parallel_multigpu.py",
         "ch04/optimized_pipeline_parallel_multigpu_1f1b.py",
     ):
@@ -4153,7 +4174,6 @@ def test_pipeline_and_demo_activation_paths_use_inplace_relu() -> None:
         assert "torch.no_grad()" not in worker_section
 
     for relative in (
-        "ch04/optimized_pipeline_parallel_1f1b.py",
         "ch04/optimized_pipeline_parallel_multigpu_1f1b.py",
     ):
         source = (REPO_ROOT / relative).read_text(encoding="utf-8")

--- a/code/tests/test_executed_runtime_comparison.py
+++ b/code/tests/test_executed_runtime_comparison.py
@@ -1,0 +1,182 @@
+"""Central runtime admission uses real benchmark-worker receipts."""
+
+from __future__ import annotations
+
+import math
+import os
+
+import pytest
+
+from core.benchmark.models import BenchmarkRun
+from core.benchmark.run_manifest import RunManifest
+from core.benchmark.runtime_comparison import (
+    ExecutedRuntimeComparisonError,
+    compare_executed_runtime_provenance,
+)
+from tests.test_evaluation_harness_integration import _benchmark, _harness
+
+
+@pytest.fixture(scope="module")
+def real_executed_runs(tmp_path_factory: pytest.TempPathFactory) -> tuple[BenchmarkRun, BenchmarkRun]:
+    root = tmp_path_factory.mktemp("executed-runtime-comparison")
+    reference = _harness().benchmark_with_manifest(
+        _benchmark(root),
+        run_id="runtime-reference-thread",
+    )
+    candidate = _harness(subprocess_mode=True).benchmark_with_manifest(
+        _benchmark(root),
+        run_id="runtime-candidate-subprocess",
+    )
+    assert not reference.result.errors, reference.result.errors
+    assert not candidate.result.errors, candidate.result.errors
+    assert reference.result.timing.iterations > 0
+    assert candidate.result.timing.iterations > 0
+    return reference, candidate
+
+
+def _failure_codes(comparison, *, run=None) -> set[str]:
+    return {
+        failure.code
+        for failure in comparison.integrity_failures
+        if run is None or failure.run == run
+    }
+
+
+def test_manifest_runtime_capture_is_explicitly_deferrable_and_never_finalized_by_fallback() -> None:
+    standalone = RunManifest.create(config={"execution_mode": "thread"})
+    assert standalone.runtime_provenance is not None
+    assert standalone.runtime_provenance.process_id == os.getpid()
+
+    coordinator = RunManifest.create(
+        config={"execution_mode": "thread"},
+        capture_execution_runtime=False,
+    )
+    assert coordinator.runtime_provenance is None
+    coordinator.finalize()
+    assert coordinator.runtime_provenance is None
+
+
+def test_real_thread_and_subprocess_receipts_are_admitted(real_executed_runs) -> None:
+    reference, candidate = real_executed_runs
+
+    assert reference.result.execution_process_ids == {0: os.getpid()}
+    assert candidate.result.execution_process_ids[0] != os.getpid()
+    assert (
+        candidate.result.execution_process_ids[0]
+        == candidate.result.runtime_provenance.process_id
+    )
+
+    comparison = compare_executed_runtime_provenance(reference, candidate)
+
+    assert comparison.matches
+    assert comparison.target == "cpu"
+    assert comparison.integrity_failures == []
+    assert comparison.runtime_parity is not None
+    assert comparison.runtime_parity.matches
+
+
+def test_two_sided_coordinator_substitution_is_rejected_by_independent_pid_receipt(
+    real_executed_runs,
+) -> None:
+    reference, candidate = real_executed_runs
+    substituted = candidate.model_copy(deep=True)
+    coordinator_runtime = reference.result.runtime_provenance.model_copy(deep=True)
+    substituted.result.runtime_provenance = coordinator_runtime.model_copy(deep=True)
+    substituted.manifest.runtime_provenance = coordinator_runtime.model_copy(deep=True)
+
+    comparison = compare_executed_runtime_provenance(reference, substituted)
+
+    assert not comparison.matches
+    assert comparison.target == "cpu"
+    assert comparison.runtime_parity is not None and comparison.runtime_parity.matches
+    assert "runtime_process_id_mismatch" in _failure_codes(
+        comparison,
+        run="candidate",
+    )
+    error = ExecutedRuntimeComparisonError(comparison)
+    assert error.comparison is comparison
+    assert "runtime_process_id_mismatch" in str(error)
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_code"),
+    [
+        ("manifest", "manifest_missing"),
+        ("runtime", "result_runtime_provenance_missing"),
+        ("execution_ids", "execution_process_ids_missing"),
+        ("execution_pid", "runtime_process_id_mismatch"),
+        ("manifest_result", "manifest_result_runtime_mismatch"),
+    ],
+)
+def test_missing_or_invalid_receipts_return_structured_rejection(
+    real_executed_runs,
+    case,
+    expected_code,
+) -> None:
+    reference, real_candidate = real_executed_runs
+    candidate = real_candidate.model_copy(deep=True)
+
+    if case == "manifest":
+        candidate.manifest = None
+    elif case == "runtime":
+        candidate.result.runtime_provenance = None
+        candidate.manifest.runtime_provenance = None
+    elif case == "execution_ids":
+        candidate.result.execution_process_ids = {}
+    elif case == "execution_pid":
+        candidate.result.execution_process_ids[0] += 1
+    elif case == "manifest_result":
+        candidate.result.runtime_provenance.torch_version += "-corrupt"
+    else:  # pragma: no cover - parametrization guard
+        raise AssertionError(case)
+
+    comparison = compare_executed_runtime_provenance(reference, candidate)
+
+    assert not comparison.matches
+    assert expected_code in _failure_codes(comparison, run="candidate")
+    assert all(failure.detail for failure in comparison.integrity_failures)
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_code"),
+    [
+        ("device_missing", "device_missing"),
+        ("device_mismatch", "device_target_mismatch"),
+        ("device_unsupported", "device_unsupported"),
+        ("result_errors", "result_errors"),
+        ("zero_timing", "timing_values_invalid"),
+        ("nonfinite_timing", "timing_values_invalid"),
+        ("zero_iterations", "timing_iterations_invalid"),
+    ],
+)
+def test_invalid_executed_result_never_reaches_matching_admission(
+    real_executed_runs,
+    case,
+    expected_code,
+) -> None:
+    reference, real_candidate = real_executed_runs
+    candidate = real_candidate.model_copy(deep=True)
+
+    if case == "device_missing":
+        candidate.result.device = None
+    elif case == "device_mismatch":
+        candidate.result.device = "cuda:0"
+    elif case == "device_unsupported":
+        candidate.result.device = "mps"
+    elif case == "result_errors":
+        candidate.result.errors = ["worker reported an execution failure"]
+    elif case == "zero_timing":
+        candidate.result.timing.mean_ms = 0.0
+    elif case == "nonfinite_timing":
+        candidate.result.timing.mean_ms = math.inf
+    elif case == "zero_iterations":
+        candidate.result.timing.iterations = 0
+    else:  # pragma: no cover - parametrization guard
+        raise AssertionError(case)
+
+    comparison = compare_executed_runtime_provenance(reference, candidate)
+
+    assert not comparison.matches
+    assert expected_code in _failure_codes(comparison)
+    if case in {"device_missing", "device_mismatch", "device_unsupported"}:
+        assert comparison.target is None

--- a/code/tests/test_expected_gpu_identity.py
+++ b/code/tests/test_expected_gpu_identity.py
@@ -1,0 +1,159 @@
+"""Expected-versus-observed GPU identity checks for environment validation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from core.harness import validity_checks
+from core.harness.device_identity_contract import observe_cuda_device_identity
+from core.harness.validity_checks import EnvironmentProbe, validate_environment
+
+GPU_UUID_A = "GPU-12345678-1234-5678-1234-567812345678"
+GPU_UUID_B = "GPU-87654321-4321-8765-4321-876543218765"
+
+
+@pytest.fixture(autouse=True)
+def _use_linux_environment_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise the Linux-only validator while preserving real CUDA behavior."""
+    monkeypatch.setattr(validity_checks, "sys", SimpleNamespace(platform="linux"))
+
+
+def _write_probe_file(root, path: str, content: str) -> None:
+    target = root / path.lstrip("/")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+
+
+def _clean_probe(root) -> EnvironmentProbe:
+    _write_probe_file(root, "/proc/swaps", "Filename Type Size Used Priority\n")
+    _write_probe_file(root, "/proc/sys/vm/swappiness", "0\n")
+    _write_probe_file(root, "/proc/cpuinfo", "processor: 0\n")
+    _write_probe_file(root, "/sys/devices/virtual/dmi/id/product_name", "BareMetal\n")
+    _write_probe_file(
+        root,
+        "/sys/devices/system/cpu/cpufreq/policy0/scaling_governor",
+        "performance\n",
+    )
+    _write_probe_file(root, "/sys/devices/system/node/node0/cpulist", "0-3\n")
+    return EnvironmentProbe(root=root, env={}, cpu_affinity={0, 1, 2, 3})
+
+
+def test_default_cpu_validation_does_not_require_gpu_identity(tmp_path) -> None:
+    result = validate_environment(
+        device=torch.device("cpu"),
+        probe=_clean_probe(tmp_path),
+    )
+
+    assert result.is_valid, result.errors
+    assert "expected_device_uuid" not in result.details
+    assert "observed_device_uuid" not in result.details
+
+
+def test_expected_gpu_identity_rejects_configured_cpu_device(tmp_path) -> None:
+    result = validate_environment(
+        device=torch.device("cpu"),
+        probe=_clean_probe(tmp_path),
+        expected_device_uuid=GPU_UUID_A,
+        expected_compute_capability="10.0",
+    )
+
+    assert not result.is_valid
+    assert any(
+        "cannot be observed for configured device type 'cpu'" in error for error in result.errors
+    )
+    assert result.details["expected_device_uuid"] == GPU_UUID_A
+    assert result.details["expected_compute_capability"] == "10.0"
+    assert result.details["observed_device_uuid"] is None
+    assert result.details["observed_compute_capability"] is None
+
+
+def test_partial_expected_gpu_identity_is_rejected(tmp_path) -> None:
+    result = validate_environment(
+        device=torch.device("cpu"),
+        probe=_clean_probe(tmp_path),
+        expected_device_uuid=GPU_UUID_A,
+    )
+
+    assert not result.is_valid
+    assert any("must be configured together" in error for error in result.errors)
+
+
+@pytest.mark.skipif(
+    torch.cuda.is_available(),
+    reason="CUDA-unavailable behavior requires a host without CUDA",
+)
+def test_expected_gpu_identity_is_unknown_when_cuda_is_unavailable(tmp_path) -> None:
+    result = validate_environment(
+        device=torch.device("cuda"),
+        probe=_clean_probe(tmp_path),
+        expected_device_uuid=GPU_UUID_A,
+        expected_compute_capability="10.0",
+    )
+
+    assert not result.is_valid
+    assert any(
+        "CUDA device requested but CUDA is not available" in error for error in result.errors
+    )
+    assert any(
+        "Expected GPU identity/capability is unavailable" in error for error in result.errors
+    )
+    assert result.details["observed_device_uuid"] is None
+    assert result.details["observed_compute_capability"] is None
+
+
+def _live_cuda_observation():
+    if not torch.cuda.is_available():
+        pytest.skip("real GPU identity validation requires a CUDA device")
+    pytest.importorskip("pynvml", reason="real GPU identity validation requires pynvml")
+    device = torch.device("cuda", torch.cuda.current_device())
+    return device, observe_cuda_device_identity(device)
+
+
+def test_expected_gpu_identity_accepts_live_observed_cuda_device(tmp_path) -> None:
+    device, observed = _live_cuda_observation()
+
+    result = validate_environment(
+        device=device,
+        probe=_clean_probe(tmp_path),
+        expected_device_uuid=observed.nvml_uuid,
+        expected_compute_capability=observed.compute_capability,
+    )
+
+    assert result.is_valid, result.errors
+    assert result.details["expected_device_uuid"] == observed.nvml_uuid
+    assert result.details["expected_compute_capability"] == observed.compute_capability
+    assert result.details["observed_device_uuid"] == observed.nvml_uuid
+    assert result.details["observed_cuda_device_uuid"] == observed.cuda_uuid
+    assert result.details["observed_compute_capability"] == observed.compute_capability
+
+
+@pytest.mark.parametrize("mismatch", ["device_uuid", "compute_capability"])
+def test_expected_gpu_identity_rejects_live_cuda_mismatch(
+    tmp_path,
+    mismatch: str,
+) -> None:
+    device, observed = _live_cuda_observation()
+    wrong_uuid = GPU_UUID_A if observed.nvml_uuid != GPU_UUID_A else GPU_UUID_B
+    wrong_capability = "9.0" if observed.compute_capability != "9.0" else "10.0"
+
+    result = validate_environment(
+        device=device,
+        probe=_clean_probe(tmp_path),
+        expected_device_uuid=(wrong_uuid if mismatch == "device_uuid" else observed.nvml_uuid),
+        expected_compute_capability=(
+            wrong_capability if mismatch == "compute_capability" else observed.compute_capability
+        ),
+    )
+
+    assert not result.is_valid
+    expected_message = (
+        "Expected GPU UUID mismatch"
+        if mismatch == "device_uuid"
+        else "Expected compute capability mismatch"
+    )
+    assert any(expected_message in error for error in result.errors), result.errors
+    assert result.details["observed_device_uuid"] == observed.nvml_uuid
+    assert result.details["observed_compute_capability"] == observed.compute_capability

--- a/code/tests/test_output_tolerance_map.py
+++ b/code/tests/test_output_tolerance_map.py
@@ -1,0 +1,406 @@
+"""Real CPU coverage for exact-keyed output tolerance policies."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+from core.benchmark.verification import (
+    get_output_tolerances,
+    normalize_output_tolerances,
+    output_tolerances_from_dict,
+    output_tolerances_to_dict,
+)
+from core.benchmark.verification_mixin import VerificationPayloadMixin
+from core.benchmark.verified_comparison import VerifiedComparisonError
+from core.benchmark.verify_runner import VerifyConfig, VerifyRunner
+from core.harness.benchmark_harness import (
+    BaseBenchmark,
+    BenchmarkConfig,
+    BenchmarkHarness,
+    BenchmarkMode,
+    ExecutionMode,
+    _parse_subprocess_output_tolerances,
+    compare_benchmarks,
+)
+
+_OUTPUT_TOLERANCES = {
+    "prediction": (0.0, 1e-6),
+    "parameter.weight": (0.0, 1e-6),
+}
+
+
+class _TrainingOutputBenchmark(VerificationPayloadMixin, BaseBenchmark):
+    allow_cpu = True
+
+    def __init__(
+        self,
+        *,
+        parameter_step: float = 0.0,
+        prediction_offset: float = 0.0,
+        output_tolerances: dict[str, tuple[float, float]] | None = None,
+    ) -> None:
+        super().__init__()
+        self.device = torch.device("cpu")
+        self.parameter_step = parameter_step
+        self.prediction_offset = prediction_offset
+        self.declared_output_tolerances = output_tolerances or dict(_OUTPUT_TOLERANCES)
+        self.input_tensor: torch.Tensor | None = None
+        self.prediction: torch.Tensor | None = None
+        self.weight: torch.Tensor | None = None
+        self.full_output: dict[str, torch.Tensor] | None = None
+        self.benchmark_calls = 0
+        self.register_workload_metadata(samples_per_iteration=8)
+
+    def setup(self) -> None:
+        self.input_tensor = torch.arange(8, dtype=torch.float32)
+        self.weight = torch.tensor([0.02], dtype=torch.float32)
+
+    def benchmark_fn(self) -> torch.Tensor:
+        if self.input_tensor is None or self.weight is None:
+            raise RuntimeError("setup() must run before benchmark_fn()")
+        self.benchmark_calls += 1
+        self.prediction = self.input_tensor * 2.0 + self.prediction_offset
+        self.weight.add_(self.parameter_step)
+        return self.prediction
+
+    def capture_verification_payload(self) -> None:
+        if self.input_tensor is None or self.prediction is None or self.weight is None:
+            raise RuntimeError("timed execution did not produce training outputs")
+        self.full_output = {
+            "prediction": self.prediction.detach().clone(),
+            "parameter.weight": self.weight.detach().clone(),
+        }
+        self._set_verification_payload(
+            inputs={"input": self.input_tensor},
+            output=self.prediction,
+            batch_size=self.input_tensor.shape[0],
+            parameter_count=self.weight.numel(),
+            output_tolerance=(0.5, 5.0),
+            output_tolerances=self.declared_output_tolerances,
+        )
+
+    def get_verify_output(self) -> dict[str, torch.Tensor]:
+        if self.full_output is None:
+            raise RuntimeError("capture_verification_payload() must run first")
+        return {name: tensor.detach().clone() for name, tensor in self.full_output.items()}
+
+    def validate_result(self) -> None:
+        return None
+
+
+def _cpu_harness() -> BenchmarkHarness:
+    config = BenchmarkConfig(
+        device=torch.device("cpu"),
+        iterations=2,
+        warmup=5,
+        use_subprocess=False,
+        execution_mode=ExecutionMode.THREAD,
+        enable_profiling=False,
+        enable_memory_tracking=False,
+        enable_cleanup=False,
+        lock_gpu_clocks=False,
+        enforce_environment_validation=False,
+        detect_setup_precomputation=False,
+        adaptive_iterations=False,
+        clear_compile_cache=False,
+        measurement_timeout_seconds=15,
+    )
+    return BenchmarkHarness(mode=BenchmarkMode.CUSTOM, config=config)
+
+
+def _verify_config() -> VerifyConfig:
+    return VerifyConfig(
+        skip_jitter_check=True,
+        skip_fresh_input_check=True,
+        skip_workload_check=True,
+    )
+
+
+def test_real_cpu_comparison_records_exact_keyed_tolerances() -> None:
+    baseline = _TrainingOutputBenchmark()
+    optimized = _TrainingOutputBenchmark()
+
+    result = compare_benchmarks(baseline, optimized, harness=_cpu_harness())
+
+    assert baseline.benchmark_calls > 5
+    assert optimized.benchmark_calls > 5
+    assert result["verification"]["passed"] is True
+    assert result["verification"]["output_tolerances"] == {
+        "parameter.weight": {"rtol": 0.0, "atol": 1e-6},
+        "prediction": {"rtol": 0.0, "atol": 1e-6},
+    }
+
+
+@pytest.mark.parametrize(
+    "optimized",
+    [
+        pytest.param(_TrainingOutputBenchmark(parameter_step=0.01), id="parameter.weight"),
+        pytest.param(_TrainingOutputBenchmark(prediction_offset=0.01), id="prediction"),
+    ],
+)
+def test_real_cpu_comparison_rejects_each_corrupted_output_with_loose_global_tolerance(
+    optimized: _TrainingOutputBenchmark,
+) -> None:
+    baseline = _TrainingOutputBenchmark()
+
+    with pytest.raises(VerifiedComparisonError, match="output_mismatch") as exc_info:
+        compare_benchmarks(baseline, optimized, harness=_cpu_harness())
+
+    assert exc_info.value.code == "output_mismatch"
+    assert exc_info.value.evidence["passed"] is False
+    assert exc_info.value.evidence["output_tolerances"]["parameter.weight"] == {
+        "rtol": 0.0,
+        "atol": 1e-6,
+    }
+
+
+def test_real_cpu_comparison_rejects_different_maps() -> None:
+    baseline = _TrainingOutputBenchmark()
+    optimized_tolerances = dict(_OUTPUT_TOLERANCES)
+    optimized_tolerances["parameter.weight"] = (0.0, 2e-6)
+    optimized = _TrainingOutputBenchmark(output_tolerances=optimized_tolerances)
+
+    with pytest.raises(VerifiedComparisonError, match="output_tolerances_mismatch") as exc_info:
+        compare_benchmarks(baseline, optimized, harness=_cpu_harness())
+
+    assert exc_info.value.code == "output_tolerances_mismatch"
+
+
+def test_real_cpu_comparison_requires_exact_output_key_coverage() -> None:
+    incomplete = {"prediction": (0.0, 1e-6)}
+
+    with pytest.raises(VerifiedComparisonError, match="must exactly cover") as exc_info:
+        compare_benchmarks(
+            _TrainingOutputBenchmark(output_tolerances=incomplete),
+            _TrainingOutputBenchmark(output_tolerances=incomplete),
+            harness=_cpu_harness(),
+        )
+
+    assert exc_info.value.code == "output_tolerances_mismatch"
+
+
+def test_verify_runner_roundtrips_map_and_rejects_corrupted_parameter(tmp_path: Path) -> None:
+    runner = VerifyRunner(cache_dir=tmp_path / "cache")
+    baseline = _TrainingOutputBenchmark()
+
+    baseline_result = runner.verify_baseline(baseline, config=_verify_config())
+    assert baseline_result.passed is True
+    assert baseline_result.signature_hash is not None
+
+    cached = runner.cache.get(baseline_result.signature_hash)
+    assert cached is not None
+    assert cached.output_tolerances == _OUTPUT_TOLERANCES
+
+    optimized_result = runner.verify_optimized(
+        _TrainingOutputBenchmark(parameter_step=0.01),
+        config=_verify_config(),
+    )
+    assert optimized_result.passed is False
+    assert optimized_result.reason == "output_mismatch"
+    assert optimized_result.comparison_details is not None
+    assert optimized_result.comparison_details.output_tolerances == _OUTPUT_TOLERANCES
+
+
+def test_verify_runner_rejects_non_tensor_entries_in_actual_output_dict(tmp_path: Path) -> None:
+    class MixedOutputBenchmark(_TrainingOutputBenchmark):
+        def get_verify_output(self) -> dict[str, object]:
+            outputs: dict[str, object] = super().get_verify_output()
+            outputs["parameter.bias"] = None
+            return outputs
+
+    result = VerifyRunner(cache_dir=tmp_path / "cache").verify_baseline(
+        MixedOutputBenchmark(),
+        config=_verify_config(),
+    )
+
+    assert result.passed is False
+    assert "get_verify_output()['parameter.bias'] must be a torch.Tensor" in str(result.reason)
+
+
+def test_real_subprocess_transports_map_through_json(tmp_path: Path) -> None:
+    module_path = tmp_path / "subprocess_output_tolerances.py"
+    module_path.write_text(
+        """
+import torch
+from core.benchmark.verification_mixin import VerificationPayloadMixin
+from core.harness.benchmark_harness import BaseBenchmark
+
+class ChildBenchmark(VerificationPayloadMixin, BaseBenchmark):
+    allow_cpu = True
+    def __init__(self):
+        super().__init__()
+        self.device = torch.device('cpu')
+        self.input_tensor = None
+        self.output = None
+        self.full_output = None
+        self.output_value = 1.0
+        self.policy_atol = 1e-6
+        self.use_map = True
+        self.should_fail = False
+        self.register_workload_metadata(samples_per_iteration=4)
+    def setup(self):
+        self.input_tensor = torch.arange(4, dtype=torch.float32)
+    def benchmark_fn(self):
+        if self.should_fail:
+            raise RuntimeError('intentional second-run failure')
+        self.output = self.input_tensor + self.output_value
+        return self.output
+    def capture_verification_payload(self):
+        self.full_output = {
+            'prediction': self.output.detach().clone(),
+            'parameter.weight': torch.tensor([0.02]),
+        }
+        self._set_verification_payload(
+            inputs={'input': self.input_tensor}, output=self.output,
+            batch_size=4, parameter_count=1, output_tolerance=(0.5, 5.0),
+            output_tolerances=(
+                {
+                    'prediction': (0.0, self.policy_atol),
+                    'parameter.weight': (0.0, 1e-6),
+                }
+                if self.use_map else None
+            ),
+        )
+    def get_verify_output(self):
+        if self.full_output is None:
+            raise RuntimeError('capture_verification_payload() must run first')
+        return {name: tensor.detach().clone() for name, tensor in self.full_output.items()}
+    def validate_result(self):
+        return None
+
+class DeclaredChildBenchmark(ChildBenchmark):
+    def get_output_tolerances(self):
+        if not self.use_map:
+            return None
+        return {
+            'prediction': (0.0, self.policy_atol),
+            'parameter.weight': (0.0, 1e-6),
+        }
+""",
+        encoding="utf-8",
+    )
+    module_name = "_test_subprocess_output_tolerances"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    config = _cpu_harness().config
+    config.use_subprocess = True
+    config.execution_mode = ExecutionMode.SUBPROCESS
+    config.subprocess_stderr_dir = str(tmp_path / "logs")
+    harness = BenchmarkHarness(mode=BenchmarkMode.CUSTOM, config=config)
+
+    # A first-run payload-only mixin has no policy until its post-measurement
+    # capture hook. It remains a valid source of a strict child receipt.
+    payload_only_benchmark = module.ChildBenchmark()
+    payload_only_result = harness.benchmark(payload_only_benchmark)
+    assert not payload_only_result.errors
+    assert get_output_tolerances(payload_only_benchmark) == _OUTPUT_TOLERANCES
+
+    benchmark = module.DeclaredChildBenchmark()
+    result = harness.benchmark(benchmark)
+
+    assert not result.errors
+    assert result.execution_process_ids[0] != __import__("os").getpid()
+    transported = get_output_tolerances(benchmark)
+    assert transported == _OUTPUT_TOLERANCES
+    serialized = json.loads(json.dumps(output_tolerances_to_dict(transported)))
+    assert output_tolerances_from_dict(serialized) == _OUTPUT_TOLERANCES
+
+    actual_receipt = {"output_tolerances": serialized}
+    has_policy, parsed = _parse_subprocess_output_tolerances(
+        copy.deepcopy(actual_receipt),
+        declared_output_tolerances=_OUTPUT_TOLERANCES,
+    )
+    assert has_policy is True
+    assert parsed == _OUTPUT_TOLERANCES
+
+    missing_receipt = copy.deepcopy(actual_receipt)
+    missing_receipt.pop("output_tolerances")
+    none_receipt = copy.deepcopy(actual_receipt)
+    none_receipt["output_tolerances"] = None
+    different_receipt = copy.deepcopy(actual_receipt)
+    different_receipt["output_tolerances"]["parameter.weight"]["atol"] = 2e-6
+    for corrupted_receipt in (missing_receipt, none_receipt, different_receipt):
+        with pytest.raises(ValueError, match="pre-dispatch"):
+            _parse_subprocess_output_tolerances(
+                corrupted_receipt,
+                declared_output_tolerances=_OUTPUT_TOLERANCES,
+            )
+
+    runner_benchmark = module.DeclaredChildBenchmark()
+    subprocess_result = harness.benchmark(runner_benchmark)
+    assert not subprocess_result.errors
+    assert "_subprocess_output_tolerances" in vars(runner_benchmark)
+    runner_benchmark.output_value = 7.0
+    runner_benchmark.policy_atol = 3e-6
+    runner = VerifyRunner(cache_dir=tmp_path / "reused-instance-cache")
+    runner_result = runner.verify_baseline(runner_benchmark, config=_verify_config())
+    assert runner_result.passed is True
+    assert "_subprocess_verify_output" not in vars(runner_benchmark)
+    assert "_subprocess_output_tolerances" not in vars(runner_benchmark)
+    assert runner_result.signature_hash is not None
+    reused_golden = runner.cache.get(runner_result.signature_hash)
+    assert reused_golden is not None
+    assert reused_golden.output_tolerances == {
+        "prediction": (0.0, 3e-6),
+        "parameter.weight": (0.0, 1e-6),
+    }
+
+    benchmark.use_map = False
+    no_map_result = harness.benchmark(benchmark)
+    assert not no_map_result.errors
+    assert "_subprocess_output_tolerances" in vars(benchmark)
+    assert benchmark._subprocess_output_tolerances is None
+    assert get_output_tolerances(benchmark) is None
+
+    benchmark.output_value = 4.0
+    benchmark.policy_atol = 2e-6
+    benchmark.use_map = True
+    thread_result = _cpu_harness().benchmark(benchmark)
+    assert not thread_result.errors
+    assert "_subprocess_verify_output" not in vars(benchmark)
+    assert "_subprocess_output_tolerances" not in vars(benchmark)
+    assert torch.equal(
+        benchmark.get_verify_output()["prediction"],
+        torch.arange(4, dtype=torch.float32) + 4.0,
+    )
+    assert get_output_tolerances(benchmark) == {
+        "prediction": (0.0, 2e-6),
+        "parameter.weight": (0.0, 1e-6),
+    }
+
+    failed_benchmark = module.ChildBenchmark()
+    first_result = harness.benchmark(failed_benchmark)
+    assert not first_result.errors
+    failed_benchmark.should_fail = True
+    failed_result = _cpu_harness().benchmark(failed_benchmark)
+    assert any("intentional second-run failure" in error for error in failed_result.errors)
+    assert "_subprocess_verify_output" not in vars(failed_benchmark)
+    assert "_subprocess_output_tolerance" not in vars(failed_benchmark)
+    assert "_subprocess_output_tolerances" not in vars(failed_benchmark)
+    assert "_subprocess_input_signature" not in vars(failed_benchmark)
+    with pytest.raises(RuntimeError, match="capture_verification_payload"):
+        failed_benchmark.get_verify_output()
+
+
+@pytest.mark.parametrize(
+    "value, error",
+    [
+        ({"output": (float("nan"), 0.0)}, "finite and nonnegative"),
+        ({"output": (-1.0, 0.0)}, "finite and nonnegative"),
+        ({"output": [0.0, 0.0]}, r"must be an \(rtol, atol\) tuple"),
+        ({}, "must not return an empty dictionary"),
+    ],
+)
+def test_tolerance_map_rejects_invalid_numeric_policy(value: object, error: str) -> None:
+    with pytest.raises((TypeError, ValueError), match=error):
+        normalize_output_tolerances(value)

--- a/code/tests/test_output_tolerance_map.py
+++ b/code/tests/test_output_tolerance_map.py
@@ -305,6 +305,20 @@ class DeclaredChildBenchmark(ChildBenchmark):
     assert not payload_only_result.errors
     assert get_output_tolerances(payload_only_benchmark) == _OUTPUT_TOLERANCES
 
+    # Torchrun coordinators receive actual child output and the required global
+    # tolerance but do not execute capture_verification_payload() locally. An
+    # absent optional map receipt must therefore remain a legitimate None.
+    transported_parent = module.ChildBenchmark()
+    transported_parent.use_map = False
+    transported_parent_result = harness.benchmark(transported_parent)
+    assert not transported_parent_result.errors
+    assert transported_parent._verification_payload is None
+    assert isinstance(transported_parent._subprocess_verify_output, dict)
+    assert transported_parent._subprocess_output_tolerance == (0.5, 5.0)
+    assert transported_parent._subprocess_output_tolerances is None
+    vars(transported_parent).pop("_subprocess_output_tolerances")
+    assert get_output_tolerances(transported_parent) is None
+
     benchmark = module.DeclaredChildBenchmark()
     result = harness.benchmark(benchmark)
 

--- a/code/tests/test_pipeline_1f1b_schedule.py
+++ b/code/tests/test_pipeline_1f1b_schedule.py
@@ -1,0 +1,450 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import time
+import uuid
+from collections.abc import Callable
+from contextlib import redirect_stdout
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+import torch.distributed as dist
+from ch04.pipeline_parallel_common import (
+    CONTRACT_ENV,
+    ITERATIONS_ENV,
+    LAUNCH_MONOTONIC_NS_ENV,
+    LAUNCH_WALL_NS_ENV,
+    PIPELINE_RESULT_LAYERS_ENV,
+    PIPELINE_RESULT_SCHEDULE_ENV,
+    PIPELINE_RESULT_SHAPE_ENV,
+    PIPELINE_RESULT_SOURCE_ENV,
+    PIPELINE_RESULT_VARIANT_ENV,
+    RESULT_DIR_ENV,
+    RUN_ID_ENV,
+    WORLD_SIZE_ENV,
+    PipelineIterationCapture,
+    make_pipeline_child_result_contract,
+    run_1f1b_iteration,
+    run_gpipe_iteration,
+    validate_pipeline_child_result_bundle,
+    verify_and_concatenate_pipeline_capture,
+    write_pipeline_child_result,
+)
+from core.harness.benchmark_harness import BenchmarkConfig
+
+_WORLD_SIZE = 2
+_MICROBATCHES = 8
+_SHAPE = (_MICROBATCHES, 1, 2)
+_LAYERS = 2
+
+
+def _run_environment(
+    *,
+    result_dir: Path,
+    run_id: str,
+    source: str,
+    variant: str,
+    schedule: str,
+    launch_wall_ns: int,
+    launch_monotonic_ns: int,
+) -> dict[str, str]:
+    contract = make_pipeline_child_result_contract(
+        batch_size=_SHAPE[0],
+        parameter_count=1,
+    )
+    return {
+        RESULT_DIR_ENV: str(result_dir),
+        RUN_ID_ENV: run_id,
+        CONTRACT_ENV: json.dumps(contract.to_dict(), sort_keys=True, separators=(",", ":")),
+        WORLD_SIZE_ENV: str(_WORLD_SIZE),
+        ITERATIONS_ENV: "1",
+        LAUNCH_WALL_NS_ENV: str(launch_wall_ns),
+        LAUNCH_MONOTONIC_NS_ENV: str(launch_monotonic_ns),
+        PIPELINE_RESULT_SOURCE_ENV: source,
+        PIPELINE_RESULT_VARIANT_ENV: variant,
+        PIPELINE_RESULT_SCHEDULE_ENV: schedule,
+        PIPELINE_RESULT_SHAPE_ENV: json.dumps(_SHAPE, separators=(",", ":")),
+        PIPELINE_RESULT_LAYERS_ENV: str(_LAYERS),
+    }
+
+
+def _stage(value: torch.Tensor, increment: float) -> torch.Tensor:
+    return value + increment
+
+
+def _gloo_worker(
+    rank: int,
+    rendezvous: str,
+    run_environments: list[dict[str, str]],
+) -> None:
+    os.environ["GLOO_SOCKET_IFNAME"] = "lo0" if sys.platform == "darwin" else "lo"
+    dist.init_process_group(
+        "gloo",
+        init_method=rendezvous,
+        rank=rank,
+        world_size=_WORLD_SIZE,
+    )
+    try:
+        rank0_input = torch.arange(
+            torch.tensor(_SHAPE).prod().item(), dtype=torch.float32
+        ).reshape(_SHAPE).to(torch.bfloat16)
+        forward_increment = float(rank + 1)
+        backward_increment = float((rank + 1) * 10)
+
+        def forward_step(value: torch.Tensor) -> torch.Tensor:
+            return _stage(value, forward_increment)
+
+        def backward_step(_activation: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
+            return _stage(value, backward_increment)
+
+        forward_stages: list[Callable[[torch.Tensor], torch.Tensor]] = [
+            lambda value, increment=float(stage + 1): _stage(value, increment)
+            for stage in range(_WORLD_SIZE)
+        ]
+        backward_stages: list[Callable[[torch.Tensor], torch.Tensor]] = [
+            lambda value, increment=float((stage + 1) * 10): _stage(value, increment)
+            for stage in range(_WORLD_SIZE)
+        ]
+
+        for run_index, environment in enumerate(run_environments):
+            os.environ.update(environment)
+            os.environ["RANK"] = str(rank)
+            os.environ["WORLD_SIZE"] = str(_WORLD_SIZE)
+            recv_forward = (
+                [torch.empty((1, 1, 2), dtype=torch.bfloat16) for _ in range(_MICROBATCHES)]
+                if rank > 0
+                else []
+            )
+            recv_backward = (
+                [torch.empty((1, 1, 2), dtype=torch.bfloat16) for _ in range(_MICROBATCHES)]
+                if rank < _WORLD_SIZE - 1
+                else []
+            )
+            capture = PipelineIterationCapture.create(_MICROBATCHES)
+            started = time.perf_counter()
+            if run_index == 0:
+                run_gpipe_iteration(
+                    rank=rank,
+                    world_size=_WORLD_SIZE,
+                    num_micro_batches=_MICROBATCHES,
+                    get_rank0_microbatch=lambda index: rank0_input[index : index + 1],
+                    recv_forward_buffers=recv_forward,
+                    recv_backward_buffers=recv_backward,
+                    forward_step=forward_step,
+                    backward_step=backward_step,
+                    capture=capture,
+                )
+            else:
+                run_1f1b_iteration(
+                    rank=rank,
+                    world_size=_WORLD_SIZE,
+                    num_micro_batches=_MICROBATCHES,
+                    get_rank0_microbatch=lambda index: rank0_input[index : index + 1],
+                    recv_forward_buffers=recv_forward,
+                    recv_backward_buffers=recv_backward,
+                    forward_step=forward_step,
+                    backward_step=backward_step,
+                    activation_slots=[None] * max(_WORLD_SIZE - rank - 1, 1),
+                    capture=capture,
+                )
+            elapsed_ms = max((time.perf_counter() - started) * 1000.0, 1e-9)
+            verify_input, verify_output = verify_and_concatenate_pipeline_capture(
+                rank=rank,
+                capture=capture,
+                forward_stages=forward_stages,
+                backward_stages=backward_stages,
+                tolerance=(0.0, 0.0),
+            )
+            result_dir = Path(environment[RESULT_DIR_ENV])
+            stdout_path = result_dir.with_name(f"{result_dir.name}.rank-{rank}.stdout")
+            with (
+                stdout_path.open("w", encoding="utf-8") as stdout_handle,
+                redirect_stdout(stdout_handle),
+            ):
+                assert write_pipeline_child_result(
+                    verify_input=verify_input,
+                    verify_output=verify_output,
+                    completed_iterations=1,
+                    time_per_iter_ms=elapsed_ms,
+                    reference_verified=True,
+                )
+                if rank == 0:
+                    print(f"rank0 time_per_iter_ms: {elapsed_ms:.9f}", flush=True)
+            dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+def _validate(
+    result_dir: Path,
+    *,
+    environment: dict[str, str],
+    source: str,
+    variant: str,
+    schedule: str,
+    finish_wall_ns: int,
+    finish_monotonic_ns: int,
+    stdout: str | None = None,
+) -> dict[str, Any]:
+    if stdout is None:
+        stdout = "".join(
+            result_dir.with_name(f"{result_dir.name}.rank-{rank}.stdout").read_text(
+                encoding="utf-8"
+            )
+            for rank in range(_WORLD_SIZE)
+        )
+    return validate_pipeline_child_result_bundle(
+        result_dir,
+        contract=make_pipeline_child_result_contract(batch_size=_SHAPE[0], parameter_count=1),
+        run_id=environment[RUN_ID_ENV],
+        source=source,
+        variant=variant,
+        schedule=schedule,
+        world_size=_WORLD_SIZE,
+        requested_iterations=1,
+        shape=_SHAPE,
+        num_layers=_LAYERS,
+        launch_wall_ns=int(environment[LAUNCH_WALL_NS_ENV]),
+        launch_monotonic_ns=int(environment[LAUNCH_MONOTONIC_NS_ENV]),
+        finish_wall_ns=finish_wall_ns,
+        finish_monotonic_ns=finish_monotonic_ns,
+        stdout=stdout,
+    )
+
+
+@pytest.mark.skipif(not dist.is_available(), reason="torch.distributed is unavailable")
+def test_real_gloo_schedules_transport_timed_full_outputs_and_reject_bad_receipts(
+    tmp_path: Path,
+) -> None:
+    launch_wall_ns = time.time_ns()
+    launch_monotonic_ns = time.monotonic_ns()
+    baseline_dir = tmp_path / "baseline"
+    optimized_dir = tmp_path / "optimized"
+    baseline_dir.mkdir()
+    optimized_dir.mkdir()
+    baseline_environment = _run_environment(
+        result_dir=baseline_dir,
+        run_id=uuid.uuid4().hex,
+        source="ch04.baseline_pipeline_parallel",
+        variant="baseline",
+        schedule="gpipe",
+        launch_wall_ns=launch_wall_ns,
+        launch_monotonic_ns=launch_monotonic_ns,
+    )
+    optimized_environment = _run_environment(
+        result_dir=optimized_dir,
+        run_id=uuid.uuid4().hex,
+        source="ch04.optimized_pipeline_parallel_1f1b",
+        variant="optimized",
+        schedule="1f1b-paired-p2p",
+        launch_wall_ns=launch_wall_ns,
+        launch_monotonic_ns=launch_monotonic_ns,
+    )
+    rendezvous_path = tmp_path / "gloo-rendezvous"
+    torch.multiprocessing.spawn(
+        _gloo_worker,
+        args=(
+            f"file://{rendezvous_path}",
+            [baseline_environment, optimized_environment],
+        ),
+        nprocs=_WORLD_SIZE,
+        join=True,
+        daemon=False,
+    )
+    finish_monotonic_ns = time.monotonic_ns()
+    finish_wall_ns = time.time_ns()
+
+    baseline = _validate(
+        baseline_dir,
+        environment=baseline_environment,
+        source="ch04.baseline_pipeline_parallel",
+        variant="baseline",
+        schedule="gpipe",
+        finish_wall_ns=finish_wall_ns,
+        finish_monotonic_ns=finish_monotonic_ns,
+    )
+    optimized = _validate(
+        optimized_dir,
+        environment=optimized_environment,
+        source="ch04.optimized_pipeline_parallel_1f1b",
+        variant="optimized",
+        schedule="1f1b-paired-p2p",
+        finish_wall_ns=finish_wall_ns,
+        finish_monotonic_ns=finish_monotonic_ns,
+    )
+    assert baseline["input_signature"].matches(optimized["input_signature"])
+    assert baseline["verify_inputs"].keys() == optimized["verify_inputs"].keys()
+    assert baseline["verify_output"].keys() == optimized["verify_output"].keys()
+    for name in baseline["verify_inputs"]:
+        torch.testing.assert_close(
+            baseline["verify_inputs"][name], optimized["verify_inputs"][name], rtol=0, atol=0
+        )
+    for name in baseline["verify_output"]:
+        torch.testing.assert_close(
+            baseline["verify_output"][name], optimized["verify_output"][name], rtol=0, atol=0
+        )
+
+    original = torch.arange(16, dtype=torch.float32).reshape(_SHAPE).to(torch.bfloat16)
+    torch.testing.assert_close(
+        optimized["verify_inputs"]["rank-0:pipeline_input"], original, rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        optimized["verify_inputs"]["rank-1:pipeline_input"], original + 1, rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        optimized["verify_output"]["rank-0:pipeline_output"], original + 33, rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        optimized["verify_output"]["rank-1:pipeline_output"], original + 23, rtol=0, atol=0
+    )
+    assert len({row["pid"] for row in optimized["metadata_by_rank"].values()}) == 2
+    assert all(row["time_per_iter_ms"] > 0 for row in optimized["metadata_by_rank"].values())
+
+    optimized_stdout = "".join(
+        optimized_dir.with_name(f"{optimized_dir.name}.rank-{rank}.stdout").read_text(
+            encoding="utf-8"
+        )
+        for rank in range(_WORLD_SIZE)
+    )
+    receipt_lines = [
+        line
+        for line in optimized_stdout.splitlines(keepends=True)
+        if line.startswith("AISP_PIPELINE_RESULT_RECEIPT:")
+    ]
+    missing_receipt_stdout = optimized_stdout.replace(receipt_lines[1], "", 1)
+    with pytest.raises(RuntimeError, match="stdout receipt rank quorum"):
+        _validate(
+            optimized_dir,
+            environment=optimized_environment,
+            source="ch04.optimized_pipeline_parallel_1f1b",
+            variant="optimized",
+            schedule="1f1b-paired-p2p",
+            finish_wall_ns=finish_wall_ns,
+            finish_monotonic_ns=finish_monotonic_ns,
+            stdout=missing_receipt_stdout,
+        )
+
+    receipt_payload = json.loads(
+        receipt_lines[0].removeprefix("AISP_PIPELINE_RESULT_RECEIPT:")
+    )
+    receipt_payload["pid"] += 1
+    mismatched_receipt = (
+        "AISP_PIPELINE_RESULT_RECEIPT:"
+        + json.dumps(receipt_payload, sort_keys=True, separators=(",", ":"))
+        + "\n"
+    )
+    mismatched_receipt_stdout = optimized_stdout.replace(
+        receipt_lines[0], mismatched_receipt, 1
+    )
+    with pytest.raises(RuntimeError, match="metadata differs from its worker stdout receipt"):
+        _validate(
+            optimized_dir,
+            environment=optimized_environment,
+            source="ch04.optimized_pipeline_parallel_1f1b",
+            variant="optimized",
+            schedule="1f1b-paired-p2p",
+            finish_wall_ns=finish_wall_ns,
+            finish_monotonic_ns=finish_monotonic_ns,
+            stdout=mismatched_receipt_stdout,
+        )
+
+    missing_dir = tmp_path / "missing"
+    shutil.copytree(optimized_dir, missing_dir)
+    (missing_dir / "rank-1.meta.json").unlink()
+    with pytest.raises(RuntimeError, match="rank quorum"):
+        _validate(
+            missing_dir,
+            environment=optimized_environment,
+            source="ch04.optimized_pipeline_parallel_1f1b",
+            variant="optimized",
+            schedule="1f1b-paired-p2p",
+            finish_wall_ns=finish_wall_ns,
+            finish_monotonic_ns=finish_monotonic_ns,
+            stdout=optimized_stdout,
+        )
+
+    stale_dir = tmp_path / "stale"
+    shutil.copytree(optimized_dir, stale_dir)
+    stale_metadata_path = stale_dir / "rank-0.meta.json"
+    stale_metadata = json.loads(stale_metadata_path.read_text(encoding="utf-8"))
+    stale_metadata["created_wall_ns"] = launch_wall_ns - 1
+    stale_metadata_path.write_text(json.dumps(stale_metadata), encoding="utf-8")
+    with pytest.raises(RuntimeError, match="freshness"):
+        _validate(
+            stale_dir,
+            environment=optimized_environment,
+            source="ch04.optimized_pipeline_parallel_1f1b",
+            variant="optimized",
+            schedule="1f1b-paired-p2p",
+            finish_wall_ns=finish_wall_ns,
+            finish_monotonic_ns=finish_monotonic_ns,
+            stdout=optimized_stdout,
+        )
+
+    mismatch_dir = tmp_path / "mismatch"
+    shutil.copytree(optimized_dir, mismatch_dir)
+    mismatch_metadata_path = mismatch_dir / "rank-0.meta.json"
+    mismatch_metadata = json.loads(mismatch_metadata_path.read_text(encoding="utf-8"))
+    mismatch_metadata["source"] = "ch04.baseline_pipeline_parallel"
+    mismatch_metadata_path.write_text(json.dumps(mismatch_metadata), encoding="utf-8")
+    with pytest.raises(RuntimeError, match="source/variant mismatch"):
+        _validate(
+            mismatch_dir,
+            environment=optimized_environment,
+            source="ch04.optimized_pipeline_parallel_1f1b",
+            variant="optimized",
+            schedule="1f1b-paired-p2p",
+            finish_wall_ns=finish_wall_ns,
+            finish_monotonic_ns=finish_monotonic_ns,
+            stdout=optimized_stdout,
+        )
+
+
+def test_post_timing_reference_rejects_a_wrong_actual_microbatch() -> None:
+    capture = PipelineIterationCapture.create(2)
+    capture.forward_inputs[:] = [torch.ones((1, 2)), torch.full((1, 2), 2.0)]
+    capture.backward_inputs[:] = [torch.full((1, 2), 4.0), torch.full((1, 2), 5.0)]
+    capture.backward_outputs[:] = [torch.full((1, 2), 5.0), torch.full((1, 2), 999.0)]
+
+    with pytest.raises(AssertionError):
+        verify_and_concatenate_pipeline_capture(
+            rank=1,
+            capture=capture,
+            forward_stages=[lambda value: value + 1, lambda value: value + 2],
+            backward_stages=[lambda value: value + 10, lambda value: value + 20],
+            tolerance=(0.0, 0.0),
+        )
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name"),
+    (
+        ("ch04.baseline_pipeline_parallel", "BaselinePipelineParallelBenchmark"),
+        ("ch04.optimized_pipeline_parallel_1f1b", "OptimizedPipelineParallelBenchmark"),
+    ),
+)
+def test_profile_specs_do_not_request_full_tensor_transport(
+    module_name: str,
+    class_name: str,
+    tmp_path: Path,
+) -> None:
+    module = __import__(module_name, fromlist=[class_name])
+    benchmark = getattr(module, class_name)()
+    config = BenchmarkConfig(nproc_per_node=2, iterations=1, warmup=5)
+
+    spec = benchmark.get_profile_torchrun_spec(
+        profiler="torch",
+        config=config,
+        output_path=tmp_path / "trace.json",
+    )
+
+    assert spec is not None
+    assert spec.result_callback is None
+    assert RESULT_DIR_ENV not in spec.env
+    assert spec.env["AISP_TORCH_PROFILE_OUTPUT"] == str(tmp_path / "trace.json")
+    assert benchmark._pipeline_result_context is None

--- a/code/tests/test_pipeline_1f1b_schedule.py
+++ b/code/tests/test_pipeline_1f1b_schedule.py
@@ -14,6 +14,7 @@ from typing import Any
 import pytest
 import torch
 import torch.distributed as dist
+
 from ch04.pipeline_parallel_common import (
     CONTRACT_ENV,
     ITERATIONS_ENV,
@@ -418,6 +419,23 @@ def test_post_timing_reference_rejects_a_wrong_actual_microbatch() -> None:
             forward_stages=[lambda value: value + 1, lambda value: value + 2],
             backward_stages=[lambda value: value + 10, lambda value: value + 20],
             tolerance=(0.0, 0.0),
+        )
+
+
+def test_default_reference_tolerance_rejects_a_small_bf16_output_error() -> None:
+    capture = PipelineIterationCapture.create(1)
+    capture.forward_inputs[:] = [torch.ones((1, 2), dtype=torch.bfloat16)]
+    capture.backward_inputs[:] = [torch.ones((1, 2), dtype=torch.bfloat16)]
+    capture.backward_outputs[:] = [torch.ones((1, 2), dtype=torch.bfloat16)]
+    stages = [lambda value: value, lambda value: value]
+    _, actual = verify_and_concatenate_pipeline_capture(
+        rank=1, capture=capture, forward_stages=stages, backward_stages=stages,
+    )
+    torch.testing.assert_close(actual, torch.ones_like(actual), rtol=0, atol=0)
+    capture.backward_outputs[0][0, 0] += 0.125
+    with pytest.raises(AssertionError):
+        verify_and_concatenate_pipeline_capture(
+            rank=1, capture=capture, forward_stages=stages, backward_stages=stages,
         )
 
 

--- a/code/tests/test_profiler_nesting_guard.py
+++ b/code/tests/test_profiler_nesting_guard.py
@@ -1,0 +1,58 @@
+"""Real profiler contexts must not contaminate harness timing or nesting."""
+
+import pytest
+import torch
+
+from tests.protection_test_utils import cpu_harness
+
+
+@pytest.mark.parametrize("profiler_kind", ["kineto", "autograd"])
+@pytest.mark.parametrize("entrypoint", [
+    "benchmark", "_benchmark_custom", "_benchmark_pytorch",
+    "_benchmark_triton", "_benchmark_with_profiling",
+])
+def test_enclosing_profiler_rejected_before_work(profiler_kind, entrypoint):
+    harness, config = cpu_harness()
+    calls = []
+
+    def work():
+        calls.append(torch.ones(4) + 1)
+
+    profiler = (
+        torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU])
+        if profiler_kind == "kineto" else torch.autograd.profiler.profile()
+    )
+    with profiler:
+        with pytest.raises(RuntimeError, match="Active PyTorch profiler"):
+            if entrypoint == "benchmark":
+                harness.benchmark(work)
+            else:
+                getattr(harness, entrypoint)(work, config)
+        assert calls == []
+        # The rejected run must leave the caller's profiler usable.
+        torch.ones(4).add_(1)
+    assert any(event.key == "aten::add_" for event in profiler.key_averages())
+    samples, _ = harness._benchmark_custom(work, config)
+    assert len(samples) == len(calls) == config.iterations
+    for output in calls:
+        torch.testing.assert_close(output, torch.full((4,), 2.0), rtol=0, atol=0)
+
+
+def test_harness_can_collect_its_own_profile_after_timing(tmp_path):
+    import json
+    from pathlib import Path
+
+    harness, config = cpu_harness(profiling_output_dir=tmp_path)
+    outputs = []
+
+    def work():
+        outputs.append(torch.ones(4).add_(1))
+
+    times, _ = harness._benchmark_custom(work, config)
+    assert len(times) == config.iterations
+    profile_times, traces = harness._benchmark_with_profiling(work, config)
+    assert len(profile_times) == config.iterations
+    trace = json.loads(Path(traces["pytorch_trace"]).read_text())
+    assert any(event.get("name") == "aten::add_" for event in trace["traceEvents"])
+    for output in outputs:
+        torch.testing.assert_close(output, torch.full((4,), 2.0), rtol=0, atol=0)

--- a/code/tests/test_run_manifest_provenance.py
+++ b/code/tests/test_run_manifest_provenance.py
@@ -48,8 +48,11 @@ def test_benchmark_with_manifest_records_collection_warning_when_patch_fails(mon
 
     real_create = RunManifest.create.__func__
 
-    def _create_with_bad_hardware(cls, config=None, start_time=None):
-        manifest = real_create(cls, config=config, start_time=start_time)
+    def _create_with_bad_hardware(cls, config=None, start_time=None, *, capture_execution_runtime=True):
+        manifest = real_create(
+            cls, config=config, start_time=start_time,
+            capture_execution_runtime=capture_execution_runtime,
+        )
         manifest.hardware = _BadHardware()
         return manifest
 

--- a/code/tests/test_runtime_provenance_integration.py
+++ b/code/tests/test_runtime_provenance_integration.py
@@ -1,0 +1,128 @@
+"""Runtime identity must belong to the worker that executed the real workload."""
+
+import os
+import json
+import subprocess
+import time
+
+import pytest
+
+from core.benchmark.models import BenchmarkRun
+from core.benchmark.run_manifest import require_runtime_provenance_parity
+from core.benchmark.runtime_comparison import compare_executed_runtime_provenance
+from tests.test_evaluation_harness_integration import _benchmark, _harness
+
+
+@pytest.mark.parametrize("subprocess_mode", [False, True])
+def test_harness_result_and_manifest_retain_execution_process(tmp_path, subprocess_mode):
+    run = _harness(subprocess_mode=subprocess_mode).benchmark_with_manifest(_benchmark(tmp_path))
+    assert not run.result.errors, run.result.errors
+    assert run.result.timing.iterations > 0
+    runtime = run.result.runtime_provenance
+    assert runtime is not None
+    assert run.result.execution_process_ids == {0: runtime.process_id}
+    assert run.result.device == "cpu"
+    if subprocess_mode:
+        assert runtime.process_id != os.getpid()
+    else:
+        assert runtime.process_id == os.getpid()
+    assert run.manifest is not None
+    assert run.manifest.runtime_provenance == runtime
+    restored = BenchmarkRun.model_validate_json(run.model_dump_json())
+    assert restored.manifest.runtime_provenance == runtime
+    assert require_runtime_provenance_parity(run.manifest, restored.manifest, target="cpu").matches
+
+
+def test_pair_gate_uses_real_worker_snapshot_and_rejects_drift(tmp_path):
+    baseline = _harness().benchmark_with_manifest(_benchmark(tmp_path))
+    candidate = _harness(subprocess_mode=True).benchmark_with_manifest(_benchmark(tmp_path))
+    assert not baseline.result.errors and not candidate.result.errors
+    assert compare_executed_runtime_provenance(baseline, candidate).matches
+
+    # Explicit receipt corruption exercises the admission policy; these values
+    # are never presented as observations from a different installed runtime.
+    corrupted = candidate.model_copy(deep=True)
+    corrupted.result.runtime_provenance.torch_version += "-unexpected"
+    corrupted.manifest.runtime_provenance = corrupted.result.runtime_provenance.model_copy(deep=True)
+    parity = compare_executed_runtime_provenance(baseline, corrupted)
+    assert not parity.matches
+    assert "torch_version" in parity.runtime_parity.mismatched_fields
+    assert parity.target == "cpu"
+
+    missing = candidate.model_copy(deep=True)
+    missing.manifest.runtime_provenance = None
+    missing.result.runtime_provenance = None
+    parity = compare_executed_runtime_provenance(baseline, missing)
+    assert not parity.matches and parity.integrity_failures
+
+    substituted = candidate.model_copy(deep=True)
+    substituted.manifest.runtime_provenance = baseline.manifest.runtime_provenance.model_copy(deep=True)
+    assert not compare_executed_runtime_provenance(baseline, substituted).matches
+
+
+@pytest.mark.parametrize("corruption", ["pid", "device"])
+def test_subprocess_transport_rejects_corrupted_real_worker_receipt(tmp_path, monkeypatch, corruption):
+    """Corrupt only transport data from an actual completed child invocation."""
+    real_popen = subprocess.Popen
+
+    class CorruptingTransport(real_popen):
+        def communicate(self, *args, **kwargs):
+            stdout, stderr = super().communicate(*args, **kwargs)
+            if "core.harness.isolated_runner" not in self.args:
+                return stdout, stderr
+            start = stdout.index('{"success"')
+            record, end = json.JSONDecoder().raw_decode(stdout[start:])
+            assert record["success"], record
+            result = json.loads(record["result_json"])
+            if corruption == "pid":
+                result["runtime_provenance"]["process_id"] = os.getpid()
+            else:
+                result["device"] = "cuda:0"
+            record["result_json"] = json.dumps(result)
+            return stdout[:start] + json.dumps(record) + stdout[start + end:], stderr
+
+    monkeypatch.setattr(subprocess, "Popen", CorruptingTransport)
+    run = _harness(subprocess_mode=True).benchmark_with_manifest(_benchmark(tmp_path))
+    assert run.result.errors
+    assert run.result.timing.iterations == 0
+    assert any(("PID" if corruption == "pid" else "device") in error for error in run.result.errors)
+
+
+def test_runtime_collection_occurs_after_work_with_separate_grace(tmp_path, monkeypatch):
+    from core.benchmark import run_manifest
+
+    benchmark = _benchmark(tmp_path)
+    actual_capture = run_manifest.capture_runtime_provenance
+    calls = []
+
+    def delayed_capture():
+        assert benchmark.benchmark_calls > 5
+        assert benchmark.output is not None
+        calls.append(benchmark.benchmark_calls)
+        time.sleep(0.3)  # Metadata latency, not fabricated benchmark execution.
+        return actual_capture()
+
+    monkeypatch.setattr(run_manifest, "capture_runtime_provenance", delayed_capture)
+    harness = _harness()
+    harness.config.measurement_timeout_seconds = 0.2
+    run = harness.benchmark_with_manifest(benchmark)
+    assert not run.result.errors, run.result.errors
+    assert run.result.timing.iterations > 0
+    assert len(calls) == 1
+
+
+def test_runtime_collection_rejects_an_exceeded_receipt_budget(tmp_path, monkeypatch):
+    from core.benchmark import run_manifest
+    from core.harness import benchmark_harness
+
+    actual_capture = run_manifest.capture_runtime_provenance
+
+    def delayed_capture():
+        time.sleep(0.15)
+        return actual_capture()
+
+    monkeypatch.setattr(run_manifest, "capture_runtime_provenance", delayed_capture)
+    monkeypatch.setattr(benchmark_harness, "_RUNTIME_PROVENANCE_TIMEOUT_SECONDS", 0.1)
+    run = _harness().benchmark_with_manifest(_benchmark(tmp_path))
+    assert run.result.timing.iterations == 0
+    assert any("Runtime provenance collection exceeded" in error for error in run.result.errors)

--- a/code/tests/test_runtime_provenance_integration.py
+++ b/code/tests/test_runtime_provenance_integration.py
@@ -6,6 +6,7 @@ import subprocess
 import time
 
 import pytest
+from pydantic import ValidationError
 
 from core.benchmark.models import BenchmarkRun
 from core.benchmark.run_manifest import require_runtime_provenance_parity
@@ -21,6 +22,7 @@ def test_harness_result_and_manifest_retain_execution_process(tmp_path, subproce
     runtime = run.result.runtime_provenance
     assert runtime is not None
     assert run.result.execution_process_ids == {0: runtime.process_id}
+    assert run.result.local_world_size == 1
     assert run.result.device == "cpu"
     if subprocess_mode:
         assert runtime.process_id != os.getpid()
@@ -29,8 +31,14 @@ def test_harness_result_and_manifest_retain_execution_process(tmp_path, subproce
     assert run.manifest is not None
     assert run.manifest.runtime_provenance == runtime
     restored = BenchmarkRun.model_validate_json(run.model_dump_json())
+    assert restored.result.local_world_size == 1
     assert restored.manifest.runtime_provenance == runtime
     assert require_runtime_provenance_parity(run.manifest, restored.manifest, target="cpu").matches
+    for invalid_count in (True, 0, -1, "1", 1.5):
+        corrupted = run.model_dump(mode="json")
+        corrupted["result"]["local_world_size"] = invalid_count
+        with pytest.raises(ValidationError, match="local_world_size"):
+            BenchmarkRun.model_validate_json(json.dumps(corrupted))
 
 
 def test_pair_gate_uses_real_worker_snapshot_and_rejects_drift(tmp_path):

--- a/code/tests/test_runtime_provenance_parity.py
+++ b/code/tests/test_runtime_provenance_parity.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+import torch
+
+from core.benchmark.run_manifest import (
+    CPU_RUNTIME_PARITY_FIELDS,
+    CUDA_RUNTIME_PARITY_FIELDS,
+    EnvironmentInfo,
+    GitInfo,
+    HardwareInfo,
+    RunManifest,
+    RuntimeProvenance,
+    RuntimeProvenanceParityError,
+    SoftwareInfo,
+    capture_runtime_provenance,
+    compare_runtime_provenance,
+    require_runtime_provenance_parity,
+)
+
+
+def _runtime(**updates: object) -> RuntimeProvenance:
+    values: dict[str, object] = {
+        "cuda_available": True,
+        "driver_version": "580.126.09",
+        "torch_version": "2.9.1+cu130",
+        "cuda_version": "13.0",
+        "cudnn_version": "91300",
+        "python_version": "3.12.0",
+        "os": "linux",
+        "python_executable": "/usr/bin/python3",
+        "process_id": 1234,
+        "captured_at": "2026-09-07T00:00:00+00:00",
+        "library_versions": {
+            "nvidia-cublas-cu13": "13.0.0",
+            "numpy": "2.1.2",
+            "torch": "2.9.1+cu130",
+            "triton": "3.5.1",
+        },
+        "library_versions_complete": True,
+        "collection_warnings": [],
+    }
+    values.update(updates)
+    return RuntimeProvenance(**values)
+
+
+def _manifest(runtime: RuntimeProvenance | None) -> RunManifest:
+    return RunManifest(
+        hardware=HardwareInfo(
+            gpu_model="NVIDIA B200",
+            cuda_version="13.0",
+            driver_version="580.126.09",
+            compute_capability="10.0",
+        ),
+        software=SoftwareInfo(
+            pytorch_version="2.9.1+cu130",
+            triton_version="3.5.1",
+            python_version="3.12.0",
+            os="linux",
+        ),
+        runtime_provenance=runtime,
+        environment=EnvironmentInfo(),
+        git=GitInfo(commit="deadbeef", branch="main", dirty=False),
+        start_time=datetime(2026, 9, 7),
+    )
+
+
+def test_capture_runtime_provenance_records_current_process_and_libraries() -> None:
+    runtime = capture_runtime_provenance()
+
+    assert runtime.process_id == os.getpid()
+    assert Path(runtime.python_executable).resolve() == Path(sys.executable).resolve()
+    assert runtime.torch_version == str(torch.__version__)
+    assert runtime.python_version == sys.version.split()[0]
+    assert runtime.os == sys.platform
+    assert runtime.library_versions_complete is True
+    assert runtime.library_versions["torch"]
+
+
+def test_capture_runtime_provenance_runs_inside_real_child_process() -> None:
+    code_root = Path(__file__).resolve().parents[1]
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from core.benchmark.run_manifest import capture_runtime_provenance; "
+                "print(capture_runtime_provenance().model_dump_json())"
+            ),
+        ],
+        cwd=code_root,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    payload = json.loads(completed.stdout)
+
+    assert payload["process_id"] != os.getpid()
+    assert Path(payload["python_executable"]).resolve() == Path(sys.executable).resolve()
+    assert payload["torch_version"] == str(torch.__version__)
+    assert payload["library_versions_complete"] is True
+
+
+def test_library_capture_uses_sys_path_precedence_and_records_shadowed_versions(
+    tmp_path: Path,
+) -> None:
+    selected = tmp_path / "selected"
+    donor = tmp_path / "donor"
+    for root, version in ((selected, "1.0"), (donor, "0.9")):
+        metadata_dir = root / f"vllm-{version}.dist-info"
+        metadata_dir.mkdir(parents=True)
+        (metadata_dir / "METADATA").write_text(
+            f"Metadata-Version: 2.1\nName: vllm\nVersion: {version}\n",
+            encoding="utf-8",
+        )
+
+    code_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join((str(selected), str(donor), str(code_root)))
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from core.benchmark.run_manifest import capture_runtime_provenance; "
+                "print(capture_runtime_provenance().model_dump_json())"
+            ),
+        ],
+        cwd=code_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    payload = json.loads(completed.stdout)
+
+    assert payload["library_versions"]["vllm"] == "1.0"
+    assert "0.9" in payload["shadowed_library_versions"]["vllm"]
+    assert payload["library_versions_complete"] is True
+
+
+def test_library_capture_marks_conflicting_versions_at_same_precedence_unknown(
+    tmp_path: Path,
+) -> None:
+    ambiguous = tmp_path / "ambiguous"
+    for version in ("1.0", "2.0"):
+        metadata_dir = ambiguous / f"vllm-{version}.dist-info"
+        metadata_dir.mkdir(parents=True)
+        (metadata_dir / "METADATA").write_text(
+            f"Metadata-Version: 2.1\nName: vllm\nVersion: {version}\n",
+            encoding="utf-8",
+        )
+
+    code_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join((str(ambiguous), str(code_root)))
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from core.benchmark.run_manifest import capture_runtime_provenance; "
+                "print(capture_runtime_provenance().model_dump_json())"
+            ),
+        ],
+        cwd=code_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    payload = json.loads(completed.stdout)
+
+    assert payload["library_versions"]["vllm"] == "1.0 | 2.0"
+    assert payload["library_versions_complete"] is False
+    assert any(
+        "conflicting active distribution versions" in warning
+        for warning in payload["collection_warnings"]
+    )
+
+
+def test_canonical_cpu_and_cuda_parity_fields_are_explicit() -> None:
+    assert CPU_RUNTIME_PARITY_FIELDS == (
+        "torch_version",
+        "python_version",
+        "os",
+        "library_versions",
+    )
+    assert CUDA_RUNTIME_PARITY_FIELDS == (
+        "cuda_available",
+        "driver_version",
+        "torch_version",
+        "cuda_version",
+        "cudnn_version",
+        "python_version",
+        "os",
+        "library_versions",
+    )
+
+
+def test_matching_executor_snapshots_pass_for_the_declared_target() -> None:
+    reference = _manifest(_runtime(process_id=101))
+    candidate = _manifest(
+        _runtime(
+            process_id=202,
+            python_executable="/venv/bin/python",
+            shadowed_library_versions={"vllm": ["0.15.0"]},
+        )
+    )
+
+    cpu = compare_runtime_provenance(reference, candidate, target="cpu")
+    cuda = require_runtime_provenance_parity(reference, candidate, target="cuda")
+
+    assert cpu.matches is True
+    assert cuda.matches is True
+    assert cpu.mismatched_fields == []
+    assert cuda.unknown_fields == []
+    assert "process_id" not in cuda.required_fields
+    assert "python_executable" not in cuda.required_fields
+
+
+@pytest.mark.parametrize(
+    ("field_name", "different_value"),
+    [
+        ("driver_version", "580.173.02"),
+        ("torch_version", "2.10.0+cu130"),
+        ("cuda_version", "13.1"),
+        ("cudnn_version", "91400"),
+        ("library_versions", {"numpy": "2.2.0", "torch": "2.9.1+cu130"}),
+    ],
+)
+def test_cuda_parity_reports_each_runtime_or_library_mismatch(
+    field_name: str,
+    different_value: object,
+) -> None:
+    reference = _manifest(_runtime())
+    candidate = _manifest(_runtime(**{field_name: different_value}))
+
+    comparison = compare_runtime_provenance(reference, candidate, target="cuda")
+
+    assert comparison.matches is False
+    assert comparison.mismatched_fields == [field_name]
+    assert comparison.unknown_fields == []
+    assert comparison.fields[field_name].status == "mismatch"
+
+
+def test_incomplete_library_snapshot_is_unknown_and_gate_raises() -> None:
+    reference = _manifest(_runtime())
+    candidate = _manifest(_runtime(library_versions_complete=False))
+
+    comparison = compare_runtime_provenance(reference, candidate, target="cpu")
+
+    assert comparison.matches is False
+    assert comparison.mismatched_fields == []
+    assert comparison.unknown_fields == ["library_versions"]
+    with pytest.raises(RuntimeProvenanceParityError) as exc_info:
+        require_runtime_provenance_parity(reference, candidate, target="cpu")
+    assert exc_info.value.comparison == comparison
+
+
+def test_cuda_profile_rejects_cpu_snapshots_even_when_they_match() -> None:
+    cpu_runtime = _runtime(
+        cuda_available=False,
+        driver_version=None,
+        cuda_version=None,
+        cudnn_version=None,
+    )
+    reference = _manifest(cpu_runtime)
+    candidate = _manifest(cpu_runtime.model_copy(deep=True))
+
+    comparison = compare_runtime_provenance(reference, candidate, target="cuda")
+
+    assert comparison.matches is False
+    assert comparison.fields["cuda_available"].status == "mismatch"
+    assert comparison.unknown_fields == [
+        "driver_version",
+        "cuda_version",
+        "cudnn_version",
+    ]
+
+
+def test_historical_manifest_without_runtime_provenance_loads_but_is_unknown() -> None:
+    legacy_payload = _manifest(None).model_dump(mode="json")
+    legacy_payload.pop("runtime_provenance")
+
+    historical = RunManifest.model_validate(legacy_payload)
+    comparison = compare_runtime_provenance(historical, historical, target="cpu")
+
+    assert historical.runtime_provenance is None
+    assert comparison.matches is False
+    assert comparison.unknown_fields == list(CPU_RUNTIME_PARITY_FIELDS)
+
+
+def test_subprocess_coordinator_does_not_claim_executor_runtime() -> None:
+    manifest = RunManifest.create(config={"execution_mode": "subprocess"})
+
+    assert manifest.runtime_provenance is None
+    manifest.finalize()
+    comparison = compare_runtime_provenance(manifest, manifest, target="cpu")
+    assert comparison.matches is False
+    assert comparison.unknown_fields == list(CPU_RUNTIME_PARITY_FIELDS)
+
+
+def test_runtime_parity_requires_an_explicit_supported_target() -> None:
+    manifest = _manifest(_runtime())
+
+    with pytest.raises(ValueError, match="Unsupported runtime parity target"):
+        compare_runtime_provenance(manifest, manifest, target="gpu")  # type: ignore[arg-type]

--- a/code/tests/test_te_precision_training_outputs.py
+++ b/code/tests/test_te_precision_training_outputs.py
@@ -10,7 +10,45 @@ import torch.nn as nn
 
 from ch13.baseline_precisionfp8_te import BaselineTEFP8Benchmark
 from ch13.optimized_precisionfp8_te import OptimizedTEFP8Benchmark
+from core.benchmark.verification import get_output_tolerances
+from core.benchmark.verification_mixin import VerificationPayloadMixin
 from core.benchmark.verify_runner import VerifyRunner
+
+EXPECTED_OUTPUT_TOLERANCES = {
+    "prediction": (0.4, 1.0),
+    "parameter.fc1.weight": (0.001, 0.00075),
+    "parameter.fc1.bias": (0.001, 0.00005),
+    "parameter.fc2.weight": (0.001, 0.00075),
+    "parameter.fc2.bias": (0.001, 0.00005),
+}
+
+
+def _assert_calibrated_output_policy(benchmark, output) -> None:
+    tolerances = get_output_tolerances(benchmark)
+    assert benchmark.get_output_tolerance() == (0.4, 1.0)
+    assert tolerances == EXPECTED_OUTPUT_TOLERANCES
+    assert VerificationPayloadMixin.get_output_tolerances(benchmark) == tolerances
+    assert set(tolerances) == set(output)
+    runner = VerifyRunner()
+    assert runner.compare_perf_outputs(output, output, tolerances).passed
+
+    for name, expected in output.items():
+        tolerance = {name: tolerances[name]}
+        zeroed = expected.clone()
+        zeroed.zero_()
+        assert not runner.compare_perf_outputs(
+            {name: expected}, {name: zeroed}, tolerance
+        ).passed
+
+        perturbed = expected.clone()
+        index = int(torch.argmax(expected.reshape(-1).abs()))
+        reference = float(expected.reshape(-1)[index])
+        rtol, atol = tolerances[name]
+        perturbation = 2.0 * (atol + rtol * abs(reference))
+        perturbed.reshape(-1)[index].add_(perturbation)
+        assert not runner.compare_perf_outputs(
+            {name: expected}, {name: perturbed}, tolerance
+        ).passed
 
 
 @pytest.mark.parametrize(
@@ -32,6 +70,9 @@ def test_training_payload_contains_target_prediction_and_every_named_parameter(
     )
     verify_input = torch.arange(6, dtype=torch.float32).reshape(2, 3)
     verify_target = torch.arange(4, dtype=torch.float32).reshape(2, 2) + 100
+    with torch.no_grad():
+        for parameter in benchmark.model.parameters():
+            parameter.fill_(0.25)
     prediction = benchmark.model(verify_input).detach()
     benchmark._verify_input = verify_input
     benchmark._verify_target = verify_target
@@ -64,6 +105,7 @@ def test_training_payload_contains_target_prediction_and_every_named_parameter(
     assert all(tensor.device.type == "cpu" for tensor in output.values())
     for name, expected in parameter_snapshots.items():
         torch.testing.assert_close(output[f"parameter.{name}"], expected)
+    _assert_calibrated_output_policy(benchmark, output)
     corrupted = {name: tensor.clone() for name, tensor in output.items()}
     corrupted[next(name for name in corrupted if name.startswith("parameter."))].add_(1)
     assert not VerifyRunner().compare_perf_outputs(output, corrupted, (0.0, 0.0)).passed
@@ -116,32 +158,32 @@ def _require_real_te218_cuda() -> None:
 def test_real_te218_cuda_harness_retains_full_training_output(benchmark_type) -> None:
     _require_real_te218_cuda()
     from core.harness.benchmark_harness import (
-        BenchmarkConfig,
         BenchmarkHarness,
         BenchmarkMode,
         ExecutionMode,
     )
 
     benchmark = benchmark_type()
-    config = BenchmarkConfig(
-        device=torch.device("cuda"),
-        iterations=1,
-        warmup=0,
-        use_subprocess=False,
-        execution_mode=ExecutionMode.THREAD,
-        enable_profiling=False,
-        enable_memory_tracking=False,
-        enforce_environment_validation=False,
-        allow_virtualization=True,
-        clear_l2_cache=False,
-        monitor_gpu_state=False,
-        track_memory_allocations=False,
-        single_gpu=True,
-    )
+    config = benchmark.get_config()
+    config.device = torch.device("cuda")
+    config.use_subprocess = False
+    config.execution_mode = ExecutionMode.THREAD
+    config.enable_profiling = False
+    config.enable_memory_tracking = False
+    config.enforce_environment_validation = False
+    config.allow_virtualization = True
+    config.clear_l2_cache = False
+    config.monitor_gpu_state = False
+    config.track_memory_allocations = False
+    config.single_gpu = True
+    assert config.backend_policy == "fp32_strict"
+    assert config.iterations == 50
+    assert config.warmup == 10
     result = BenchmarkHarness(mode=BenchmarkMode.CUSTOM, config=config).benchmark(benchmark)
 
     assert not result.errors, result.errors
-    assert result.timing.iterations == 1
+    assert result.timing.iterations == 50
+    assert result.timing.warmup_iterations == 10
     output = benchmark.get_verify_output()
     assert "prediction" in output
     parameter_outputs = {
@@ -152,6 +194,7 @@ def test_real_te218_cuda_harness_retains_full_training_output(benchmark_type) ->
     assert parameter_outputs
     assert sum(tensor.numel() for tensor in parameter_outputs.values()) == benchmark.parameter_count
     assert all(torch.isfinite(tensor).all() for tensor in output.values())
+    _assert_calibrated_output_policy(benchmark, output)
     retained_inputs = benchmark.get_verify_inputs()
     assert set(retained_inputs) == {"input", "target"}
     assert all(tensor.device.type == "cpu" for tensor in retained_inputs.values())

--- a/code/tests/test_te_precision_training_outputs.py
+++ b/code/tests/test_te_precision_training_outputs.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import os
+from collections import OrderedDict
+from importlib.metadata import PackageNotFoundError, version
+
+import pytest
+import torch
+import torch.nn as nn
+
+from ch13.baseline_precisionfp8_te import BaselineTEFP8Benchmark
+from ch13.optimized_precisionfp8_te import OptimizedTEFP8Benchmark
+from core.benchmark.verify_runner import VerifyRunner
+
+
+@pytest.mark.parametrize(
+    "benchmark_type",
+    [BaselineTEFP8Benchmark, OptimizedTEFP8Benchmark],
+)
+def test_training_payload_contains_target_prediction_and_every_named_parameter(
+    benchmark_type,
+) -> None:
+    benchmark = benchmark_type()
+    benchmark.model = nn.Sequential(
+        OrderedDict(
+            (
+                ("fc1", nn.Linear(3, 4)),
+                ("activation", nn.GELU()),
+                ("fc2", nn.Linear(4, 2)),
+            )
+        )
+    )
+    verify_input = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    verify_target = torch.arange(4, dtype=torch.float32).reshape(2, 2) + 100
+    prediction = benchmark.model(verify_input).detach()
+    benchmark._verify_input = verify_input
+    benchmark._verify_target = verify_target
+    benchmark.output = prediction
+    benchmark._verify_output_buffer = torch.empty_like(prediction)
+    benchmark.parameter_count = sum(parameter.numel() for parameter in benchmark.model.parameters())
+
+    parameter_snapshots = {
+        name: parameter.detach().clone()
+        for name, parameter in benchmark.model.named_parameters()
+    }
+    benchmark.capture_verification_payload()
+
+    inputs = benchmark.get_verify_inputs()
+    assert set(inputs) == {"input", "target"}
+    assert inputs["input"].data_ptr() == verify_input.data_ptr()
+    assert inputs["target"].data_ptr() == verify_target.data_ptr()
+    torch.testing.assert_close(inputs["input"], verify_input)
+    torch.testing.assert_close(inputs["target"], verify_target)
+    signature = benchmark.get_input_signature()
+    assert signature.shapes["target"] == tuple(verify_target.shape)
+    assert signature.dtypes["target"] == "float32"
+
+    output = benchmark.get_verify_output()
+    assert set(output) == {
+        "prediction",
+        *(f"parameter.{name}" for name in parameter_snapshots),
+    }
+    torch.testing.assert_close(output["prediction"], prediction)
+    assert all(tensor.device.type == "cpu" for tensor in output.values())
+    for name, expected in parameter_snapshots.items():
+        torch.testing.assert_close(output[f"parameter.{name}"], expected)
+    corrupted = {name: tensor.clone() for name, tensor in output.items()}
+    corrupted[next(name for name in corrupted if name.startswith("parameter."))].add_(1)
+    assert not VerifyRunner().compare_perf_outputs(output, corrupted, (0.0, 0.0)).passed
+
+    with torch.no_grad():
+        for parameter in benchmark.model.parameters():
+            parameter.add_(10)
+    retained = benchmark.get_verify_output()
+    for name, expected in parameter_snapshots.items():
+        torch.testing.assert_close(retained[f"parameter.{name}"], expected)
+
+    benchmark.teardown()
+    retained_inputs = benchmark.get_verify_inputs()
+    assert all(tensor.device.type == "cpu" for tensor in retained_inputs.values())
+    torch.testing.assert_close(retained_inputs["target"], verify_target)
+    assert all(tensor.device.type == "cpu" for tensor in benchmark.get_verify_output().values())
+
+
+def test_fp16_baseline_metrics_do_not_label_the_run_as_fp32() -> None:
+    benchmark = BaselineTEFP8Benchmark()
+    benchmark._last_elapsed_ms = 1.25
+
+    metrics = benchmark.get_custom_metrics()
+
+    assert metrics["precision.reduced_ms"] == 1.25
+    assert metrics["precision.theoretical_storage_reduction_factor"] == 2.0
+    assert "precision.fp32_ms" not in metrics
+
+
+def _require_real_te218_cuda() -> None:
+    if os.environ.get("AISP_RUN_TE218_CUDA_TESTS") != "1":
+        pytest.skip("set AISP_RUN_TE218_CUDA_TESTS=1 for the real TE2.18 CUDA harness test")
+    if not torch.cuda.is_available():
+        pytest.skip("real Transformer Engine test requires CUDA")
+    try:
+        te_version = version("transformer_engine")
+    except PackageNotFoundError:
+        pytest.skip("real Transformer Engine test requires transformer_engine")
+    if not te_version.startswith("2.18."):
+        pytest.skip(f"real Transformer Engine test requires 2.18.x, found {te_version}")
+
+
+@pytest.mark.cuda
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "benchmark_type",
+    [BaselineTEFP8Benchmark, OptimizedTEFP8Benchmark],
+)
+def test_real_te218_cuda_harness_retains_full_training_output(benchmark_type) -> None:
+    _require_real_te218_cuda()
+    from core.harness.benchmark_harness import (
+        BenchmarkConfig,
+        BenchmarkHarness,
+        BenchmarkMode,
+        ExecutionMode,
+    )
+
+    benchmark = benchmark_type()
+    config = BenchmarkConfig(
+        device=torch.device("cuda"),
+        iterations=1,
+        warmup=0,
+        use_subprocess=False,
+        execution_mode=ExecutionMode.THREAD,
+        enable_profiling=False,
+        enable_memory_tracking=False,
+        enforce_environment_validation=False,
+        allow_virtualization=True,
+        clear_l2_cache=False,
+        monitor_gpu_state=False,
+        track_memory_allocations=False,
+        single_gpu=True,
+    )
+    result = BenchmarkHarness(mode=BenchmarkMode.CUSTOM, config=config).benchmark(benchmark)
+
+    assert not result.errors, result.errors
+    assert result.timing.iterations == 1
+    output = benchmark.get_verify_output()
+    assert "prediction" in output
+    parameter_outputs = {
+        name.removeprefix("parameter."): tensor
+        for name, tensor in output.items()
+        if name.startswith("parameter.")
+    }
+    assert parameter_outputs
+    assert sum(tensor.numel() for tensor in parameter_outputs.values()) == benchmark.parameter_count
+    assert all(torch.isfinite(tensor).all() for tensor in output.values())
+    retained_inputs = benchmark.get_verify_inputs()
+    assert set(retained_inputs) == {"input", "target"}
+    assert all(tensor.device.type == "cpu" for tensor in retained_inputs.values())
+    assert all(tensor.device.type == "cpu" for tensor in output.values())
+
+
+def _run_real_te218_step_with_target_delta(benchmark_type, target_delta: float):
+    torch.manual_seed(7391)
+    torch.cuda.manual_seed_all(7391)
+    benchmark = benchmark_type()
+    benchmark.batch_size = 16
+    benchmark.hidden_dim = 128
+    benchmark.setup()
+    try:
+        if isinstance(benchmark, BaselineTEFP8Benchmark):
+            training_target = benchmark.targets
+        else:
+            training_target = benchmark.target_pool[0]
+        assert training_target is not None
+        live_target = benchmark.get_verify_inputs()["target"]
+        assert live_target.data_ptr() == training_target.data_ptr()
+        initial_parameters = {
+            name: parameter.detach().cpu().clone()
+            for name, parameter in benchmark.model.named_parameters()
+        }
+        with torch.no_grad():
+            live_target.add_(target_delta)
+        benchmark.benchmark_fn()
+        benchmark.capture_verification_payload()
+        final_parameters = {
+            name.removeprefix("parameter."): tensor
+            for name, tensor in benchmark.get_verify_output().items()
+            if name.startswith("parameter.")
+        }
+        return initial_parameters, final_parameters
+    finally:
+        benchmark.teardown()
+
+
+@pytest.mark.cuda
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "benchmark_type",
+    [BaselineTEFP8Benchmark, OptimizedTEFP8Benchmark],
+)
+def test_real_te218_live_target_changes_post_sgd_parameters(benchmark_type) -> None:
+    _require_real_te218_cuda()
+    control_initial, control_final = _run_real_te218_step_with_target_delta(
+        benchmark_type, 0.0
+    )
+    changed_initial, changed_final = _run_real_te218_step_with_target_delta(
+        benchmark_type, 8.0
+    )
+
+    assert control_initial.keys() == changed_initial.keys()
+    assert control_final.keys() == changed_final.keys() == control_initial.keys()
+    for name in control_initial:
+        torch.testing.assert_close(control_initial[name], changed_initial[name], rtol=0, atol=0)
+    assert any(
+        not torch.equal(control_final[name], changed_final[name])
+        for name in control_final
+    )

--- a/code/tests/test_torchrun_runtime_provenance.py
+++ b/code/tests/test_torchrun_runtime_provenance.py
@@ -14,7 +14,9 @@ import pytest
 import torch
 
 import core.harness.torchrun_runtime_provenance as runtime_transport
+from core.benchmark.models import BenchmarkRun
 from core.benchmark.run_manifest import RuntimeProvenance, capture_runtime_provenance
+from core.benchmark.runtime_comparison import compare_executed_runtime_provenance
 from core.harness.benchmark_harness import (
     BaseBenchmark,
     BenchmarkConfig,
@@ -443,6 +445,10 @@ def test_benchmark_with_manifest_uses_actual_torchrun_worker_receipts(tmp_path: 
     )
     assert raw_receipts.execution_process_ids == run.result.execution_process_ids
     assert raw_receipts.snapshots_by_local_rank == run.result.runtime_provenance_by_local_rank
+    assert run.result.local_world_size == 2
+
+    round_tripped = BenchmarkRun.model_validate_json(run.model_dump_json())
+    assert round_tripped.result.local_world_size == 2
 
     assert run.result.validation_message is not None
     assert run.result.validation_message.count("all_reduce=3") == 2
@@ -453,6 +459,70 @@ def test_benchmark_with_manifest_uses_actual_torchrun_worker_receipts(tmp_path: 
         assert datetime.fromisoformat(runtime.captured_at) >= datetime.fromisoformat(
             marker["target_finished_at"]
         )
+
+    clean_comparison = compare_executed_runtime_provenance(
+        run,
+        round_tripped,
+    )
+    assert clean_comparison.matches
+    assert clean_comparison.integrity_failures == []
+
+    truncated = round_tripped.model_copy(deep=True)
+    truncated.result.execution_process_ids.pop(1)
+    truncated.result.runtime_provenance_by_local_rank.pop(1)
+    rejected = compare_executed_runtime_provenance(run, truncated)
+    assert not rejected.matches
+    truncation_codes = {
+        failure.code
+        for failure in rejected.integrity_failures
+        if failure.run == "candidate"
+    }
+    assert "execution_process_ids_incomplete" in truncation_codes
+
+    missing_count = round_tripped.model_copy(deep=True)
+    missing_count.result.local_world_size = None
+    rejected = compare_executed_runtime_provenance(run, missing_count)
+    assert not rejected.matches
+    assert any(
+        failure.code == "local_world_size_missing" and failure.run == "candidate"
+        for failure in rejected.integrity_failures
+    )
+
+    invalid_count = round_tripped.model_copy(deep=True)
+    invalid_count.result.local_world_size = True
+    rejected = compare_executed_runtime_provenance(run, invalid_count)
+    assert not rejected.matches
+    assert any(
+        failure.code == "local_world_size_invalid" and failure.run == "candidate"
+        for failure in rejected.integrity_failures
+    )
+
+    corrupted = run.model_copy(deep=True)
+    corrupted.result.runtime_provenance_by_local_rank[1].torch_version += "+corrupt-rank1"
+    rejected = compare_executed_runtime_provenance(run, corrupted)
+    assert not rejected.matches
+    rank_failures = [
+        failure
+        for failure in rejected.integrity_failures
+        if failure.code == "runtime_rank_provenance_mismatch"
+    ]
+    assert len(rank_failures) == 1
+    assert rank_failures[0].run == "candidate"
+    assert rank_failures[0].local_rank == 1
+    assert "torch_version" in rank_failures[0].detail
+
+    incomplete = run.model_copy(deep=True)
+    incomplete.result.runtime_provenance_by_local_rank[1].library_versions_complete = False
+    rejected = compare_executed_runtime_provenance(run, incomplete)
+    unknown_failures = [
+        failure
+        for failure in rejected.integrity_failures
+        if failure.code == "runtime_rank_provenance_unknown"
+    ]
+    assert len(unknown_failures) == 1
+    assert unknown_failures[0].run == "candidate"
+    assert unknown_failures[0].local_rank == 1
+    assert "library_versions" in unknown_failures[0].detail
 
 
 @pytest.mark.parametrize(

--- a/code/tests/test_torchrun_runtime_provenance.py
+++ b/code/tests/test_torchrun_runtime_provenance.py
@@ -1,0 +1,537 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import socket
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+import torch
+
+import core.harness.torchrun_runtime_provenance as runtime_transport
+from core.benchmark.run_manifest import RuntimeProvenance, capture_runtime_provenance
+from core.harness.benchmark_harness import (
+    BaseBenchmark,
+    BenchmarkConfig,
+    BenchmarkHarness,
+    LaunchVia,
+    TorchrunLaunchSpec,
+)
+from core.harness.torchrun_runtime_provenance import (
+    TORCHRUN_RUNTIME_PROVENANCE_PREFIX,
+    TORCHRUN_RUNTIME_PROVENANCE_SCHEMA,
+    TorchrunRuntimeProvenanceError,
+    format_torchrun_runtime_provenance_frames,
+    parse_torchrun_runtime_provenance_stdout,
+)
+
+CODE_ROOT = Path(__file__).resolve().parents[1]
+TEST_PIPE_BUF = 512
+
+
+class _TorchrunHarnessSmokeBenchmark(BaseBenchmark):
+    allow_cpu = True
+
+    def __init__(self, target: Path, marker_dir: Path) -> None:
+        super().__init__()
+        self.name = "runtime-provenance-harness-smoke"
+        self._target = target
+        self._marker_dir = marker_dir
+        self._input = torch.tensor([1.0])
+        self._output = self._input + 1.0
+
+    def benchmark_fn(self) -> None:
+        self._output = self._input + 1.0
+
+    def get_torchrun_spec(self, config: BenchmarkConfig | None = None) -> TorchrunLaunchSpec:
+        return TorchrunLaunchSpec(
+            script_path=self._target,
+            script_args=[str(self._marker_dir)],
+            parse_rank0_only=False,
+            name=self.name,
+        )
+
+    def get_verify_inputs(self) -> dict[str, torch.Tensor]:
+        return {"input": self._input}
+
+    def get_verify_output(self) -> torch.Tensor:
+        return self._output
+
+    def get_input_signature(self) -> dict[str, object]:
+        return {"shape": tuple(self._input.shape), "dtype": str(self._input.dtype)}
+
+    def get_output_tolerance(self) -> tuple[float, float]:
+        return (0.0, 0.0)
+
+
+def _cpu_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    for name in (
+        "RANK",
+        "WORLD_SIZE",
+        "LOCAL_RANK",
+        "LOCAL_WORLD_SIZE",
+        "MASTER_ADDR",
+        "MASTER_PORT",
+    ):
+        environment.pop(name, None)
+    environment["CUDA_VISIBLE_DEVICES"] = ""
+    environment["OMP_NUM_THREADS"] = "1"
+    prior_pythonpath = environment.get("PYTHONPATH")
+    environment["PYTHONPATH"] = (
+        str(CODE_ROOT)
+        if not prior_pythonpath
+        else os.pathsep.join((str(CODE_ROOT), prior_pythonpath))
+    )
+    return environment
+
+
+def _wrapper_command(target: Path, *, emit: bool) -> list[str]:
+    command = [
+        sys.executable,
+        "-m",
+        "core.harness.torchrun_wrapper",
+        "--aisp-target-script",
+        str(target),
+        "--aisp-expected-torch-seed",
+        "42",
+    ]
+    if emit:
+        command.append("--aisp-emit-runtime-provenance")
+    return command
+
+
+def _frames(
+    snapshot: RuntimeProvenance,
+    *,
+    local_rank: int = 0,
+    rank: int = 0,
+    world_size: int = 1,
+    local_world_size: int = 1,
+    pipe_buf: int = TEST_PIPE_BUF,
+) -> tuple[bytes, ...]:
+    return format_torchrun_runtime_provenance_frames(
+        snapshot,
+        local_rank=local_rank,
+        rank=rank,
+        world_size=world_size,
+        local_world_size=local_world_size,
+        pipe_buf=pipe_buf,
+    )
+
+
+def _record(snapshot: RuntimeProvenance, **metadata: int) -> str:
+    return b"".join(_frames(snapshot, **metadata)).decode("utf-8")
+
+
+def _unchecked_single_frame(
+    snapshot: RuntimeProvenance,
+    *,
+    envelope_process_id: int,
+) -> str:
+    runtime_json = json.dumps(
+        snapshot.model_dump(mode="json"),
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    payload = {
+        "s": TORCHRUN_RUNTIME_PROVENANCE_SCHEMA,
+        "r": 0,
+        "lr": 0,
+        "ws": 1,
+        "lws": 1,
+        "p": envelope_process_id,
+        "i": 0,
+        "n": 1,
+        "h": hashlib.sha256(runtime_json).hexdigest(),
+        "d": base64.b64encode(runtime_json).decode("ascii"),
+    }
+    return (
+        TORCHRUN_RUNTIME_PROVENANCE_PREFIX
+        + json.dumps(payload, separators=(",", ":"), sort_keys=True)
+        + "\n"
+    )
+
+
+def _unused_loopback_endpoint() -> str:
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return f"127.0.0.1:{listener.getsockname()[1]}"
+
+
+def test_real_cpu_wrapper_emits_child_snapshot_and_parser_cleans_stdout(tmp_path: Path) -> None:
+    target = tmp_path / "successful_target.py"
+    target.write_text(
+        "import os\n" "print(f'child diagnostic pid={os.getpid()}', flush=True)\n",
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        _wrapper_command(target, emit=True),
+        cwd=CODE_ROOT,
+        env=_cpu_environment(),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    parsed = parse_torchrun_runtime_provenance_stdout(
+        completed.stdout,
+        expected_local_ranks={0},
+        target="cpu",
+    )
+    assert parsed.raw_stdout == completed.stdout
+    assert parsed.clean_stdout.startswith("child diagnostic pid=")
+    assert TORCHRUN_RUNTIME_PROVENANCE_PREFIX not in parsed.clean_stdout
+    assert parsed.primary_snapshot.process_id > 0
+    assert parsed.primary_snapshot.process_id != os.getpid()
+    assert parsed.primary_snapshot.python_executable == sys.executable
+    assert parsed.execution_process_ids == {0: parsed.primary_snapshot.process_id}
+    record_lines = [
+        line
+        for line in completed.stdout.splitlines()
+        if line.startswith(TORCHRUN_RUNTIME_PROVENANCE_PREFIX)
+    ]
+    assert record_lines
+    pipe_buf = os.pathconf(CODE_ROOT, "PC_PIPE_BUF")
+    assert all(len((line + "\n").encode("utf-8")) <= pipe_buf for line in record_lines)
+
+
+def test_large_complete_inventory_round_trips_over_bounded_atomic_frames() -> None:
+    snapshot = capture_runtime_provenance()
+    library_versions = dict(snapshot.library_versions)
+    library_versions.update(
+        {
+            f"synthetic-performance-library-{index:03d}": f"2026.9.{index}+{'x' * 48}"
+            for index in range(160)
+        }
+    )
+    shadowed_library_versions = dict(snapshot.shadowed_library_versions)
+    shadowed_library_versions.update(
+        {
+            f"synthetic-performance-library-{index:03d}": [
+                f"/opt/alternate-environments/{index:03d}/site-packages"
+            ]
+            for index in range(16)
+        }
+    )
+    large_snapshot = snapshot.model_copy(
+        update={
+            "library_versions": library_versions,
+            "library_versions_complete": True,
+            "shadowed_library_versions": shadowed_library_versions,
+        }
+    )
+
+    frames = _frames(large_snapshot)
+
+    assert len(frames) > 2
+    assert all(len(frame) <= TEST_PIPE_BUF for frame in frames)
+    midpoint = len(frames) // 2
+    stdout = (
+        "before receipt\n"
+        + b"".join(frames[:midpoint]).decode("utf-8")
+        + "ordinary diagnostic\n"
+        + b"".join(frames[midpoint:]).decode("utf-8")
+        + "after receipt\n"
+    )
+    parsed = parse_torchrun_runtime_provenance_stdout(
+        stdout,
+        expected_local_ranks={0},
+        target="cpu",
+    )
+    assert parsed.clean_stdout == "before receipt\nordinary diagnostic\nafter receipt\n"
+    assert parsed.primary_snapshot.model_dump(mode="json") == large_snapshot.model_dump(mode="json")
+    assert parsed.execution_process_ids == {0: large_snapshot.process_id}
+
+
+def test_emitter_rejects_snapshot_for_a_different_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    snapshot = capture_runtime_provenance().model_copy(update={"process_id": os.getpid() + 1})
+    monkeypatch.setattr(runtime_transport, "capture_runtime_provenance", lambda: snapshot)
+
+    with pytest.raises(TorchrunRuntimeProvenanceError, match="emitting worker"):
+        runtime_transport.emit_torchrun_runtime_provenance(local_rank=0)
+
+
+def test_wrapper_does_not_emit_without_explicit_flag(tmp_path: Path) -> None:
+    target = tmp_path / "standalone_target.py"
+    target.write_text("print('standalone output', flush=True)\n", encoding="utf-8")
+
+    completed = subprocess.run(
+        _wrapper_command(target, emit=False),
+        cwd=CODE_ROOT,
+        env=_cpu_environment(),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == "standalone output\n"
+    assert TORCHRUN_RUNTIME_PROVENANCE_PREFIX not in completed.stdout
+
+
+def test_wrapper_emits_only_after_seed_validation(tmp_path: Path) -> None:
+    target = tmp_path / "seed_mutating_target.py"
+    target.write_text(
+        "import torch\n"
+        "torch.manual_seed(7)\n"
+        "print('target completed before seed validation', flush=True)\n",
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        _wrapper_command(target, emit=True),
+        cwd=CODE_ROOT,
+        env=_cpu_environment(),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert completed.returncode != 0
+    assert "Seed mutation detected" in completed.stderr
+    assert TORCHRUN_RUNTIME_PROVENANCE_PREFIX not in completed.stdout
+
+
+@pytest.mark.skipif(
+    not torch.distributed.is_available() or not torch.distributed.is_gloo_available(),
+    reason="real two-rank CPU test requires torch.distributed Gloo",
+)
+def test_real_two_rank_torchrun_emits_consistent_distinct_worker_snapshots(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "two_rank_gloo_target.py"
+    target.write_text(
+        "import os\n"
+        "import torch\n"
+        "import torch.distributed as dist\n"
+        "dist.init_process_group('gloo')\n"
+        "rank = int(os.environ['RANK'])\n"
+        "value = torch.tensor([rank + 1], dtype=torch.int64)\n"
+        "dist.all_reduce(value)\n"
+        "print(f'rank={rank} all_reduce={int(value.item())}', flush=True)\n"
+        "dist.destroy_process_group()\n",
+        encoding="utf-8",
+    )
+    command = [
+        sys.executable,
+        "-m",
+        "torch.distributed.run",
+        "--nnodes=1",
+        "--rdzv-backend=static",
+        f"--rdzv-endpoint={_unused_loopback_endpoint()}",
+        "--nproc-per-node=2",
+        "--module",
+        "core.harness.torchrun_wrapper",
+        "--aisp-target-script",
+        str(target),
+        "--aisp-expected-torch-seed",
+        "42",
+        "--aisp-emit-runtime-provenance",
+    ]
+
+    completed = subprocess.run(
+        command,
+        cwd=CODE_ROOT,
+        env=_cpu_environment(),
+        capture_output=True,
+        text=True,
+        timeout=90,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    parsed = parse_torchrun_runtime_provenance_stdout(
+        completed.stdout,
+        expected_local_ranks={0, 1},
+        target="cpu",
+    )
+    assert set(parsed.snapshots_by_local_rank) == {0, 1}
+    assert len({snapshot.process_id for snapshot in parsed.snapshots_by_local_rank.values()}) == 2
+    assert parsed.execution_process_ids == {
+        local_rank: snapshot.process_id
+        for local_rank, snapshot in parsed.snapshots_by_local_rank.items()
+    }
+    assert os.getpid() not in {
+        snapshot.process_id for snapshot in parsed.snapshots_by_local_rank.values()
+    }
+    assert parsed.clean_stdout.count("all_reduce=3") == 2
+    assert TORCHRUN_RUNTIME_PROVENANCE_PREFIX not in parsed.clean_stdout
+
+
+@pytest.mark.skipif(
+    not torch.distributed.is_available() or not torch.distributed.is_gloo_available(),
+    reason="real two-rank CPU test requires torch.distributed Gloo",
+)
+def test_benchmark_with_manifest_uses_actual_torchrun_worker_receipts(tmp_path: Path) -> None:
+    marker_dir = tmp_path / "worker-markers"
+    marker_dir.mkdir()
+    target = tmp_path / "harness_two_rank_gloo_target.py"
+    target.write_text(
+        "import json\n"
+        "import os\n"
+        "import sys\n"
+        "from datetime import datetime, timezone\n"
+        "from pathlib import Path\n"
+        "import torch\n"
+        "import torch.distributed as dist\n"
+        "dist.init_process_group('gloo')\n"
+        "rank = int(os.environ['LOCAL_RANK'])\n"
+        "value = torch.tensor([rank + 1], dtype=torch.int64)\n"
+        "dist.all_reduce(value)\n"
+        "dist.destroy_process_group()\n"
+        "marker = {\n"
+        "    'pid': os.getpid(),\n"
+        "    'target_finished_at': datetime.now(timezone.utc).isoformat(),\n"
+        "}\n"
+        "Path(sys.argv[1], f'rank-{rank}.json').write_text(\n"
+        "    json.dumps(marker), encoding='utf-8'\n"
+        ")\n"
+        "print(f'rank={rank} all_reduce={int(value.item())}', flush=True)\n",
+        encoding="utf-8",
+    )
+    raw_capture_dir = tmp_path / "raw-subprocess"
+    config = BenchmarkConfig(
+        device=torch.device("cpu"),
+        iterations=1,
+        warmup=5,
+        seed=42,
+        launch_via=LaunchVia.TORCHRUN,
+        nproc_per_node=2,
+        nnodes="1",
+        rdzv_backend="static",
+        rdzv_endpoint=_unused_loopback_endpoint(),
+        multi_gpu_required=False,
+        use_subprocess=False,
+        enable_profiling=False,
+        lock_gpu_clocks=False,
+        enforce_environment_validation=False,
+        measurement_timeout_seconds=90,
+        subprocess_stderr_dir=str(raw_capture_dir),
+    )
+    benchmark = _TorchrunHarnessSmokeBenchmark(target, marker_dir)
+
+    run = BenchmarkHarness(config=config).benchmark_with_manifest(
+        benchmark,
+        run_id="torchrun-runtime-provenance-integration",
+    )
+
+    assert not run.result.errors, run.result.errors
+    assert run.result.runtime_provenance is not None
+    assert run.result.runtime_provenance_by_local_rank.keys() == {0, 1}
+    assert run.result.runtime_provenance == run.result.runtime_provenance_by_local_rank[0]
+    assert run.manifest.runtime_provenance == run.result.runtime_provenance
+    assert run.result.execution_process_ids.keys() == {0, 1}
+    assert len(set(run.result.execution_process_ids.values())) == 2
+    assert os.getpid() not in run.result.execution_process_ids.values()
+
+    raw_paths = list(raw_capture_dir.glob("*_subprocess.stdout.log"))
+    assert len(raw_paths) == 1
+    raw_stdout = raw_paths[0].read_text(encoding="utf-8")
+    assert TORCHRUN_RUNTIME_PROVENANCE_PREFIX in raw_stdout
+    assert raw_stdout.count("all_reduce=3") == 2
+    raw_receipts = parse_torchrun_runtime_provenance_stdout(
+        raw_stdout,
+        expected_local_ranks={0, 1},
+        target="cpu",
+    )
+    assert raw_receipts.execution_process_ids == run.result.execution_process_ids
+    assert raw_receipts.snapshots_by_local_rank == run.result.runtime_provenance_by_local_rank
+
+    assert run.result.validation_message is not None
+    assert run.result.validation_message.count("all_reduce=3") == 2
+    assert TORCHRUN_RUNTIME_PROVENANCE_PREFIX not in run.result.validation_message
+    for local_rank, runtime in run.result.runtime_provenance_by_local_rank.items():
+        marker = json.loads((marker_dir / f"rank-{local_rank}.json").read_text(encoding="utf-8"))
+        assert marker["pid"] == run.result.execution_process_ids[local_rank]
+        assert datetime.fromisoformat(runtime.captured_at) >= datetime.fromisoformat(
+            marker["target_finished_at"]
+        )
+
+
+@pytest.mark.parametrize(
+    ("raw_stdout", "message"),
+    [
+        ("ordinary output\n", "rank set mismatch"),
+        (TORCHRUN_RUNTIME_PROVENANCE_PREFIX + "{\n", "Malformed"),
+        (
+            "ordinary output " + TORCHRUN_RUNTIME_PROVENANCE_PREFIX + "{}\n",
+            "prefix placement",
+        ),
+        (TORCHRUN_RUNTIME_PROVENANCE_PREFIX + "{}", "Incomplete"),
+    ],
+)
+def test_parser_fails_on_missing_or_malformed_frames(raw_stdout: str, message: str) -> None:
+    with pytest.raises(TorchrunRuntimeProvenanceError, match=message):
+        parse_torchrun_runtime_provenance_stdout(
+            raw_stdout,
+            expected_local_ranks={0},
+            target="cpu",
+        )
+
+
+def test_parser_rejects_duplicate_and_partial_frame_sequences() -> None:
+    snapshot = capture_runtime_provenance()
+    frames = _frames(snapshot)
+    record = b"".join(frames).decode("utf-8")
+    with pytest.raises(TorchrunRuntimeProvenanceError, match="Duplicate"):
+        parse_torchrun_runtime_provenance_stdout(
+            record + record,
+            expected_local_ranks={0},
+            target="cpu",
+        )
+
+    assert len(frames) > 1
+    with pytest.raises(TorchrunRuntimeProvenanceError, match="Incomplete"):
+        parse_torchrun_runtime_provenance_stdout(
+            b"".join(frames[:-1]).decode("utf-8"),
+            expected_local_ranks={0},
+            target="cpu",
+        )
+
+
+def test_parser_rejects_nonpositive_child_pid() -> None:
+    snapshot = capture_runtime_provenance().model_copy(update={"process_id": 0})
+
+    with pytest.raises(TorchrunRuntimeProvenanceError, match="process_id > 0"):
+        parse_torchrun_runtime_provenance_stdout(
+            _unchecked_single_frame(snapshot, envelope_process_id=1),
+            expected_local_ranks={0},
+            target="cpu",
+        )
+
+
+def test_parser_rejects_cross_rank_runtime_mismatch() -> None:
+    snapshot = capture_runtime_provenance()
+    other = snapshot.model_copy(
+        update={
+            "process_id": snapshot.process_id + 1,
+            "torch_version": snapshot.torch_version + "+different-rank",
+        }
+    )
+    stdout = _record(
+        snapshot,
+        local_rank=0,
+        rank=0,
+        world_size=2,
+        local_world_size=2,
+    ) + _record(
+        other,
+        local_rank=1,
+        rank=1,
+        world_size=2,
+        local_world_size=2,
+    )
+
+    with pytest.raises(TorchrunRuntimeProvenanceError, match="inconsistent"):
+        parse_torchrun_runtime_provenance_stdout(
+            stdout,
+            expected_local_ranks={0, 1},
+            target="cpu",
+        )

--- a/code/tests/test_verified_comparison.py
+++ b/code/tests/test_verified_comparison.py
@@ -1,0 +1,148 @@
+"""Real CPU coverage for fail-closed convenience comparisons."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from core.benchmark.runtime_comparison import ExecutedRuntimeComparisonError
+from core.benchmark.verification_mixin import VerificationPayloadMixin
+from core.benchmark.verified_comparison import (
+    VerifiedComparisonError,
+    calculate_speed_metrics,
+)
+from core.harness.benchmark_harness import (
+    BaseBenchmark,
+    BenchmarkConfig,
+    BenchmarkHarness,
+    BenchmarkMode,
+    ExecutionMode,
+    compare_benchmarks,
+)
+
+
+class _CpuComparisonBenchmark(VerificationPayloadMixin, BaseBenchmark):
+    allow_cpu = True
+
+    def __init__(self, *, output_offset: float = 0.0, fail: bool = False) -> None:
+        super().__init__()
+        self.device = torch.device("cpu")
+        self.output_offset = output_offset
+        self.fail = fail
+        self.benchmark_calls = 0
+        self.input_tensor: torch.Tensor | None = None
+        self.output: torch.Tensor | None = None
+
+    def setup(self) -> None:
+        self.input_tensor = torch.arange(32, dtype=torch.float32, device=self.device)
+
+    def benchmark_fn(self) -> torch.Tensor:
+        self.benchmark_calls += 1
+        if self.fail:
+            raise RuntimeError("intentional comparison execution failure")
+        if self.input_tensor is None:  # pragma: no cover - lifecycle guard
+            raise RuntimeError("setup() must initialize input_tensor")
+        self.output = self.input_tensor * 2.0 + self.output_offset
+        return self.output
+
+    def capture_verification_payload(self) -> None:
+        if self.input_tensor is None or self.output is None:
+            raise RuntimeError("timed execution did not produce a verification payload")
+        self._set_verification_payload(
+            inputs={"input": self.input_tensor},
+            output=self.output,
+            batch_size=32,
+            parameter_count=0,
+            output_tolerance=(0.0, 0.0),
+        )
+
+    def validate_result(self) -> None:
+        return None
+
+
+def _cpu_harness() -> BenchmarkHarness:
+    config = BenchmarkConfig(
+        device=torch.device("cpu"),
+        iterations=2,
+        warmup=5,
+        use_subprocess=False,
+        execution_mode=ExecutionMode.THREAD,
+        enable_profiling=False,
+        enable_memory_tracking=False,
+        enable_cleanup=False,
+        lock_gpu_clocks=False,
+        enforce_environment_validation=False,
+        detect_setup_precomputation=False,
+        adaptive_iterations=False,
+        clear_compile_cache=False,
+        measurement_timeout_seconds=15,
+    )
+    return BenchmarkHarness(mode=BenchmarkMode.CUSTOM, config=config)
+
+
+def test_public_compare_benchmarks_returns_verified_real_cpu_results() -> None:
+    baseline = _CpuComparisonBenchmark()
+    optimized = _CpuComparisonBenchmark()
+
+    comparison = compare_benchmarks(
+        baseline,
+        optimized,
+        harness=_cpu_harness(),
+        name="real CPU comparison",
+    )
+
+    assert comparison["name"] == "real CPU comparison"
+    assert not comparison["baseline_result"].errors
+    assert not comparison["optimized_result"].errors
+    assert comparison["runtime_comparison"]["matches"] is True
+    assert comparison["input_verification"]["passed"] is True
+    assert comparison["verification"]["passed"] is True
+    assert comparison["speedup"] == pytest.approx(
+        comparison["baseline"]["mean_ms"] / comparison["optimized"]["mean_ms"]
+    )
+    assert baseline.benchmark_calls > 5
+    assert optimized.benchmark_calls > 5
+
+
+def test_public_compare_benchmarks_rejects_real_execution_failure() -> None:
+    baseline = _CpuComparisonBenchmark()
+    optimized = _CpuComparisonBenchmark(fail=True)
+
+    with pytest.raises(ExecutedRuntimeComparisonError) as exc_info:
+        compare_benchmarks(baseline, optimized, harness=_cpu_harness())
+
+    failures = exc_info.value.comparison.integrity_failures
+    assert any(
+        failure.code == "result_errors" and failure.run == "candidate"
+        for failure in failures
+    )
+    assert any(
+        "intentional comparison execution failure" in failure.detail
+        for failure in failures
+    )
+
+
+def test_public_compare_benchmarks_rejects_incorrect_full_output() -> None:
+    baseline = _CpuComparisonBenchmark(output_offset=0.0)
+    optimized = _CpuComparisonBenchmark(output_offset=1.0)
+
+    with pytest.raises(VerifiedComparisonError, match="output_mismatch") as exc_info:
+        compare_benchmarks(baseline, optimized, harness=_cpu_harness())
+
+    assert exc_info.value.code == "output_mismatch"
+    assert exc_info.value.evidence["passed"] is False
+    assert exc_info.value.evidence["max_diff"] == pytest.approx(1.0)
+
+
+def test_slowdown_percentage_uses_elapsed_time_ratio() -> None:
+    metrics = calculate_speed_metrics(
+        100.0,
+        150.0,
+        regression_threshold_pct=40.0,
+    )
+
+    assert metrics == {
+        "speedup": pytest.approx(2.0 / 3.0),
+        "regression": True,
+        "regression_pct": pytest.approx(50.0),
+    }

--- a/docs/reviews/2026-09-07-b200-review-results.md
+++ b/docs/reviews/2026-09-07-b200-review-results.md
@@ -8,6 +8,32 @@ that are unavailable on this host.
 
 ## Validation status
 
+The renewed completion pass starts from `6b98beed1`. It adds worker-bound
+runtime receipts, expected GPU identity checks, active PyTorch profiler guards,
+and real evaluation-contract tests in place of stale skips. It also tests
+removing the DDP reducer for one-rank training while retaining the distributed
+sampler and input order. These changes are undergoing validation; the retained
+suite totals and performance measurements below describe their stated earlier
+source revisions.
+
+The first expanded CPU check passed 344 cases and skipped 100, with nine
+transport fixtures rejected because they omitted the child device. After
+adding that explicit fixture identity, all 29 tests in the affected transport
+file passed. Actual child-receipt corruption tests separately confirm that a
+wrong PID or device is rejected. Runtime collection now follows measured work
+and has a separate bounded grace period. New one-/two-B200 results will be
+recorded after execution; no DDP speedup is claimed from this source change.
+
+The retained test files now contain 43 explicit missing-protection declarations,
+down from 58. This is a source inventory, not a claim that 15 independent
+protections were qualified: several labels duplicated existing evaluation
+contracts, and the new CUDA version and identity cases still require their
+target run. Version admission covers observed driver, CUDA, cuDNN, Python,
+PyTorch and relevant installed-package versions. Installed cuBLAS package
+metadata does not identify the native library actually loaded. The profiler
+guard covers an enclosing PyTorch profiler; it does not detect an external
+Nsight session or a profiler started and stopped entirely inside a workload.
+
 | Check | Current result |
 | --- | --- |
 | Broad target execution | 486 targets attempted; unsupported and informational outcomes remain separate from passes |

--- a/docs/reviews/2026-09-07-b200-review-results.md
+++ b/docs/reviews/2026-09-07-b200-review-results.md
@@ -12,23 +12,213 @@ The renewed completion pass starts from `6b98beed1`. It adds worker-bound
 runtime receipts, expected GPU identity checks, active PyTorch profiler guards,
 and real evaluation-contract tests in place of stale skips. It also tests
 removing the DDP reducer for one-rank training while retaining the distributed
-sampler and input order. These changes are undergoing validation; the retained
-suite totals and performance measurements below describe their stated earlier
-source revisions.
+sampler and input order. B200 execution and the final failure regressions are
+complete; hosted CI and merge are the remaining delivery checks. Each retained
+suite total and measurement below identifies its source revision.
 
 The first expanded CPU check passed 344 cases and skipped 100, with nine
 transport fixtures rejected because they omitted the child device. After
 adding that explicit fixture identity, all 29 tests in the affected transport
 file passed. Actual child-receipt corruption tests separately confirm that a
 wrong PID or device is rejected. Runtime collection now follows measured work
-and has a separate bounded grace period. New one-/two-B200 results will be
-recorded after execution; no DDP speedup is claimed from this source change.
+and has a separate bounded grace period. New one-/two-B200 results are
+recorded below; the small repeated singleton improvement remains below the
+benchmark's acceptance threshold.
 
-The retained test files now contain 43 explicit missing-protection declarations,
-down from 58. This is a source inventory, not a claim that 15 independent
+On `b1169c0a9`, the focused B200 suite completed **415 passed, 45 skipped,
+zero failures or errors** in 124 seconds, with normal process drain. Both
+normal DDP runs passed complete output verification at zero tolerance and
+the new executed-runtime admission check. One GPU measured 49.200832 ms
+baseline versus 47.210013 ms optimized (1.042169x); two GPUs measured
+85.136544 versus 83.273424 ms (1.022374x). Both remain `failed_no_speedup`
+because they did not reach the unchanged 1.05x requirement. The interleaved
+old/new repeats and matched profiles are described below.
+
+The normal `ch09:memory_bound` pair also passed on `b1169c0a9`, with complete
+output and executed-runtime verification and a 26.54735x timing ratio. This
+single pair result is separate from the repeated DDP optimization experiment.
+The first DDP experiment attempt stopped in its reporting script because a
+scalar tensor could not be viewed directly as bytes. No speedup was accepted
+from that attempt. Its outputs and normal-drain receipt are retained; the
+reporter now flattens tensors before byte serialization, with actual scalar,
+empty, strided, BF16 and boolean CPU checks.
+
+The corrected experiment completed all 16 one-GPU, 100-step measurements
+across four interleaved ABBA blocks. All full-input, full-output and runtime
+comparisons passed. Eight observations per arm had medians of 48.900048 ms
+for the historical reducer path and 47.337926 ms for the singleton path;
+their ranges were 48.820–48.984 and 47.168–47.499 ms, respectively. This is
+about a 3.3% improvement, below the benchmark's 5% requirement. The first two-GPU experiment correctly completed
+64 steps, the number of available batches per rank, and was rejected by the
+experiment's incorrect 100-step assertion. Its recovery explicitly uses the
+full 64-step two-GPU epoch in both arms and retains the completed one-GPU
+measurements separately. The recovery completed 16 two-GPU measurements
+and four matched Nsight Systems captures with full output and runtime
+admission. The two-GPU control and candidate medians were 54.587270 and
+54.722537 ms, respectively, with eight observations per arm. This batch-16,
+64-step control intentionally exercises unchanged two-rank behavior; it is
+separate from the canonical batch-32 `ddp_multigpu` example. A subsequent
+Nsight Compute control capture succeeded, but its reader rejected the wide
+CSV layout. The failed attempt is retained, and the repaired reader passed
+against the actual captured CSV before a fresh paired attempt. Both fresh
+Nsight Compute reports then passed import and counter inspection, retaining
+329 finite selected counters per arm for one matched FusedAdam launch. This
+single-launch scope is supporting evidence, not a whole-run speed measure.
+
+The singleton Nsight Systems comparison removed 20,100 pointwise BF16
+multiply launches and eight concatenation-copy launches over 100 steps.
+That supports reduced reducer and launch overhead; there were no peer NCCL
+kernels in either singleton arm. Whole-process medians were 14,662.323 and
+14,693.828 ms, so no end-to-end improvement was established. The two-GPU
+profiles retained identical instance counts for all 81 kernel names and
+353,997 launches. Each Nsight Systems arm has one capture, separate from
+the repeated unprofiled timing evidence.
+
+A separate singleton startup experiment compared the retained reducer-free
+path with lazy NCCL communicator creation. Across four seed blocks and eight
+observations per arm, process-wall medians fell from 14,620.719 to 14,106.201
+ms (1.036475x), with standard deviations of 99.034 and 164.733 ms. All four
+block ratios improved, ranging from 1.036294x to 1.042302x. Matched Systems
+captures removed one 207.720-ms initialization and one 253.913-ms destruction
+range. Full inputs, outputs and runtime admission passed throughout. Commit
+`5a9eeec80` applies the exact measured source: singleton NCCL initialization
+omits `device_id`, while the multi-rank initialization call is unchanged.
+Ten focused CPU tests passed with two explicit skips. This startup result
+does not qualify the canonical benchmark's 1.05x worker-speed goal.
+
+Further pipeline review found that `ch04:pipeline_parallel` verifies a separate
+parent-process simulation before launching its distributed timing workers.
+The baseline simulation retains the last microbatch, while the optimized
+simulation uses the first. Its previous verification pass therefore does not
+qualify the timed distributed outputs. Existing timing and profiler receipts
+remain exploratory evidence; actual full-batch worker-output transport is
+repaired in `5887577d0`. Both workers retain all measured microbatches
+in input order and validate an independent sequential reference after timing.
+The candidate uses rank-dependent warmup and paired bidirectional transfers.
+The real two-rank CPU transport and related pipeline/worker tests passed
+58 cases; another 14 helper-aware hygiene cases passed. The six affected
+pipeline/tensor-parallel entrypoints have no static contract errors or warnings.
+On `4071e06ca`, the normal full-shape two-B200 pipeline run passed actual
+worker-output and runtime verification, measuring 15.502764 ms baseline and
+15.307192 ms optimized (1.012776x). It remains `failed_no_speedup`. The
+subsequent four-seed ABBA batch completed 16 launches and eight full-output
+comparisons with exact equality throughout. Eight observations per arm had
+medians of 15.941546 and 15.782274 ms (1.010092x), with standard deviations
+of 0.366567 and 0.279505 ms. Per-block ratios ranged from 0.982065x to
+1.024960x, so the result supports parity, not a qualifying speedup.
+Commit `0613b1319` therefore tightens the pipeline's output tolerance from
+`(0.1, 1.0)` to exact equality; five CPU schedule/reference tests passed,
+including rejection of a small BF16 output perturbation. Its target rerun
+passed on `632315c6b`. Both new Nsight Systems captures completed. Each new
+kernel-replay Nsight Compute attempt timed out at its 180-second limit and
+drained, leaving that profiler evidence explicitly incomplete.
+The new Systems traces retain 1,024 main matrix-multiplication launches in
+each arm. Paired transfers reduce NCCL SendRecv launches from 256 to 144
+and aggregate SendRecv kernel time from 125.700 to 54.700 ms. This supports
+the communication change without turning overlapping kernel-time sums into
+an end-to-end speedup claim.
+One subsequent bounded Compute probe selected only the common main GEMM
+after eight launches, retaining the full two-rank workload. Its baseline also
+timed out after 180 seconds and drained; the paired candidate was not launched.
+The incomplete report and exact command are retained. Compute replay therefore
+remains unresolved for this pipeline on the current host.
+
+The latest exploratory pipeline run on `b1169c0a9` measured 15.64706 ms
+baseline and 23.32224 ms optimized (0.670907x). Both Nsight Systems reports
+and their kernel, API and NVTX summaries were retained. Neither Nsight
+Compute attempt produced a complete report; the run ended `failed_profiler`
+and all owned processes drained. These captures do not repair the output
+verification gap described above.
+
+Commit `1d30adb22` additionally requires the independently retained local
+worker count and complete per-rank runtime agreement. It rejects a result
+with rank 1 removed from both receipt maps, as well as an incomplete or
+version-mismatched rank 1. Actual CPU harness checks passed 25 cases, the
+central admission suite passed 15, and the subsequent strict count-schema
+check passed all seven integration cases. The target rerun on `4071e06ca`
+completed 108 focused tests with one skip and no failures or errors, including
+the per-rank receipt checks and final replacement CUDA version-lock case.
+
+The unchanged TE precision pair was also rerun in the isolated TE 2.18
+environment on `b1169c0a9`. FP16 measured 0.500929 ms and FP8 achieved
+0.715940x, again `failed_no_speedup`, with normal process drain. Its actual
+forward outputs and runtime admission passed the existing checks, but the
+verification input omitted the training target and its numerical tolerance
+was not calibrated. Commit `4071e06ca` includes the live training target and
+all post-SGD parameter tensors in verification, retains independent CPU
+outputs after timing, and fixes the baseline's FP16 metric label. All four
+opt-in CUDA training-output tests passed in the isolated TE 2.18 environment,
+including actual changed-target parameter updates. The earlier diagnostic
+does not establish a complete training-correctness or speedup claim.
+The first full-output calibration completed all four seeds but rejected its
+seed-42-selected tolerance on holdout data. Review also found that its private
+driver constructed a fresh harness configuration with the `performance`
+backend instead of preserving the benchmark's `fp32_strict` policy. The
+attempt is retained as diagnostic data; it does not establish a tolerance for
+the published pair.
+
+The corrected calibration preserved `fp32_strict`, the default 256-by-4096
+workload and all 65 training updates: five setup, ten warmup and fifty measured
+steps. Seed 44 selected a predeclared grouped numerical policy with a 20%
+reserve; fresh holdouts 45, 1044 and 1045 all passed. Every input, training
+target, prediction and all 67,121,152 parameter elements were checked, with
+executed-runtime agreement. The selected `(rtol, atol)` values are `(0.4, 1.0)`
+for prediction, `(0.001, 0.00075)` for weights and `(0.001, 0.00005)` for biases.
+Maximum absolute differences over this cohort were 0.594971, 0.000534058 and
+0.000041008, respectively. Replacing any output with zeros or introducing a
+localized perturbation beyond its budget was rejected. These are numerical
+bounds for this workload and configuration; FP8 timing remained slower than
+FP16. Commit `9743d0588` integrates the exact-keyed policy into normal
+verification, including subprocess transport and golden-output cache
+comparisons. Both arms must declare the same map and cover every captured
+output. Missing or changed predeclared child policies are rejected. Reused
+benchmark instances discard prior child receipts before fresh execution, and
+direct verification rejects invalid output-dictionary entries instead of
+silently filtering them. The combined CPU check passed 37 cases with four
+CUDA-only skips; neighboring transport and verification checks passed 152
+cases with 15 explicit skips. On B200, this source passed 192 focused cases
+and all four opt-in TE CUDA cases. The normal TE 2.18 and TE 2.9 runs preserved
+the configured lifecycle, full output map and runtime agreement, with timing
+ratios of 0.699952x and 0.671259x, respectively. Normal singleton and two-GPU
+DDP also passed exact outputs and runtime agreement at 1.038194x and 1.011154x.
+All four normal pairs remain `failed_no_speedup`. The pipeline baseline worker
+completed, but the parent's optional tolerance-map lookup incorrectly required
+a local payload. That integration failure is retained, and the full-suite gate
+correctly held the broader run for its repair. Commit `632315c6b` makes the
+optional map return `None` when a coordinator has no local payload; declared
+maps and mandatory transported outputs remain checked. Nineteen focused CPU
+checks passed, followed by the B200 regression and TE CUDA checks. The normal
+two-B200 pipeline then passed its new exact output policy and executed-runtime
+admission. The final-source pipeline measured 15.616376 ms baseline and
+16.232841 ms optimized (0.962024x). The normal TE 2.18 and TE 2.9 ratios were
+0.720155x and 0.696505x; singleton DDP reached 1.035264x and canonical two-GPU
+DDP reached 1.009320x. These individual runs
+confirm execution and preserve the no-speedup outcomes; the interleaved
+experiments above remain the basis for optimization claims.
+
+The final full B200 suite on `632315c6b` completed **5,905 passed, 68 skipped,
+two failures and zero errors** across 5,975 cases in 2,347.253 seconds, followed
+by complete process drain. Both failures were outside benchmark execution:
+an old ZeRO2 callback test fabricated child stdout without a worker runtime
+receipt, and the Chapter 13 README generator omitted the new calibration text.
+Commit `8c0cce536` replaces the fabricated child with a real CPU worker;
+`289dd73f7` preserves the documentation in the generator. The two complete
+affected test files then passed **43 cases, zero skips, failures or errors**
+on B200, again with normal drain. Benchmark and harness execution code did not
+change between the broad run and these final regression checks.
+
+The 68 full-suite skips comprise 42 explicit missing-protection declarations,
+one nonbehavioral test-count summary, and 25 hardware, dependency, policy or
+opt-in cases. Separate target runs cover the TE 2.18 CUDA opt-in cases as
+described above. A skipped negative-dependency test means its required absent
+dependency is installed; it does not indicate a failed installed runtime.
+
+The retained test files now contain 42 explicit missing-protection declarations,
+down from 58. This is a source inventory, not a claim that 16 independent
 protections were qualified: several labels duplicated existing evaluation
-contracts, and the new CUDA version and identity cases still require their
-target run. Version admission covers observed driver, CUDA, cuDNN, Python,
+contracts. The new CUDA version and identity cases passed on B200; one final
+duplicate version-lock test label was also replaced and passed its target
+rerun. Version admission covers observed driver, CUDA, cuDNN, Python,
 PyTorch and relevant installed-package versions. Installed cuBLAS package
 metadata does not identify the native library actually loaded. The profiler
 guard covers an enclosing PyTorch profiler; it does not detect an external
@@ -40,11 +230,11 @@ Nsight session or a profiler started and stopped entirely inside a workload.
 | Benchmark contract scan | 936 entrypoints; zero errors and warnings |
 | Repository-wide Ruff correctness checks | Passed |
 | Focused GPU regressions | Earlier 813 affected-file tests and six isolated Llama tests passed; latest Colfax suites passed 32 cases in each pinned environment |
-| Latest integrated GPU suite | **5,795 passed, 79 skipped, zero failures or errors** on `46ba89929`; normal exit and complete process drain |
+| Latest integrated GPU suite | **5,905 passed, 68 skipped, two failures, zero errors** on `632315c6b`; both failures repaired and the affected files passed **43 B200 tests** on `289dd73f7`; all processes drained |
 | Standalone MoE entrypoint | Level 0 completed its normal 436.5M-parameter workload |
 | Normal dual-pool vLLM runs | Exact tokens passed twice; speed target failed twice |
 | Gradient-fusion NCU | Complete five-metric reports inspected; later repeats timed out or reported driver `UnknownError`, so replay remains intermittent |
-| Hosted CI | **5,341 CPU tests passed, 536 skipped, zero failures or errors**; static analysis, dashboard and all configured CUDA architecture builds passed on `568c9102c` |
+| Hosted CI | Prior retained run: **5,341 CPU tests passed, 536 skipped, zero failures or errors**; static analysis, dashboard and configured CUDA architecture builds passed on `568c9102c`. Renewed delivery checks remain pending. |
 | Main delivery | [PR #23](https://github.com/cfregly/ai-performance-engineering/pull/23) merged as `a8e0b5b21`; its tree matches the tested head. Earlier repair PRs #20 and #21 are also merged |
 | Explicit opt-in GPU tests | ZeRO2 passed; two Blackwell tests passed on each of two ranks; local-model vLLM passed |
 | Version-specific FP8 template | The actual TE 2.18 CUDA template passed in a separate environment; one executed case, no skip |
@@ -152,8 +342,8 @@ directly traced. See the [lab](../../code/labs/flashattention4/README.md).
    Grace/GB10, four-or-more GPUs, multi-node communication, and the missing
    Phi3.5/TensorRT-LLM model engine remain outside this host's coverage.
 6. **Implement the explicitly missing benchmark protections before claiming them.**
-   Dataset/holdout provenance, execution placement, managed-memory events and
-   related skipped detectors remain engineering work. Passing arithmetic or
+   Per-operation CPU execution placement, managed-memory events, uninitialized
+   memory provenance and related skipped detectors remain engineering work. Passing arithmetic or
    test-name counts cannot establish these protections.
 
 Ordinary examples support Python and local `torchrun`; Slurm is optional.


### PR DESCRIPTION
Benchmark comparisons could accept parent-process pipeline outputs, incomplete worker receipts, and overly broad FP8 training tolerances. This change binds comparisons to the processes that executed the work, checks complete per-rank runtime and device metadata, and verifies every timed pipeline microbatch and every retained TE training parameter.

Pipeline 1F1B now pairs communication in rank order and requires exact output equality. Singleton DDP avoids reducer work and eager NCCL communicator creation; multi-rank initialization remains unchanged. TE uses calibrated per-output numerical bounds that survive subprocess transport and golden-output cache comparisons. Fresh dispatches discard stale child receipts, and direct verification rejects invalid output entries.

Repeated B200 experiments retained complete outputs and runtime agreement. The singleton reducer change improved measured worker time by about 3.3%; a separate lazy-NCCL change improved process time by about 3.6%. The pipeline remains near timing parity, and FP8 remains slower than FP16 for the tested training workload. These outcomes do not satisfy every example's speed target. Current-host runs are explicitly portable because the host reports virtualization.

Validation:

- Full B200 suite: 5,905 passed, 68 skipped, two failures, zero errors on `632315c6b`. Both failures were repaired in a test fixture and the README generator; the two complete affected files then passed all 43 tests on B200 at `289dd73f7`. Benchmark and harness execution code did not change between those runs.
- Final focused B200 checks: 192 passed, plus four real TE 2.18 CUDA tests. Normal TE 2.18/2.9, two-GPU pipeline, and one-/two-GPU DDP all passed complete output and executed-runtime verification. Their no-speedup outcomes are retained.
- All 936 benchmark entrypoints passed contract checks with zero errors or warnings. Repository-wide Ruff correctness checks passed.
- [Hosted benchmark validation](https://github.com/cfregly/ai-performance-engineering/actions/runs/34202021120) passed on `f32a3d012`: 5,442 CPU tests passed, 533 skipped, zero failures or errors. Static analysis, all 936 entrypoint contracts, and dashboard audit/lint/build plus 21 tests passed. [Configured CUDA architecture builds](https://github.com/cfregly/ai-performance-engineering/actions/runs/34202021092) also passed on the same head.

The [validation report](https://github.com/cfregly/ai-performance-engineering/blob/f32a3d012134ebb1d7a31f9b3802db8882595d8a/docs/reviews/2026-09-07-b200-review-results.md) records source revisions, timings, profiling limits, missing hardware, explicit skips, and suggested follow-up improvements. Examples use Python or local `torchrun`; Slurm remains optional.
